### PR TITLE
fix(deploy): stop the migrate/worker image-build race (dayotter-app:local already exists)

### DIFF
--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -45,9 +45,10 @@ services:
   # One-shot: apply committed DB migrations, then exit. web/worker wait for it to
   # finish successfully before starting, so the schema is always current on boot.
   migrate:
-    build:
-      context: ..
-      dockerfile: apps/worker/Dockerfile
+    # Reuses the worker image instead of declaring its own build. Two services
+    # building the SAME tag (dayotter-app:local) makes Compose/Bake export it
+    # twice in parallel -> "image ... already exists". `worker` is the single
+    # build target for this tag; migrate just runs a one-shot command against it.
     image: dayotter-app:local
     env_file: .env
     environment:


### PR DESCRIPTION
## Problem
`docker compose ... up --build` fails intermittently with:
```
target migrate: failed to solve: image "docker.io/library/dayotter-app:local": already exists
```
Both the **`migrate`** and **`worker`** services declared a `build:` producing the **same image tag** `dayotter-app:local`. Docker Compose's Bake builder builds targets **in parallel**, so the two builds export the identical tag at the same time and collide (especially with the containerd image store).

## Fix
Make `worker` the **single build target** for `dayotter-app:local`; `migrate` now just references `image: dayotter-app:local` (no `build:`) and runs its one-shot migration command against it. The image is produced during the build phase (before any container starts), so `migrate` — which only `depends_on: postgres` — always has it available.

No other service shares a tag (`web` builds its own `dayotter-web:local`), so there's nothing left for Bake to build twice.

## Verified
`docker compose -f docker-compose.prod.yml config` renders cleanly:
- `migrate`: `image: dayotter-app:local`, **no build**, one-shot `pnpm --filter @dayotter/db migrate`
- `worker`: builds `apps/worker/Dockerfile` → `dayotter-app:local`
- `web`: builds `apps/web/Dockerfile` → `dayotter-web:local`

Fixes the need for the `COMPOSE_BAKE=false` workaround.
