### PR TITLE
fix(deploy): bake NEXT_PUBLIC_* into the web build (Google sign-in button never rendered)

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -14,6 +14,24 @@ RUN pnpm install --frozen-lockfile --filter "@dayotter/web..."
 # --- Build the Next.js standalone bundle ---
 FROM deps AS build
 ENV NEXT_TELEMETRY_DISABLED=1
+# NEXT_PUBLIC_* are INLINED into the client bundle at build time, so they must be
+# present during `next build` (passed as build args from compose). Setting them in
+# the runtime .env alone has no effect — the value is already baked. Empty = the
+# feature stays hidden.
+ARG NEXT_PUBLIC_GOOGLE_AUTH=""
+ARG NEXT_PUBLIC_PHONE_AUTH=""
+ARG NEXT_PUBLIC_VAPID_PUBLIC_KEY=""
+ARG NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=""
+ARG NEXT_PUBLIC_TURNSTILE_SITE_KEY=""
+ARG NEXT_PUBLIC_MIXPANEL_TOKEN=""
+ARG NEXT_PUBLIC_GA_ID=""
+ENV NEXT_PUBLIC_GOOGLE_AUTH=$NEXT_PUBLIC_GOOGLE_AUTH \
+    NEXT_PUBLIC_PHONE_AUTH=$NEXT_PUBLIC_PHONE_AUTH \
+    NEXT_PUBLIC_VAPID_PUBLIC_KEY=$NEXT_PUBLIC_VAPID_PUBLIC_KEY \
+    NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY \
+    NEXT_PUBLIC_TURNSTILE_SITE_KEY=$NEXT_PUBLIC_TURNSTILE_SITE_KEY \
+    NEXT_PUBLIC_MIXPANEL_TOKEN=$NEXT_PUBLIC_MIXPANEL_TOKEN \
+    NEXT_PUBLIC_GA_ID=$NEXT_PUBLIC_GA_ID
 RUN pnpm --filter @dayotter/web build
 
 # --- Minimal runtime image ---

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -63,6 +63,16 @@ services:
     build:
       context: ..
       dockerfile: apps/web/Dockerfile
+      # NEXT_PUBLIC_* are baked into the web build, so they're passed as build args
+      # (read from deploy/.env). Change one -> rebuild with `up -d --build web`.
+      args:
+        NEXT_PUBLIC_GOOGLE_AUTH: ${NEXT_PUBLIC_GOOGLE_AUTH:-}
+        NEXT_PUBLIC_PHONE_AUTH: ${NEXT_PUBLIC_PHONE_AUTH:-}
+        NEXT_PUBLIC_VAPID_PUBLIC_KEY: ${NEXT_PUBLIC_VAPID_PUBLIC_KEY:-}
+        NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY:-}
+        NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${NEXT_PUBLIC_TURNSTILE_SITE_KEY:-}
+        NEXT_PUBLIC_MIXPANEL_TOKEN: ${NEXT_PUBLIC_MIXPANEL_TOKEN:-}
+        NEXT_PUBLIC_GA_ID: ${NEXT_PUBLIC_GA_ID:-}
     image: dayotter-web:local
     restart: unless-stopped
     env_file: .env


### PR DESCRIPTION
## Symptom
"Continue with Google" doesn't appear on the live sign-in page even with `GOOGLE_CLIENT_ID/SECRET` and `NEXT_PUBLIC_GOOGLE_AUTH=1` set in `deploy/.env`. Same latent problem for phone-auth, Stripe, VAPID web push, Turnstile, and analytics.

## Root cause
`NEXT_PUBLIC_*` values are **inlined into the client bundle at `next build` time**. The web Dockerfile ran `pnpm build` with none of them in the environment, and the compose `web` service declared **no `build.args`** — so they all baked as empty strings. The runtime `.env` (env_file / environment) only affects the *running* container, never the already-built client bundle, so the flags were dead.

## Fix
- **Dockerfile** (`build` stage): `ARG` + `ENV` for each of the 7 `NEXT_PUBLIC_*` vars, set before `pnpm build`.
- **`docker-compose.prod.yml`** (`web.build.args`): forward each from `deploy/.env` (`${NEXT_PUBLIC_...:-}`).

Verified with `docker compose config`: `NEXT_PUBLIC_GOOGLE_AUTH: "1"` now reaches the build; unset ones default to empty (feature stays hidden).

## Apply on the server
```bash
cd ~/dayotter/deploy
grep -q '^NEXT_PUBLIC_GOOGLE_AUTH=1' .env || sed -i 's|^NEXT_PUBLIC_GOOGLE_AUTH=.*|NEXT_PUBLIC_GOOGLE_AUTH=1|' .env
docker compose -f docker-compose.prod.yml -f docker-compose.nginx.yml --env-file .env up -d --build web
```
Also make sure `https://dayotter.com/api/auth/callback/google` is an authorized redirect URI on the Google OAuth client.
