### PR TITLE
content+ux+mobile: real /docs, bookings filter, and Android target-SDK 35 fix

### DIFF
--- a/apps/mobile/.gitignore
+++ b/apps/mobile/.gitignore
@@ -20,3 +20,7 @@ npm-debug.*
 *.key
 *.mobileprovision
 .DS_Store
+
+# Signing + store-submit secrets — never commit (public repo)
+*.keystore
+*service-account*.json

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -50,6 +50,19 @@
             "com.google.android.googlequicksearchbox"
           ]
         }
+      ],
+      [
+        "expo-build-properties",
+        {
+          "android": {
+            "compileSdkVersion": 35,
+            "targetSdkVersion": 35,
+            "buildToolsVersion": "35.0.0"
+          },
+          "ios": {
+            "deploymentTarget": "15.1"
+          }
+        }
       ]
     ],
     "extra": {

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,6 +2,7 @@
   "expo": {
     "name": "DayOtter",
     "slug": "dayotter",
+    "owner": "dayotter",
     "scheme": "dayotter",
     "version": "0.1.0",
     "orientation": "portrait",
@@ -16,15 +17,22 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.dayotter.app",
-      "buildNumber": "1"
+      "buildNumber": "1",
+      "infoPlist": {
+        "NSSpeechRecognitionUsageDescription": "DayOtter turns your spoken commands into scheduling actions.",
+        "NSMicrophoneUsageDescription": "DayOtter uses the microphone so you can speak scheduling commands."
+      }
     },
     "android": {
       "package": "com.dayotter.app",
-      "versionCode": 1,
+      "versionCode": 2,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#12305F"
-      }
+      },
+      "permissions": [
+        "android.permission.RECORD_AUDIO"
+      ]
     },
     "web": {
       "favicon": "./assets/favicon.png"
@@ -38,13 +46,18 @@
         {
           "microphonePermission": "DayOtter uses the microphone so you can speak scheduling commands.",
           "speechRecognitionPermission": "DayOtter turns your spoken commands into scheduling actions.",
-          "androidSpeechServicePackages": ["com.google.android.googlequicksearchbox"]
+          "androidSpeechServicePackages": [
+            "com.google.android.googlequicksearchbox"
+          ]
         }
       ]
     ],
     "extra": {
       "eas": {
-        "projectId": "cd87a7ee-bf23-407c-a664-0743fe0f3257"
+        "projectId": "c23c4638-20dd-4be4-9c78-3d11c8f2bc66"
+      },
+      "router": {
+        "origin": false
       }
     }
   }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -17,6 +17,7 @@
     "@react-native-community/datetimepicker": "8.2.0",
     "better-auth": "1.6.23",
     "expo": "~52.0.23",
+    "expo-build-properties": "~0.13.3",
     "expo-constants": "~17.0.4",
     "expo-device": "~7.0.3",
     "expo-linking": "~7.0.4",

--- a/apps/web/app/(app)/event-types/page.tsx
+++ b/apps/web/app/(app)/event-types/page.tsx
@@ -77,7 +77,7 @@ export default async function EventTypesPage() {
                   {et.description}
                 </p>
               ) : null}
-              <div className="mt-4 flex items-center justify-between gap-2 border-t border-[var(--color-border)] pt-3">
+              <div className="mt-4 flex flex-wrap items-center justify-between gap-x-3 gap-y-2 border-t border-[var(--color-border)] pt-3">
                 {handle ? (
                   <div className="flex items-center gap-3">
                     <CopyLinkButton path={`/${handle}/${et.slug}`} />

--- a/apps/web/app/(marketing)/docs/[slug]/page.tsx
+++ b/apps/web/app/(marketing)/docs/[slug]/page.tsx
@@ -1,0 +1,75 @@
+import { Prose } from "@/components/marketing/page-shell";
+import { GUIDES, getGuide } from "@/lib/docs";
+import { ArrowLeft } from "lucide-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+export function generateStaticParams() {
+  return GUIDES.map((g) => ({ slug: g.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const g = getGuide((await params).slug);
+  if (!g) return { title: "Docs — DayOtter" };
+  return { title: `${g.title} — DayOtter Docs`, description: g.summary };
+}
+
+export default async function DocGuidePage({ params }: { params: Promise<{ slug: string }> }) {
+  const g = getGuide((await params).slug);
+  if (!g) notFound();
+
+  return (
+    <article>
+      <header className="border-b border-[var(--color-border)]">
+        <div className="mx-auto max-w-2xl px-6 py-14">
+          <Link
+            href="/docs"
+            className="mb-6 inline-flex items-center gap-1.5 text-sm text-[var(--color-muted)] transition-colors hover:text-[var(--color-text)]"
+          >
+            <ArrowLeft size={15} /> All docs
+          </Link>
+          <p className="eyebrow mb-3">
+            {g.category} · {g.readMinutes} min read
+          </p>
+          <h1 className="font-display text-4xl leading-[1.08] tracking-[-0.01em]">{g.title}</h1>
+          <p className="mt-4 text-lg text-[var(--color-muted)]">{g.summary}</p>
+        </div>
+      </header>
+
+      <Prose>
+        {g.body.map((b, i) => (
+          <div key={i}>
+            {b.heading ? <h2>{b.heading}</h2> : null}
+            {b.paragraphs?.map((p, j) => (
+              <p key={j}>{p}</p>
+            ))}
+            {b.steps ? (
+              <ol>
+                {b.steps.map((s, j) => (
+                  <li key={j}>{s}</li>
+                ))}
+              </ol>
+            ) : null}
+            {b.bullets ? (
+              <ul>
+                {b.bullets.map((s, j) => (
+                  <li key={j}>{s}</li>
+                ))}
+              </ul>
+            ) : null}
+          </div>
+        ))}
+        <hr />
+        <p>
+          Ready to try it? <Link href="/sign-up">Get started free</Link>, or browse{" "}
+          <Link href="/docs">all guides</Link>.
+        </p>
+      </Prose>
+    </article>
+  );
+}

--- a/apps/web/app/(marketing)/docs/page.tsx
+++ b/apps/web/app/(marketing)/docs/page.tsx
@@ -1,38 +1,33 @@
 import { MarketingHeader } from "@/components/marketing/page-shell";
+import { DOC_CATEGORIES, GUIDES } from "@/lib/docs";
 import { BRAND } from "@/lib/marketing";
-import { BookOpen, Code2, Server, Webhook } from "lucide-react";
+import { ArrowUpRight, Code2, Server, Webhook } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
 
 export const metadata: Metadata = {
   title: "Documentation — DayOtter",
-  description: "Guides for using, self-hosting, and building on DayOtter.",
+  description: "Guides for setting up, using, and building on DayOtter.",
 };
 
-const GUIDES = [
-  {
-    icon: BookOpen,
-    title: "Getting started",
-    body: "Connect your calendars, create an event type, and share your booking link.",
-    href: "/sign-up",
-  },
+const BUILD_LINKS = [
   {
     icon: Server,
     title: "Self-hosting",
-    body: "Run DayOtter on your own infrastructure with Docker — every feature, free.",
+    body: "Run the whole thing on your own infrastructure with Docker.",
     href: "/self-hosting",
   },
   {
     icon: Code2,
     title: "REST API",
-    body: "Authenticate with an API key and read/create bookings, event types, and availability under /api/v1.",
+    body: "API keys + /api/v1 for bookings, event types, and availability.",
     href: BRAND.github,
     external: true,
   },
   {
     icon: Webhook,
     title: "Webhooks & embed",
-    body: "Get signed booking.created / cancelled / rescheduled events, or drop the booking widget on your site.",
+    body: "Signed booking events, or drop the booking widget on your site.",
     href: BRAND.github,
     external: true,
   },
@@ -44,33 +39,70 @@ export default function DocsPage() {
       <MarketingHeader
         eyebrow="Docs"
         title="Documentation"
-        subtitle="Everything you need to use, self-host, and build on DayOtter."
+        subtitle="Short, task-focused guides to get you booked — and a few pointers for building on DayOtter."
       />
-      <section className="mx-auto max-w-4xl px-6 py-16">
-        <div className="grid gap-5 sm:grid-cols-2">
-          {GUIDES.map((g) => {
+      <section className="mx-auto max-w-3xl px-6 py-16">
+        {DOC_CATEGORIES.map((cat) => {
+          const guides = GUIDES.filter((g) => g.category === cat);
+          if (guides.length === 0) return null;
+          return (
+            <div key={cat} className="mb-12">
+              <p className="eyebrow mb-4">{cat}</p>
+              <div className="divide-y divide-[var(--color-border)] overflow-hidden rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)]">
+                {guides.map((g) => (
+                  <Link
+                    key={g.slug}
+                    href={`/docs/${g.slug}`}
+                    className="flex items-center justify-between gap-4 px-5 py-4 transition-colors hover:bg-[var(--color-surface-2)]"
+                  >
+                    <div className="min-w-0">
+                      <p className="font-medium">{g.title}</p>
+                      <p className="mt-0.5 text-sm text-[var(--color-muted)]">{g.summary}</p>
+                    </div>
+                    <span className="shrink-0 font-mono text-xs text-[var(--color-faint)]">
+                      {g.readMinutes} min
+                    </span>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+
+        <p className="eyebrow mb-4">Build on DayOtter</p>
+        <div className="grid gap-4 sm:grid-cols-3">
+          {BUILD_LINKS.map((l) => {
             const inner = (
-              <div className="h-full rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)] p-6 shadow-[var(--shadow-card)] transition-colors hover:border-[var(--color-border-strong)]">
-                <div className="flex h-10 w-10 items-center justify-center rounded-[var(--radius-md)] bg-[var(--color-accent-soft)]">
-                  <g.icon size={18} className="text-[var(--color-accent)]" />
+              <div
+                key={l.title}
+                className="h-full rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)] p-5 shadow-[var(--shadow-card)] transition-colors hover:border-[var(--color-border-strong)]"
+              >
+                <div className="flex h-9 w-9 items-center justify-center rounded-[var(--radius-md)] bg-[var(--color-accent-soft)]">
+                  <l.icon size={16} className="text-[var(--color-accent)]" />
                 </div>
-                <h2 className="mt-4 text-lg font-semibold">{g.title}</h2>
-                <p className="mt-1.5 text-sm text-[var(--color-muted)]">{g.body}</p>
+                <p className="mt-3 flex items-center gap-1 font-medium">
+                  {l.title}
+                  {l.external ? (
+                    <ArrowUpRight size={13} className="text-[var(--color-faint)]" />
+                  ) : null}
+                </p>
+                <p className="mt-1 text-sm text-[var(--color-muted)]">{l.body}</p>
               </div>
             );
-            return g.external ? (
-              <a key={g.title} href={g.href} target="_blank" rel="noreferrer">
+            return l.external ? (
+              <a key={l.title} href={l.href} target="_blank" rel="noreferrer">
                 {inner}
               </a>
             ) : (
-              <Link key={g.title} href={g.href}>
+              <Link key={l.title} href={l.href}>
                 {inner}
               </Link>
             );
           })}
         </div>
+
         <p className="mt-10 text-center text-sm text-[var(--color-muted)]">
-          Looking for something specific?{" "}
+          Can't find what you need?{" "}
           <Link href="/contact" className="text-[var(--color-accent)] hover:underline">
             Ask us
           </Link>

--- a/apps/web/components/bookings-workspace.tsx
+++ b/apps/web/components/bookings-workspace.tsx
@@ -31,12 +31,33 @@ const STATUS_LABEL: Record<string, string> = { no_show: "no-show" };
 
 type Tab = "calendar" | "history";
 
+// History status filters. Each maps one or more raw booking statuses to a
+// friendly label; a filter only shows when the history actually contains it.
+const FILTERS: { key: string; label: string; match: (status: string) => boolean }[] = [
+  { key: "all", label: "All", match: () => true },
+  { key: "confirmed", label: "Confirmed", match: (s) => s === "confirmed" },
+  { key: "completed", label: "Completed", match: (s) => s === "completed" },
+  { key: "cancelled", label: "Cancelled", match: (s) => s === "cancelled" || s === "rejected" },
+  { key: "no_show", label: "No-show", match: (s) => s === "no_show" },
+  { key: "pending", label: "Pending", match: (s) => s === "pending" },
+];
+
 /** Bookings surface: a colour-coded calendar (month/week/agenda) plus a full
  *  history list (including past + cancelled). */
 export function BookingsWorkspace({ tz, history }: { tz: string; history: HistoryBooking[] }) {
   // Default to History so the server-loaded rows render immediately; the
   // calendar fetches its own range only when that tab is opened.
   const [tab, setTab] = useState<Tab>("history");
+  const [statusFilter, setStatusFilter] = useState("all");
+
+  // Only surface filters that match at least one booking (besides "All"), and
+  // only bother showing the row when there's more than one status to filter by.
+  const availableFilters = FILTERS.filter(
+    (f) => f.key === "all" || history.some((b) => f.match(b.status)),
+  );
+  const showFilters = availableFilters.length > 2;
+  const active = FILTERS.find((f) => f.key === statusFilter) ?? FILTERS[0]!;
+  const shownHistory = history.filter((b) => active.match(b.status));
 
   return (
     <>
@@ -66,11 +87,38 @@ export function BookingsWorkspace({ tz, history }: { tz: string; history: Histor
           description="Calm waters for now — when someone books one of your booking types, it surfaces here."
         />
       ) : (
-        <div className="space-y-2">
-          {history.map((b) => (
-            <HistoryRow key={b.id} b={b} tz={tz} />
-          ))}
-        </div>
+        <>
+          {showFilters ? (
+            <div className="mb-4 flex flex-wrap gap-1.5">
+              {availableFilters.map((f) => (
+                <button
+                  key={f.key}
+                  type="button"
+                  onClick={() => setStatusFilter(f.key)}
+                  className={cn(
+                    "rounded-full border px-3 py-1 text-xs font-medium transition-colors",
+                    statusFilter === f.key
+                      ? "border-[var(--color-accent)] bg-[var(--color-accent-soft)] text-[var(--color-accent)]"
+                      : "border-[var(--color-border-strong)] text-[var(--color-muted)] hover:text-[var(--color-text)]",
+                  )}
+                >
+                  {f.label}
+                </button>
+              ))}
+            </div>
+          ) : null}
+          {shownHistory.length === 0 ? (
+            <p className="py-10 text-center text-sm text-[var(--color-muted)]">
+              No {active.label.toLowerCase()} bookings.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {shownHistory.map((b) => (
+                <HistoryRow key={b.id} b={b} tz={tz} />
+              ))}
+            </div>
+          )}
+        </>
       )}
     </>
   );

--- a/apps/web/lib/docs.ts
+++ b/apps/web/lib/docs.ts
@@ -1,0 +1,264 @@
+/** Local documentation content. Add a guide here and it appears on /docs +
+ *  /docs/[slug]. Keep it task-oriented — what a person does, not how the code works. */
+
+export interface DocBlock {
+  heading?: string;
+  paragraphs?: string[];
+  /** Rendered as an ordered list (numbered steps). */
+  steps?: string[];
+  /** Rendered as an unordered list. */
+  bullets?: string[];
+}
+
+export type DocCategory = "Get started" | "Features" | "Advanced";
+
+export interface DocGuide {
+  slug: string;
+  title: string;
+  summary: string;
+  category: DocCategory;
+  readMinutes: number;
+  body: DocBlock[];
+}
+
+export const GUIDES: DocGuide[] = [
+  {
+    slug: "getting-started",
+    title: "Getting started",
+    summary: "From sign-up to a shareable booking link in about five minutes.",
+    category: "Get started",
+    readMinutes: 4,
+    body: [
+      {
+        paragraphs: [
+          "DayOtter turns your calendars into a link people can book. Here's the whole path, start to finish.",
+        ],
+      },
+      {
+        heading: "The five-minute setup",
+        steps: [
+          "Create your account at /sign-up (email, Google, or phone).",
+          "Connect a calendar so DayOtter knows when you're busy — Settings → Calendars.",
+          "Set the hours you're open under Availability.",
+          "Create a booking type (e.g. a 30-minute intro) under Booking Types.",
+          "Copy your booking link from the dashboard and share it.",
+        ],
+      },
+      {
+        heading: "What happens when someone books",
+        paragraphs: [
+          "They open your link, see only the times you're genuinely free, and pick one. The meeting lands on your connected calendar with a video link attached, and both of you get a confirmation and reminders. No back-and-forth, no double-booking.",
+        ],
+      },
+      {
+        heading: "Next steps",
+        bullets: [
+          "Add reminder channels so nudges reach you where you are.",
+          "Protect focus time with buffers, daily limits, and focus blocks.",
+          "Invite teammates and share availability as a team.",
+        ],
+      },
+    ],
+  },
+  {
+    slug: "connect-a-calendar",
+    title: "Connect a calendar",
+    summary:
+      "Link Google, Outlook, iCloud, or any feed so you're never offered a time you're busy.",
+    category: "Get started",
+    readMinutes: 3,
+    body: [
+      {
+        paragraphs: [
+          "DayOtter never invents availability — it reads your real calendars. Connect every calendar that holds commitments so a booking can't land on top of one.",
+        ],
+      },
+      {
+        heading: "Supported calendars",
+        bullets: [
+          "Google Calendar and Microsoft 365 / Outlook (one-click OAuth).",
+          "Apple iCloud (with an app-specific password).",
+          "Any read-only ICS / webcal feed, for calendars you can only subscribe to.",
+        ],
+      },
+      {
+        heading: "Connect one",
+        steps: [
+          "Go to Settings → Calendars.",
+          "Pick your provider and approve access.",
+          "Choose which of that account's calendars DayOtter should check for conflicts.",
+        ],
+      },
+      {
+        heading: "Busy, not private",
+        paragraphs: [
+          "DayOtter only sees that you're busy, never the details of your events. You also choose exactly which calendar new bookings are written to — keep the rest read-only, just for conflict checks. Connection tokens are encrypted at rest.",
+        ],
+      },
+    ],
+  },
+  {
+    slug: "create-a-booking-type",
+    title: "Create a booking type",
+    summary: "One booking type per kind of meeting — shaped exactly how you work.",
+    category: "Features",
+    readMinutes: 4,
+    body: [
+      {
+        paragraphs: [
+          "A booking type is a shareable meeting template: its length, where it happens, and the rules around it. Make one for each kind of meeting you take.",
+        ],
+      },
+      {
+        heading: "The essentials",
+        bullets: [
+          "Title, URL slug, and duration (offer several lengths if you like).",
+          "Location: Google Meet, Zoom, Microsoft Teams, phone, or in person.",
+          "Buffers before and after, and a minimum notice so nobody books you in five minutes.",
+          "Daily and weekly limits to cap how much you take on.",
+          "Intake questions so you show up prepared.",
+        ],
+      },
+      {
+        heading: "Private and one-off links",
+        paragraphs: [
+          "Mark a type private to keep it off your public page and share it only with the people you choose. Or generate a one-off link for a single meeting that expires once it's used — handy when you don't want to expose your whole calendar.",
+        ],
+      },
+      {
+        heading: "Paid bookings",
+        paragraphs: [
+          "Connect Stripe and set a price to take payment at booking time — useful for consultations or paid sessions. Free types stay free.",
+        ],
+      },
+    ],
+  },
+  {
+    slug: "set-your-availability",
+    title: "Set your availability",
+    summary:
+      "Weekly hours, date exceptions, multiple schedules, and defenses that protect your time.",
+    category: "Features",
+    readMinutes: 4,
+    body: [
+      {
+        heading: "Weekly hours",
+        paragraphs: [
+          "Under Availability, set the hours you're open on each day. Add multiple ranges per day (say, a morning and an afternoon block), then Save. These are the times DayOtter will ever offer.",
+        ],
+      },
+      {
+        heading: "Date overrides and schedules",
+        paragraphs: [
+          "Override specific dates — a day off, a one-time early start. Running different offerings? Create multiple named schedules (e.g. “Consulting hours”) and assign each booking type to the right one.",
+        ],
+      },
+      {
+        heading: "Defenses that hold",
+        bullets: [
+          "Focus blocks: reserve deep-work time that's off-limits to bookings.",
+          "Adaptive availability: cap meetings per day; once a day is full, it stops offering slots.",
+          "Travel buffers: reserve time around in-person meetings automatically.",
+          "A protected lunch that never gets booked over.",
+        ],
+      },
+    ],
+  },
+  {
+    slug: "reminders-and-notifications",
+    title: "Reminders & notifications",
+    summary: "Reach people where they already are, so meetings don't get missed.",
+    category: "Features",
+    readMinutes: 3,
+    body: [
+      {
+        paragraphs: [
+          "The best reminder is the one someone actually reads. Email reminders are always on; add more channels on top for you and your attendees.",
+        ],
+      },
+      {
+        heading: "Channels",
+        bullets: [
+          "Slack, SMS, WhatsApp, mobile push, and browser (web) push.",
+          "Add and verify each under Settings → Notifications — DayOtter sends a test to confirm it works.",
+        ],
+      },
+      {
+        heading: "Timing",
+        paragraphs: [
+          "Choose the lead times that fit you — a day before to plan, an hour before to get moving. Every new booking inherits them, so you set it once.",
+        ],
+      },
+    ],
+  },
+  {
+    slug: "team-scheduling",
+    title: "Team scheduling",
+    summary: "Round-robin, collective availability, and shared team rules — from one link.",
+    category: "Features",
+    readMinutes: 3,
+    body: [
+      {
+        heading: "Create a team",
+        steps: [
+          "Go to Teams and create a team.",
+          "Add members by email (they need a DayOtter account).",
+          "Create a team booking type and pick how it schedules.",
+        ],
+      },
+      {
+        heading: "Collective vs round-robin",
+        paragraphs: [
+          "A collective type finds a slot when everyone required is free. A round-robin type spreads incoming bookings across the team so no one carries them all. Either way it's a single link — DayOtter picks the right host and time.",
+        ],
+      },
+      {
+        heading: "Shared view and rules",
+        paragraphs: [
+          "See the whole team's free/busy for the week in one place, and set team rules — holidays, no-meeting windows — that every member's links respect.",
+        ],
+      },
+    ],
+  },
+  {
+    slug: "the-otter-assistant",
+    title: "Ask Otter (the AI assistant)",
+    summary: "Chat or talk to your calendar — it drafts every change and never acts without a tap.",
+    category: "Advanced",
+    readMinutes: 3,
+    body: [
+      {
+        paragraphs: [
+          "Otter is the assistant on your dashboard. Ask it in plain language — by typing or by voice — and it reads your real availability to get things done.",
+        ],
+      },
+      {
+        heading: "What you can ask",
+        bullets: [
+          "“Move my 3pm to Friday morning.”",
+          "“Find me a free hour this week for deep work.”",
+          "“Create a 20-minute intro call booking type.”",
+          "“Turn off SMS reminders.”",
+        ],
+      },
+      {
+        heading: "Confirm-first, always",
+        paragraphs: [
+          "Otter can create booking types, hold focus time, change your availability and preferences, manage reminder channels, and more — but it only ever proposes. Every change is an editable card you approve, and anything destructive asks twice.",
+        ],
+      },
+      {
+        heading: "Turning it on",
+        paragraphs: [
+          "On the cloud, Otter is ready when you sign in. Self-hosting? Add your own ANTHROPIC_API_KEY and it turns on.",
+        ],
+      },
+    ],
+  },
+];
+
+export function getGuide(slug: string): DocGuide | undefined {
+  return GUIDES.find((g) => g.slug === slug);
+}
+
+export const DOC_CATEGORIES: DocCategory[] = ["Get started", "Features", "Advanced"];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,9 @@ importers:
       expo:
         specifier: ~52.0.23
         version: 52.0.49(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@19.1.17)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@19.1.17)(react@18.3.1))(react@18.3.1)
+      expo-build-properties:
+        specifier: ~0.13.3
+        version: 0.13.3(expo@52.0.49(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@19.1.17)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@19.1.17)(react@18.3.1))(react@18.3.1))
       expo-constants:
         specifier: ~17.0.4
         version: 17.0.8(expo@52.0.49(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@19.1.17)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@19.1.17)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@19.1.17)(react@18.3.1))
@@ -3946,6 +3949,11 @@ packages:
       react: '*'
       react-native: '*'
 
+  expo-build-properties@0.13.3:
+    resolution: {integrity: sha512-gw7AYP+YF50Gr912BedelRDTfR4GnUEn9p5s25g4nv0hTJGWpBZdCYR5/Oi2rmCHJXxBqhPjxzV7JRh72fntLg==}
+    peerDependencies:
+      expo: '*'
+
   expo-constants@17.0.8:
     resolution: {integrity: sha512-XfWRyQAf1yUNgWZ1TnE8pFBMqGmFP5Gb+SFSgszxDdOoheB/NI5D4p7q86kI2fvGyfTrxAe+D+74nZkfsGvUlg==}
     peerDependencies:
@@ -7464,7 +7472,7 @@ snapshots:
       '@better-fetch/fetch': 1.3.1
       '@opentelemetry/semantic-conventions': 1.41.1
       '@standard-schema/spec': 1.1.0
-      better-call: 1.3.7(zod@3.25.76)
+      better-call: 1.3.7(zod@4.4.3)
       jose: 6.2.3
       kysely: 0.29.2
       nanostores: 1.4.0
@@ -9439,7 +9447,7 @@ snapshots:
       '@better-fetch/fetch': 1.3.1
       '@noble/ciphers': 2.2.0
       '@noble/hashes': 2.2.0
-      better-call: 1.3.7(zod@3.25.76)
+      better-call: 1.3.7(zod@4.4.3)
       defu: 6.1.7
       jose: 6.2.3
       kysely: 0.29.2
@@ -9454,15 +9462,6 @@ snapshots:
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
-
-  better-call@1.3.7(zod@3.25.76):
-    dependencies:
-      '@better-auth/utils': 0.4.2
-      '@better-fetch/fetch': 1.3.1
-      rou3: 0.7.12
-      set-cookie-parser: 3.1.1
-    optionalDependencies:
-      zod: 3.25.76
 
   better-call@1.3.7(zod@4.4.3):
     dependencies:
@@ -10202,6 +10201,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
     optional: true
+
+  expo-build-properties@0.13.3(expo@52.0.49(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@19.1.17)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@19.1.17)(react@18.3.1))(react@18.3.1)):
+    dependencies:
+      ajv: 8.20.0
+      expo: 52.0.49(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@19.1.17)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@19.1.17)(react@18.3.1))(react@18.3.1)
+      semver: 7.8.5
 
   expo-constants@17.0.8(expo@52.0.49(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@19.1.17)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@19.1.17)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@19.1.17)(react@18.3.1)):
     dependencies:


### PR DESCRIPTION
Finishes the thin **/docs** page and clears two **UX audit backlog** items.

## Content — real docs
`/docs` was a card grid that linked out to sign-up / GitHub with no actual guides. Now it's a proper docs system:
- **`lib/docs.ts`** — 7 short, task-focused guides: Getting started · Connect a calendar · Create a booking type · Set your availability · Reminders & notifications · Team scheduling · Ask Otter (AI). Grouped by category (Get started / Features / Advanced) with read times.
- **`/docs/[slug]`** renderer — renders headings, paragraphs, ordered **steps**, and bullet lists through the shared Prose styles.
- **Index** — a clean categorised list linking each guide, plus a "Build on DayOtter" row (self-hosting, REST API, webhooks).

## UX audit backlog
- **Bookings history filter** — status chips (All / Confirmed / Completed / Cancelled / No-show / Pending), shown only when the list actually contains multiple statuses. Fixes the "100 rows, no way to find cancelled / older" gap.
- **Event-types mobile** — the crowded 5-action card row now wraps cleanly instead of overflowing on narrow screens.

## Verified
`/docs` index (categorised guide list) and a guide page render correctly — steps + bullets, clean typography, no mojibake. Typecheck + biome clean.

## Still deferred (with rationale)
- **Availability save model** (autosave vs explicit Save) — a UX-preference change that needs a deliberate call; left as-is.
- **Insights ↔ Analytics client tabs** — Next.js prefetches the sibling route, so switching is already near-instant; a route-merge isn't worth the risk.
- **Shared loading skeleton** — cosmetic; can follow later.

---

### Mobile deploy fix (added)
Google Play rejected `eas submit` with **"Target SDK of artifact is too low"**. Pinned it with **expo-build-properties** (compile/target SDK **35**, buildTools 35.0.0, iOS deploymentTarget 15.1), and folded in the correct EAS project config (owner `dayotter`, the `eas init` projectId) that was set locally but hadn't reached `main`.

**Rebuild → resubmit:** `eas build -p android --profile production` then `eas submit -p android` (versionCode auto-increments).