### PR TITLE
content: feature-led blog + repositioned marketing copy (open source as a bonus)

### DIFF
--- a/apps/web/app/(marketing)/about/page.tsx
+++ b/apps/web/app/(marketing)/about/page.tsx
@@ -48,15 +48,6 @@ export default function AboutPage() {
           propose, you decide. We never silently rearrange your day.
         </p>
 
-        <h2>Built in the open</h2>
-        <p>
-          We ship fast and in public. Follow along, file issues, or send a pull request on{" "}
-          <a href={BRAND.github} target="_blank" rel="noreferrer">
-            GitHub
-          </a>
-          .
-        </p>
-
         <hr />
         <p>
           <em>Made for people who value their time.</em>

--- a/apps/web/app/(marketing)/about/page.tsx
+++ b/apps/web/app/(marketing)/about/page.tsx
@@ -4,7 +4,8 @@ import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "About — DayOtter",
-  description: "Why we built DayOtter — the open-source home for your time.",
+  description:
+    "Why we built DayOtter — every calendar, your booking links, reminders, and an assistant in one calm place.",
 };
 
 export default function AboutPage() {
@@ -13,7 +14,7 @@ export default function AboutPage() {
       <MarketingHeader
         eyebrow="About"
         title="Software that respects your time"
-        subtitle="DayOtter is the open-source home for your calendar — built for people who guard their hours."
+        subtitle="DayOtter brings every calendar, your booking links, reminders, and a scheduling assistant into one calm place — built for people who guard their hours."
       />
       <Prose>
         <p>
@@ -31,11 +32,11 @@ export default function AboutPage() {
           otter guards its afternoon.
         </p>
 
-        <h2>Open at the core</h2>
+        <h2>Yours to run</h2>
         <p>
-          The entire scheduling engine is open source under Apache-2.0. Run it yourself and every
-          feature is free, forever. Or use our cloud and let us handle the servers. Either way, your
-          calendar data is yours — OAuth tokens are encrypted at rest, and we never sell what you
+          A quiet bonus: the whole scheduling engine is open source, so you can self-host it and get
+          every feature free, or use our cloud and let us handle the servers. Either way your
+          calendar data stays yours — OAuth tokens are encrypted at rest, and we never sell what you
           put in.
         </p>
 

--- a/apps/web/app/(marketing)/blog/page.tsx
+++ b/apps/web/app/(marketing)/blog/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 
 export const metadata: Metadata = {
   title: "Blog — DayOtter",
-  description: "Notes on time, calendars, and building DayOtter in the open.",
+  description: "Notes on calendars, focus, and getting your time back.",
 };
 
 export default function BlogPage() {
@@ -15,7 +15,7 @@ export default function BlogPage() {
       <MarketingHeader
         eyebrow="Blog"
         title="Notes on time"
-        subtitle="Thoughts on calendars, focus, and building DayOtter in the open."
+        subtitle="Thoughts on calendars, focus, and getting your time back."
       />
       <section className="mx-auto max-w-2xl px-6 py-16">
         <div className="space-y-2">

--- a/apps/web/app/(marketing)/changelog/page.tsx
+++ b/apps/web/app/(marketing)/changelog/page.tsx
@@ -9,6 +9,16 @@ export const metadata: Metadata = {
 const ENTRIES = [
   {
     date: "July 2026",
+    title: "Ask Otter, a refreshed interface & new sign-in",
+    items: [
+      "Ask Otter: a conversational assistant in your dashboard — by chat or voice — that reads your schedule and can act on your whole setup (bookings, booking types, availability, focus time, preferences, teams, reminder channels, automations). Always confirm-first; deletes ask twice.",
+      "A refreshed, premium interface end to end — a cleaner typeface, in-theme dialogs and toasts, and a tidier mobile navigation.",
+      "Phone number + one-time-code sign-in, email verification, and self-serve account deletion.",
+      "Browser (web push) reminders alongside mobile push, Slack, SMS, and WhatsApp.",
+    ],
+  },
+  {
+    date: "July 2026",
     title: "Billing, editions & the developer platform",
     items: [
       "Open-core editions: self-host free, cloud $9/seat Pro.",
@@ -43,7 +53,7 @@ export default function ChangelogPage() {
       <MarketingHeader
         eyebrow="Changelog"
         title="What's new"
-        subtitle="We ship fast and in the open. Here's the recent work."
+        subtitle="We ship fast. Here's the recent work."
       />
       <section className="mx-auto max-w-2xl px-6 py-16">
         <ol className="relative space-y-10 border-l border-[var(--color-border)] pl-6">

--- a/apps/web/components/marketing/hero.tsx
+++ b/apps/web/components/marketing/hero.tsx
@@ -3,9 +3,8 @@
 import { BookingMock, CalendarMock, ReminderMock } from "@/components/marketing/mocks";
 import { FadeUp, Float } from "@/components/marketing/motion";
 import { buttonVariants } from "@/components/ui/button";
-import { BRAND } from "@/lib/marketing";
 import { motion } from "framer-motion";
-import { ArrowRight, Smartphone, Star } from "lucide-react";
+import { ArrowRight, Smartphone } from "lucide-react";
 import Link from "next/link";
 
 export function Hero() {
@@ -33,8 +32,9 @@ export function Hero() {
         </FadeUp>
         <FadeUp delay={0.16}>
           <p className="mx-auto mt-6 max-w-xl text-lg leading-relaxed text-[var(--color-muted)]">
-            One calm home for your time — sync every calendar, share availability across your team,
-            and let people book you. Beautifully. Self-hostable, or use the cloud.
+            One calm home for your time — sync every calendar, share your availability, and let
+            people book you without the back-and-forth. Beautifully simple, on the cloud or your own
+            server.
           </p>
         </FadeUp>
         <FadeUp delay={0.24}>
@@ -42,14 +42,9 @@ export function Hero() {
             <Link href="/sign-up" className={buttonVariants({ variant: "primary", size: "lg" })}>
               Get started free <ArrowRight size={17} />
             </Link>
-            <a
-              href={BRAND.github}
-              target="_blank"
-              rel="noreferrer"
-              className={buttonVariants({ variant: "outline", size: "lg" })}
-            >
-              <Star size={16} /> Star on GitHub
-            </a>
+            <Link href="#how" className={buttonVariants({ variant: "outline", size: "lg" })}>
+              See how it works
+            </Link>
           </div>
         </FadeUp>
         <FadeUp delay={0.32}>

--- a/apps/web/components/marketing/hero.tsx
+++ b/apps/web/components/marketing/hero.tsx
@@ -23,7 +23,7 @@ export function Hero() {
 
       <div className="relative mx-auto max-w-5xl px-6 pt-16 text-center sm:pt-24">
         <FadeUp>
-          <span className="eyebrow">Open-source team scheduling</span>
+          <span className="eyebrow">Scheduling, minus the back-and-forth</span>
         </FadeUp>
         <FadeUp delay={0.08}>
           <h1 className="font-display mx-auto mt-5 max-w-4xl text-[2.6rem] leading-[1.04] tracking-[-0.02em] sm:text-6xl lg:text-[4.5rem]">

--- a/apps/web/components/marketing/sections.tsx
+++ b/apps/web/components/marketing/sections.tsx
@@ -84,18 +84,16 @@ export function CTA() {
               Take back your calendar.
             </h2>
             <p className="mx-auto mt-5 max-w-lg text-lg text-[var(--color-muted)]">
-              Free forever for individuals. Self-host it, or use the cloud — your time, your rules.
+              Free for individuals, $9/seat for teams. Up and running in minutes — on the cloud or
+              your own server. Your time, your rules.
             </p>
             <div className="mt-8 flex flex-wrap justify-center gap-3">
               <Link href="/sign-up" className={buttonVariants({ variant: "primary", size: "lg" })}>
                 Get started free
               </Link>
-              <a
-                href="https://github.com"
-                className={buttonVariants({ variant: "outline", size: "lg" })}
-              >
-                Star on GitHub
-              </a>
+              <Link href="/pricing" className={buttonVariants({ variant: "outline", size: "lg" })}>
+                See pricing
+              </Link>
             </div>
           </div>
         </div>

--- a/apps/web/lib/blog.ts
+++ b/apps/web/lib/blog.ts
@@ -16,31 +16,66 @@ export interface BlogPost {
 
 export const POSTS: BlogPost[] = [
   {
-    slug: "why-open-source-scheduling",
-    title: "Why scheduling should be open source",
+    slug: "meet-otter-assistant",
+    title: "Meet Otter, the assistant that runs your calendar",
     excerpt:
-      "Your calendar is a map of your life. Here's why the software that reads it should be open — and what that means for DayOtter.",
-    date: "2026-07-08",
+      "Chat or talk to Otter and it books, moves, blocks, and rearranges your week — but only ever with your say-so. Here’s what your calendar’s new copilot can do.",
+    date: "2026-07-12",
     author: "The DayOtter team",
     readMinutes: 4,
     body: [
       {
         paragraphs: [
-          "Every scheduling tool asks for the same thing: full access to your calendar. That's a lot of trust to hand a black box. We think the software that reads your most sensitive data should be software you can read back.",
+          "Scheduling is death by a thousand tiny chores: find a slot, block the prep time, move the thing that clashes, remember to tell the attendees. Otter — the assistant built into your DayOtter dashboard — does those chores for you. You just chat with it, or talk to it.",
         ],
       },
       {
-        heading: "Trust you can verify",
+        heading: "Ask in plain language",
         paragraphs: [
-          "Open source means you can audit exactly how your data is handled — how tokens are stored, what leaves your server, and what doesn't. With DayOtter, OAuth tokens are encrypted at rest and we never sell your data. But you don't have to take our word for it; the code is right there.",
-          "It also means you're never locked in. Don't like where the hosted product is going? Run it yourself. Your data, your servers, every feature.",
+          "“Move my 3pm to Friday morning.” “Find me a free hour this week for deep work.” “Block two hours tomorrow afternoon.” Otter reads your real availability across every connected calendar and turns the request into a concrete change — no menus, no forms.",
+          "Tap the mic and it works hands-free: speak the request, and Otter can read the answer back to you.",
         ],
       },
       {
-        heading: "Open core, sustainably",
+        heading: "It actually does things",
         paragraphs: [
-          "Free-and-open doesn't have to mean unsustainable. DayOtter is open-core: the whole scheduling engine — including the advanced features — is free when you self-host. Our hosted cloud funds the work with a simple $9/seat Pro plan and a couple of managed-only extras.",
-          "That balance keeps the lights on without holding the core hostage. It's the model that's worked for the tools developers actually trust.",
+          "Otter goes beyond answering questions. It can create a new booking type, hold focus time, adjust your working hours, change your timezone, set up reminder channels, and manage your automations — the things that normally take five screens of clicking. Anything you can do in DayOtter, Otter can do; it’s just faster.",
+        ],
+      },
+      {
+        heading: "Confirm-first, always",
+        paragraphs: [
+          "It never acts on its own. Every change shows up as an editable card you approve with a tap, and anything destructive asks twice before it happens. You get the speed of automation without ever losing the wheel.",
+          "Self-hosting? Otter turns on when you add your own AI key. On the cloud, it’s ready the moment you sign in.",
+        ],
+      },
+    ],
+  },
+  {
+    slug: "one-link-no-back-and-forth",
+    title: "One link, and the back-and-forth is over",
+    excerpt:
+      "“Does Tuesday work? How about Thursday at 2 — oh, my 2 just moved.” Share one DayOtter link instead and let people pick a time you’re actually free.",
+    date: "2026-07-10",
+    author: "The DayOtter team",
+    readMinutes: 3,
+    body: [
+      {
+        paragraphs: [
+          "Booking a meeting over email is a tennis match nobody wants to win. Every volley is another round of “when are you free?” against a calendar that keeps changing under you.",
+        ],
+      },
+      {
+        heading: "Share a link, not your week",
+        paragraphs: [
+          "Send one DayOtter link. The other person opens your page, sees only the times you’re genuinely open, and picks one. It lands on both calendars with a video link attached — no accounts, no reply thread, no “actually, that just filled up.”",
+        ],
+      },
+      {
+        heading: "Shaped exactly how you work",
+        paragraphs: [
+          "Set up a booking type for each kind of meeting — a 15-minute intro, a 60-minute deep dive — with buffers before and after, minimum notice, a daily cap, and intake questions so you show up prepared. Meet over Google Meet, Zoom, phone, or in person.",
+          "Need a single meeting without opening your whole calendar? Generate a one-off link that expires after it’s used. Booking someone important? Keep the type private and share it only with them.",
         ],
       },
     ],
@@ -62,14 +97,48 @@ export const POSTS: BlogPost[] = [
       {
         heading: "Propose, then confirm",
         paragraphs: [
-          "DayOtter's AI is confirm-first. Ask it to move your 3pm to tomorrow, or to defend two hours of deep work, and it drafts an editable proposal. Nothing touches your calendar until you say so.",
-          "It stays strictly in scope, too — scheduling only. It won't wander off to summarize your inbox or draft your strategy deck. It does one job, and it asks before it acts.",
+          "DayOtter’s AI is confirm-first. Ask it to move your 3pm to tomorrow, or to defend two hours of deep work, and it drafts an editable proposal. Nothing touches your calendar until you say so.",
+          "It stays strictly in scope, too — scheduling only. It won’t wander off to summarize your inbox or draft your strategy deck. It does one job, and it asks before it acts.",
         ],
       },
       {
         heading: "The best of both",
         paragraphs: [
-          "You get the leverage of automation without surrendering control of your time. That's the whole point: software that respects your calendar enough to ask first.",
+          "You get the leverage of automation without surrendering control of your time. That’s the whole point: software that respects your calendar enough to ask first.",
+        ],
+      },
+    ],
+  },
+  {
+    slug: "every-calendar-one-truth",
+    title: "Every calendar, one source of truth",
+    excerpt:
+      "Work Google, personal iCloud, a shared Outlook — DayOtter reads them all, so you’re never offered a time you’re secretly busy.",
+    date: "2026-07-04",
+    author: "The DayOtter team",
+    readMinutes: 3,
+    body: [
+      {
+        paragraphs: [
+          "Most double-bookings come from the calendar you forgot to check. The work one knows about the standup; the personal one knows about the dentist; neither knows about the other. DayOtter is the layer that does.",
+        ],
+      },
+      {
+        heading: "Connect once, stay honest",
+        paragraphs: [
+          "Link Google, Outlook, and iCloud — plus any read-only calendar feed. Before DayOtter ever offers a slot, it checks every connected calendar for a conflict. If you’re busy anywhere, that time simply isn’t on the table.",
+        ],
+      },
+      {
+        heading: "Busy, not private",
+        paragraphs: [
+          "DayOtter sees that you’re busy, never why. The details of your meetings stay on your own calendars; only free/busy shapes your availability. Connection tokens are encrypted at rest, and nothing you put in is ever sold.",
+        ],
+      },
+      {
+        heading: "Write where you want",
+        paragraphs: [
+          "Pick exactly which calendar new bookings are written to, and keep the others read-only just for conflict checks. One place decides when you’re free; you decide where the events land.",
         ],
       },
     ],
@@ -78,14 +147,14 @@ export const POSTS: BlogPost[] = [
     slug: "adaptive-availability",
     title: "Stop letting a full day get fuller",
     excerpt:
-      "Back-to-back is not a badge of honor. Adaptive availability quietly protects your worst days — here's how.",
+      "Back-to-back is not a badge of honor. Adaptive availability quietly protects your worst days — here’s how.",
     date: "2026-07-02",
     author: "The DayOtter team",
     readMinutes: 3,
     body: [
       {
         paragraphs: [
-          "The cruel math of open booking links: the busier you are, the more you get booked. A day that's already packed keeps taking hits until there's no room to think.",
+          "The cruel math of open booking links: the busier you are, the more you get booked. A day that’s already packed keeps taking hits until there’s no room to think.",
         ],
       },
       {
@@ -93,6 +162,96 @@ export const POSTS: BlogPost[] = [
         paragraphs: [
           "Adaptive availability sets a ceiling on meetings per day. Once a day hits your cap — counting both DayOtter bookings and events on your connected calendars — DayOtter simply stops offering slots that day. No awkward decline emails, no manual blocking.",
           "Pair it with travel-time buffers and automated focus blocks, and your calendar starts defending itself. You set the rules once; DayOtter enforces them every time someone tries to book.",
+        ],
+      },
+    ],
+  },
+  {
+    slug: "reminders-that-land",
+    title: "Reminders that actually get there",
+    excerpt:
+      "The best reminder is the one someone reads. DayOtter sends them where people already are — email, SMS, WhatsApp, and push.",
+    date: "2026-06-27",
+    author: "The DayOtter team",
+    readMinutes: 3,
+    body: [
+      {
+        paragraphs: [
+          "No-show isn’t usually rudeness. It’s an email that got buried under forty others by 9am. The fix isn’t nagging harder — it’s reaching people on the channel they actually check.",
+        ],
+      },
+      {
+        heading: "Meet people where they are",
+        paragraphs: [
+          "Email reminders are always on. Add Slack, SMS, WhatsApp, mobile push, or browser push on top — for you and for the people you’re meeting. A gentle nudge lands before the meeting, wherever it’ll get seen.",
+        ],
+      },
+      {
+        heading: "Timed the way you like",
+        paragraphs: [
+          "Choose the lead times that fit — a day before to plan, an hour before to get moving. Set it once and every booking inherits it. Fewer no-shows, far less chasing.",
+        ],
+      },
+    ],
+  },
+  {
+    slug: "calendar-on-autopilot",
+    title: "Put your calendar on autopilot",
+    excerpt:
+      "Prep blocks, buffers, follow-ups, focus time — the routine calendar admin you keep meaning to do, handled automatically.",
+    date: "2026-06-20",
+    author: "The DayOtter team",
+    readMinutes: 4,
+    body: [
+      {
+        paragraphs: [
+          "The meeting itself is the easy part. It’s the scaffolding around it — the prep, the buffer, the follow-up, the focus time you meant to protect — that quietly eats your week. DayOtter builds that scaffolding for you.",
+        ],
+      },
+      {
+        heading: "Automations",
+        paragraphs: [
+          "Set rules that fire on their own: add a prep block before every sales call, a buffer after long meetings, or a weekly focus window you never have to remember to book. Configure it once; DayOtter applies it every time.",
+        ],
+      },
+      {
+        heading: "Workflows",
+        paragraphs: [
+          "Send attendees the right message at the right moment automatically — a reminder the night before, a thank-you and next steps after — scoped to just the booking types you choose. It reads like you wrote it, without you writing it each time.",
+        ],
+      },
+      {
+        heading: "Defenses that hold",
+        paragraphs: [
+          "Layer on focus blocks, travel-time buffers around in-person meetings, a protected lunch, and adaptive daily caps. Bit by bit, your calendar stops being a free-for-all and starts guarding the time that matters.",
+        ],
+      },
+    ],
+  },
+  {
+    slug: "team-scheduling-without-the-spreadsheet",
+    title: "Team scheduling without the spreadsheet",
+    excerpt:
+      "Round-robin the sales team, find a time everyone’s free, or share one raft of availability — without the shared-calendar headache.",
+    date: "2026-06-14",
+    author: "The DayOtter team",
+    readMinutes: 3,
+    body: [
+      {
+        paragraphs: [
+          "Scheduling for one person is a solved problem. Scheduling across a team is where most tools fall back on a spreadsheet and a group chat. DayOtter keeps it to a single link.",
+        ],
+      },
+      {
+        heading: "Collective and round-robin",
+        paragraphs: [
+          "A collective booking type finds a slot when everyone required is free. A round-robin type spreads incoming bookings across the team so no one person carries them all. One link either way — DayOtter picks the right host and the right time.",
+        ],
+      },
+      {
+        heading: "One shared view",
+        paragraphs: [
+          "See the whole team’s free/busy for the week in a single place, and set team rules — holidays, no-meeting windows — that every member’s links quietly respect. Otters raft up so the current can’t pull them apart; your team’s calendars do the same.",
         ],
       },
     ],

--- a/apps/web/lib/marketing.ts
+++ b/apps/web/lib/marketing.ts
@@ -2,7 +2,7 @@
 
 export const BRAND = {
   name: "DayOtter",
-  tagline: "The open-source home for your time.",
+  tagline: "The calm home for your time.",
   email: "hello@dayotter.com",
   github: "https://github.com/nometria/dayotter",
   githubLicense: "https://github.com/nometria/dayotter/blob/main/LICENSE",


### PR DESCRIPTION
Fills out the thin marketing content and shifts positioning to **features + ease first, open source as a quiet bonus** (per direction — no "why scheduling should be open source" content).

### Blog — 6 new feature/ease posts (now 8 total)
`apps/web/lib/blog.ts`
- **Removed** the "Why scheduling should be open source" post.
- **Kept** the two feature posts (confirm-first AI, adaptive availability).
- **Added:**
  - *Meet Otter, the assistant that runs your calendar* — the AI assistant (chat + voice, acts confirm-first)
  - *One link, and the back-and-forth is over* — booking links/types, ease
  - *Every calendar, one source of truth* — multi-calendar sync, conflict-aware
  - *Reminders that actually get there* — email/SMS/WhatsApp/push
  - *Put your calendar on autopilot* — automations, workflows, focus defense
  - *Team scheduling without the spreadsheet* — collective + round-robin

### Repositioned copy (open source → bonus, not headline)
- Hero eyebrow: `Open-source team scheduling` → **`Scheduling, minus the back-and-forth`**
- Brand tagline: drops the open-source lead → **`The calm home for your time.`**
- **About**: leads with the product; open source reframed as a "Yours to run" bonus
- Blog + changelog subtitles: drop "in the open"

### Changelog
New top entry covering **Ask Otter**, the interface refresh, phone/OTP sign-in, and browser web push.

### Verified
`/blog` lists all 8 posts; post bodies render with correct headings and curly punctuation (no mojibake). Typecheck + biome clean. Docs-only/content — no app logic changed.
