### PR TITLE
deploy: run behind host nginx + Let's Encrypt (Caddy-less overlay)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -60,6 +60,63 @@ docker compose -f docker-compose.prod.yml --env-file .env up -d --build
 
 ---
 
+## Option D — Behind your own nginx (Let's Encrypt)
+
+For a server that already runs **host nginx** fronting other sites (e.g. an EC2
+box). Run everything except the bundled Caddy, publish the app on
+`127.0.0.1:3000`, and let your nginx terminate TLS with certbot.
+
+> The bundled Postgres publishes **no host port** (it's private to the compose
+> network), so it never conflicts with anything else on the host's `5432`
+> — e.g. a local Supabase. Nothing to change.
+
+**1. Point DNS at the box.** With Namecheap: *Domain List -> Manage -> Advanced
+DNS -> Host Records*, add `A @ -> <server IP>` and `A www -> <server IP>` (use an
+Elastic IP on EC2 so it's stable). Confirm with `dig +short dayotter.com`.
+
+**2. Configure `deploy/.env`** as in Option C, with:
+
+```ini
+APP_URL=https://dayotter.com
+BETTER_AUTH_URL=https://dayotter.com
+# DAYOTTER_SITE_ADDRESS is unused here (Caddy is disabled)
+```
+
+**3. Bring up the stack without Caddy** (database + migrations + app):
+
+```bash
+cd deploy
+docker compose -f docker-compose.prod.yml -f docker-compose.nginx.yml --env-file .env   up -d --build            # starts postgres, redis, migrate, web, worker (not caddy)
+
+curl -I http://127.0.0.1:3000     # sanity check the app is up locally
+```
+
+**4. Add the nginx site** (alongside your existing ones):
+
+```bash
+sudo cp nginx/dayotter.com.conf /etc/nginx/sites-available/dayotter.com
+sudo ln -s /etc/nginx/sites-available/dayotter.com /etc/nginx/sites-enabled/
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+**5. Issue the certificate** (adds the `:443` block + HTTP->HTTPS redirect + auto-renew):
+
+```bash
+sudo apt-get install -y certbot python3-certbot-nginx   # if not already present
+sudo certbot --nginx -d dayotter.com -d www.dayotter.com
+sudo certbot renew --dry-run
+```
+
+Open **https://dayotter.com**. To update later: `git -C .. pull` then re-run the
+Step 3 `up -d --build` command.
+
+> Prefer to reuse an existing managed/Supabase Postgres instead of the bundled
+> one? Set `DATABASE_URL=postgresql://user:pass@host:5432/dayotter` in
+> `deploy/.env` (migrations still run automatically against it) and omit the
+> `postgres` service from the `up` command.
+
+---
+
 ## What runs
 
 | Service    | Role                                                            |

--- a/deploy/docker-compose.nginx.yml
+++ b/deploy/docker-compose.nginx.yml
@@ -1,0 +1,23 @@
+# Overlay for running DayOtter behind your OWN reverse proxy (e.g. a host nginx
+# with certbot / Let's Encrypt) instead of the bundled Caddy. It:
+#   - publishes the web app on 127.0.0.1:3000 (reachable only by a proxy on the
+#     SAME host, never the public internet), and
+#   - disables the bundled `caddy` service via a compose profile.
+#
+# Usage (from deploy/), layered on top of the prod stack:
+#   docker compose -f docker-compose.prod.yml -f docker-compose.nginx.yml \
+#     --env-file .env up -d --build web worker
+#
+# Then point an nginx server block at http://127.0.0.1:3000 and terminate TLS
+# there — see deploy/nginx/dayotter.com.conf and the README section
+# "Option D — Behind your own nginx (Let's Encrypt)".
+#
+# Note: the bundled Postgres never publishes a host port, so it does NOT conflict
+# with anything else already using 5432 on the host (e.g. a local Supabase).
+services:
+  web:
+    ports:
+      - "127.0.0.1:3000:3000"
+  caddy:
+    # Profile-gated so a normal `up` never starts it; your host nginx fronts us.
+    profiles: ["disabled"]

--- a/deploy/nginx/dayotter.com.conf
+++ b/deploy/nginx/dayotter.com.conf
@@ -1,0 +1,30 @@
+# Example nginx site for DayOtter, terminating TLS with Let's Encrypt (certbot).
+#
+# 1. Copy to /etc/nginx/sites-available/dayotter.com (change the domain below).
+# 2. Enable + reload:
+#      sudo ln -s /etc/nginx/sites-available/dayotter.com /etc/nginx/sites-enabled/
+#      sudo nginx -t && sudo systemctl reload nginx
+# 3. Issue the certificate (certbot rewrites this file to add the :443 server
+#    block + an HTTP->HTTPS redirect, and sets up auto-renewal):
+#      sudo certbot --nginx -d dayotter.com -d www.dayotter.com
+#
+# Assumes the app is published on 127.0.0.1:3000 (see ../docker-compose.nginx.yml).
+server {
+    listen 80;
+    listen [::]:80;
+    server_name dayotter.com www.dayotter.com;   # <-- change to your domain
+
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;   # so Better Auth marks cookies 'secure'
+        proxy_set_header Upgrade           $http_upgrade;
+        proxy_set_header Connection        "upgrade";
+        proxy_read_timeout 120s;               # headroom for cold Next.js routes
+    }
+
+    client_max_body_size 10m;
+}


### PR DESCRIPTION
Adds a **Caddy-less deploy path** for hosts that already run their own nginx (e.g. an EC2 box fronting other sites), terminating TLS with Let's Encrypt.

### What's included
- **`deploy/docker-compose.nginx.yml`** — an overlay for `docker-compose.prod.yml` that:
  - publishes the web app on `127.0.0.1:3000` (host-local only, never the public internet), and
  - profile-gates the bundled `caddy` service **off**.
  `docker compose config` on the merged files yields `postgres, redis, migrate, web, worker` — no caddy.
- **`deploy/nginx/dayotter.com.conf`** — a ready-to-use nginx server block (proxies to `127.0.0.1:3000`, forwards `Host` / `X-Forwarded-Proto` so Better Auth marks cookies `secure`, 120s read timeout for cold Next routes), set up for `certbot --nginx`.
- **`deploy/README.md`** — a new **"Option D — Behind your own nginx (Let's Encrypt)"** section with the full flow: Namecheap DNS (A `@`/`www` → Elastic IP), env config, `up` without Caddy, the nginx site, and `certbot`.

### Usage
```bash
cd deploy
docker compose -f docker-compose.prod.yml -f docker-compose.nginx.yml --env-file .env up -d --build web worker
sudo cp nginx/dayotter.com.conf /etc/nginx/sites-available/dayotter.com
sudo ln -s /etc/nginx/sites-available/dayotter.com /etc/nginx/sites-enabled/
sudo nginx -t && sudo systemctl reload nginx
sudo certbot --nginx -d dayotter.com -d www.dayotter.com
```

### Notes
- The bundled Postgres publishes **no host port**, so it doesn't conflict with an existing `5432` on the host (e.g. a local Supabase) — documented inline.
- Docs-only + a compose overlay; no changes to the app or the existing Caddy path.
