### PR TITLE
chore: close remaining code todos — integrations doc, skeleton, AI tool, availability guard

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -25,7 +25,7 @@
     },
     "android": {
       "package": "com.dayotter.app",
-      "versionCode": 2,
+      "versionCode": 3,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#12305F"

--- a/apps/mobile/store/README.md
+++ b/apps/mobile/store/README.md
@@ -139,20 +139,18 @@ In App Store Connect create the app record (bundle id `com.dayotter.app`), then
 attach the build, screenshots, and the listing copy above. Bump `buildNumber`
 for each new upload (or rely on `autoIncrement`).
 
-## ⚠️ App Store review — two things to resolve before submitting
+## App Store review — the two common blockers are handled
 
-App Review commonly rejects on these; both are present today:
+Both guideline issues App Review usually flags are already addressed in the iOS build:
 
 1. **In-app purchase / anti-steering (Guideline 3.1.1).** `src/components/pro-lock.tsx`
-   shows an **"Upgrade on the web"** button that opens the Stripe billing page.
-   Directing users to an external purchase for digital goods is not allowed
-   without Apple's External-Purchase entitlement. Fix: remove the purchase
-   button/link from the iOS build (show the feature as locked with a neutral
-   message), add Apple In-App Purchase, or apply for the entitlement.
-2. **Sign in with Apple (Guideline 4.8).** `app/sign-in.tsx` offers Google
-   sign-in. If any third-party login is offered, Apple requires **Sign in with
-   Apple** as an equivalent option. Fix: add Sign in with Apple, or disable
-   Google sign-in on the build submitted to Apple (email/password alone is fine).
+   hides the "Upgrade on the web" button on iOS (`Platform.OS === "ios"`) and shows a
+   neutral "locked" message instead — no external-purchase steering.
+2. **Sign in with Apple (Guideline 4.8).** `app/sign-in.tsx` hides Google sign-in on
+   iOS (`Platform.OS !== "ios"`), so no third-party login is offered and Sign in with
+   Apple isn't required. Email/password (and phone OTP) remain available.
+
+If you later add Sign in with Apple and want Google back on iOS, do both together.
 
 You'll also need in App Store Connect: a privacy policy URL
 (`https://dayotter.com/privacy`), a support URL, and the App Privacy

--- a/apps/web/components/availability-editor.tsx
+++ b/apps/web/components/availability-editor.tsx
@@ -4,7 +4,7 @@ import { FormError } from "@/components/ui/form";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/cn";
 import { Check, Copy, Plus, X } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 interface Range {
   start: string; // "HH:MM"
@@ -83,6 +83,29 @@ export function AvailabilityEditor({
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Hours use an explicit Save (unlike the instant schedule actions), so guard
+  // against navigating away with unsaved edits. Derive "dirty" by comparing the
+  // current state to what was loaded — no need to flag every handler.
+  const dirty = useMemo(
+    () =>
+      JSON.stringify({ timezone, days, overrides }) !==
+      JSON.stringify({
+        timezone: initial.timezone,
+        days: initial.days,
+        overrides: initial.overrides ?? [],
+      }),
+    [timezone, days, overrides, initial],
+  );
+  useEffect(() => {
+    if (!dirty) return;
+    const onBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = "";
+    };
+    window.addEventListener("beforeunload", onBeforeUnload);
+    return () => window.removeEventListener("beforeunload", onBeforeUnload);
+  }, [dirty]);
 
   function addOverride() {
     if (!newDate || overrides.some((o) => o.date === newDate)) return;
@@ -368,7 +391,9 @@ export function AvailabilityEditor({
         <Button onClick={save} disabled={saving}>
           {saving ? "Saving…" : "Save availability"}
         </Button>
-        {saved ? (
+        {dirty ? (
+          <span className="text-sm text-[var(--color-amber)]">Unsaved changes</span>
+        ) : saved ? (
           <span className="inline-flex items-center gap-1.5 text-sm text-[var(--color-success)]">
             <Check size={15} /> Saved
           </span>

--- a/apps/web/components/bookings-calendar.tsx
+++ b/apps/web/components/bookings-calendar.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { SkeletonRows } from "@/components/ui/skeleton";
+
 import { buttonVariants } from "@/components/ui/button";
 import { track } from "@/lib/analytics";
 import { eventColorVar } from "@/lib/booking/event-type-input";
@@ -161,7 +163,9 @@ export function BookingsCalendar({ tz }: { tz: string }) {
       </div>
 
       {loading ? (
-        <p className="py-16 text-center text-sm text-[var(--color-muted)]">Loading…</p>
+        <div className="py-6">
+          <SkeletonRows rows={5} />
+        </div>
       ) : view === "month" ? (
         <MonthGrid rangeStart={rangeStart} anchor={anchor} byDay={byDay} tz={tz} />
       ) : view === "week" ? (

--- a/apps/web/components/schedules-manager.tsx
+++ b/apps/web/components/schedules-manager.tsx
@@ -5,8 +5,9 @@ import { Button } from "@/components/ui/button";
 import { ConfirmDialog, Dialog } from "@/components/ui/dialog";
 import { FormError } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { SkeletonRows } from "@/components/ui/skeleton";
 import { cn } from "@/lib/cn";
-import { Loader2, Plus, Star, Trash2 } from "lucide-react";
+import { Plus, Star, Trash2 } from "lucide-react";
 import { useState } from "react";
 
 interface ScheduleSummary {
@@ -239,8 +240,8 @@ export function SchedulesManager({
           ) : null}
 
           {loading || !detail ? (
-            <div className="flex items-center gap-2 py-16 text-sm text-[var(--color-muted)]">
-              <Loader2 size={15} className="animate-spin" /> Loading…
+            <div className="py-6">
+              <SkeletonRows rows={5} />
             </div>
           ) : (
             <AvailabilityEditor key={selectedId} scheduleId={selectedId} initial={detail} />

--- a/apps/web/components/ui/skeleton.tsx
+++ b/apps/web/components/ui/skeleton.tsx
@@ -1,0 +1,31 @@
+import { cn } from "@/lib/cn";
+
+/** A pulsing placeholder for content that's still loading. */
+export function Skeleton({ className }: { className?: string }) {
+  return (
+    <div
+      aria-hidden
+      className={cn("animate-pulse rounded-md bg-[var(--color-surface-2)]", className)}
+    />
+  );
+}
+
+/** A few stacked rows — a ready-made skeleton for list/agenda loading states. */
+export function SkeletonRows({ rows = 4, className }: { rows?: number; className?: string }) {
+  return (
+    <div className={cn("space-y-2", className)} aria-hidden>
+      {Array.from({ length: rows }).map((_, i) => (
+        <div
+          key={i}
+          className="flex items-center gap-4 rounded-[var(--radius-lg)] border border-[var(--color-border)] px-4 py-3"
+        >
+          <Skeleton className="h-9 w-9 rounded-md" />
+          <div className="flex-1 space-y-1.5">
+            <Skeleton className="h-3.5 w-1/3" />
+            <Skeleton className="h-3 w-1/2" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/lib/ai/tools/exec.ts
+++ b/apps/web/lib/ai/tools/exec.ts
@@ -625,6 +625,30 @@ export async function executeActionTool(
         return { ok: true, message: "Deleted that automation rule." };
       }
 
+      case "update_workflow": {
+        const { organizationId } = await ensureUserWorkspace(userId);
+        const id = input.id as string;
+        const wf = await db.query.workflows.findFirst({
+          where: and(
+            eq(schema.workflows.id, id),
+            eq(schema.workflows.organizationId, organizationId),
+          ),
+          columns: { id: true, name: true },
+        });
+        if (!wf) return { ok: false, message: "I couldn't find that workflow." };
+        const set: Record<string, unknown> = {};
+        if (input.name !== undefined) set.name = input.name;
+        if (input.subjectTemplate !== undefined) set.subjectTemplate = input.subjectTemplate;
+        if (input.bodyTemplate !== undefined) set.bodyTemplate = input.bodyTemplate;
+        if (input.offsetMinutes !== undefined) set.offsetMinutes = input.offsetMinutes;
+        if (input.isActive !== undefined) set.isActive = input.isActive;
+        if (Object.keys(set).length === 0) {
+          return { ok: false, message: "Tell me what to change on that workflow." };
+        }
+        await db.update(schema.workflows).set(set).where(eq(schema.workflows.id, id));
+        return { ok: true, message: `Updated \u201c${wf.name}\u201d.` };
+      }
+
       case "delete_workflow": {
         const { organizationId } = await ensureUserWorkspace(userId);
         const res = await db

--- a/apps/web/lib/ai/tools/registry.ts
+++ b/apps/web/lib/ai/tools/registry.ts
@@ -307,6 +307,39 @@ export const TOOLS: AiToolDef[] = [
     summarize: (i) => `Create workflow \u201c${i.name}\u201d`,
   },
   {
+    name: "update_workflow",
+    description:
+      "Update an existing workflow by id — its name, message subject/body, offset, or active state. Only the fields you pass change.",
+    kind: "write",
+    confirmLevel: "confirm",
+    schema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        id: { type: "string", description: "Workflow id (from list_workflows)." },
+        name: { type: "string" },
+        subjectTemplate: { type: "string" },
+        bodyTemplate: { type: "string" },
+        offsetMinutes: { type: "integer", description: "0\u201343200." },
+        isActive: { type: "boolean" },
+      },
+      required: ["id"],
+    },
+    zod: z.object({
+      id: z.string().uuid(),
+      name: z.string().min(1).max(120).optional(),
+      subjectTemplate: z.string().max(300).optional(),
+      bodyTemplate: z.string().min(1).max(5000).optional(),
+      offsetMinutes: z.number().int().min(0).max(43_200).optional(),
+      isActive: z.boolean().optional(),
+    }),
+    title: "Update workflow",
+    summarize: (i) => {
+      const f = Object.keys(i).filter((k) => k !== "id");
+      return `Update ${f.length ? f.join(", ") : "this workflow"}`;
+    },
+  },
+  {
     name: "create_team",
     description: "Create a new team (the host becomes its owner). Give a team name.",
     kind: "write",

--- a/deploy/INTEGRATIONS.md
+++ b/deploy/INTEGRATIONS.md
@@ -1,0 +1,141 @@
+# Turning on integrations
+
+Every integration is **off until you add its keys** to `deploy/.env`, then apply.
+All URLs below assume your `APP_URL` is `https://dayotter.com` — swap in your own
+domain.
+
+## How to apply a change
+
+```bash
+cd ~/dayotter/deploy
+FILES="-f docker-compose.prod.yml -f docker-compose.nginx.yml --env-file .env"
+
+# server-only keys — just recreate the containers:
+docker compose $FILES up -d
+
+# any key starting with NEXT_PUBLIC_ is BAKED into the web build — rebuild:
+docker compose $FILES up -d --build web
+```
+
+> Rule of thumb: **`NEXT_PUBLIC_*` → rebuild `web`**; everything else → plain `up -d`.
+> (`NEXT_PUBLIC_*` values are inlined at build time; the Dockerfile receives them
+> as build args, so a rebuild is required for them to take effect.)
+
+---
+
+## Google — Sign-in **and** Calendar (one OAuth client covers both)
+
+[Google Cloud Console](https://console.cloud.google.com) → create/select a project.
+
+1. **APIs & Services → Library →** enable **Google Calendar API**.
+2. **OAuth consent screen** → External; app name + support email; add the calendar
+   and email/profile scopes; add yourself as a Test user (or Publish).
+3. **Credentials → Create credentials → OAuth client ID → Web application.** Add
+   **both** authorized redirect URIs:
+   - `https://dayotter.com/api/auth/callback/google` — sign-in
+   - `https://dayotter.com/api/calendars/connect/google/callback` — calendar connect
+
+```ini
+GOOGLE_CLIENT_ID=<client id>
+GOOGLE_CLIENT_SECRET=<client secret>
+NEXT_PUBLIC_GOOGLE_AUTH=1      # shows the "Continue with Google" button
+```
+Apply: **`up -d --build web`** (because of `NEXT_PUBLIC_GOOGLE_AUTH`).
+
+## Email / SMTP (confirmations, reminders, password resets)
+
+Any SMTP provider works; **verify your sending domain first**. Using Resend:
+
+```ini
+SMTP_URL=smtps://resend:re_YOUR_API_KEY@smtp.resend.com:465
+EMAIL_FROM="DayOtter <no-reply@dayotter.com>"
+```
+Username is `resend`, password is your Resend API key. Port 465 = implicit TLS
+(use `smtp://…:587` for STARTTLS). Apply: `up -d`.
+
+## AI assistant (Anthropic)
+
+[console.anthropic.com](https://console.anthropic.com) → API Keys.
+```ini
+ANTHROPIC_API_KEY=sk-ant-...
+```
+Apply: `up -d`.
+
+## Microsoft / Outlook Calendar
+
+[Azure Portal](https://portal.azure.com) → **App registrations → New registration**.
+Redirect URI (Web): `https://dayotter.com/api/calendars/connect/microsoft/callback`.
+Delegated API permissions: `offline_access, openid, email, profile, User.Read,
+Calendars.ReadWrite`. Create a client secret.
+```ini
+MICROSOFT_CLIENT_ID=<application (client) id>
+MICROSOFT_CLIENT_SECRET=<client secret value>
+```
+Apply: `up -d`.
+
+## Zoom (auto meeting links)
+
+[Zoom Marketplace](https://marketplace.zoom.us) → **Build App → OAuth**. Redirect
+URL: `https://dayotter.com/api/integrations/zoom/callback`; scope `meeting:write`.
+```ini
+ZOOM_CLIENT_ID=<client id>
+ZOOM_CLIENT_SECRET=<client secret>
+```
+Apply: `up -d`.
+
+## SMS / WhatsApp + phone sign-in (Twilio)
+
+[Twilio Console](https://console.twilio.com) → Account SID + Auth Token; buy/verify
+a sending number.
+```ini
+TWILIO_ACCOUNT_SID=AC...
+TWILIO_AUTH_TOKEN=...
+TWILIO_SMS_FROM=+1XXXXXXXXXX
+TWILIO_WHATSAPP_FROM=whatsapp:+14155238886   # optional
+NEXT_PUBLIC_PHONE_AUTH=1     # shows the "Continue with phone" (OTP) button
+```
+Apply: **`up -d --build web`** (because of `NEXT_PUBLIC_PHONE_AUTH`).
+
+## Browser push reminders (Web Push / VAPID)
+
+Generate a keypair once: `npx web-push generate-vapid-keys`.
+```ini
+VAPID_PUBLIC_KEY=<public>
+VAPID_PRIVATE_KEY=<private>
+VAPID_SUBJECT=mailto:you@dayotter.com
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=<public>   # same value as VAPID_PUBLIC_KEY
+```
+Apply: **`up -d --build web`**.
+
+## Payments (Stripe)
+
+[Stripe Dashboard](https://dashboard.stripe.com/apikeys). Add a webhook endpoint at
+`https://dayotter.com/api/webhooks/stripe` and copy its signing secret.
+```ini
+STRIPE_SECRET_KEY=sk_live_...
+STRIPE_WEBHOOK_SECRET=whsec_...
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_...
+```
+Apply: **`up -d --build web`**.
+
+## Captcha on the booking form (Cloudflare Turnstile)
+
+[Cloudflare → Turnstile](https://dash.cloudflare.com/?to=/:account/turnstile) → add
+site `dayotter.com`.
+```ini
+TURNSTILE_SECRET=<secret key>
+NEXT_PUBLIC_TURNSTILE_SITE_KEY=<site key>
+```
+Apply: **`up -d --build web`**.
+
+---
+
+## Quick verify
+
+- **Google:** the "Continue with Google" button appears on `/sign-in`; connecting a
+  calendar under Settings → Calendars completes without an OAuth error.
+- **Email:** trigger a password reset and confirm it arrives (check the provider's
+  dashboard).
+- Logs: `docker compose -f docker-compose.prod.yml -f docker-compose.nginx.yml logs -f web worker`.
+
+The redirect URIs must match `APP_URL` **exactly** (https, no trailing slash).


### PR DESCRIPTION
Closes the remaining **code-actionable** items from the build audit.

- **`deploy/INTEGRATIONS.md`** — a per-integration setup guide (Google sign-in + calendar, Resend email, Anthropic, Microsoft, Zoom, Twilio, VAPID web push, Stripe, Turnstile) with the exact `dayotter.com` redirect/webhook URLs and the "NEXT_PUBLIC_* → rebuild" rule.
- **iOS App Store blockers** — already handled in code (pro-lock hides "Upgrade on the web" on iOS; Google sign-in is hidden on iOS, so Sign in with Apple isn't required). Updated the stale "two things to resolve" section in the store README to say so.
- **Shared loading skeleton** — new `Skeleton` / `SkeletonRows`; replaced the ad-hoc "Loading…" text in the bookings calendar and schedules manager for a consistent treatment.
- **AI registry** — `update_workflow` (workflows now have full create / update / delete).
- **Availability editor** — a derived dirty flag + `beforeunload` guard + an "Unsaved changes" hint, so hour edits aren't lost on navigation (without changing the explicit-save model).

Typecheck + biome clean.

### What's *not* in here (not code todos)
- **User-side:** filling integration keys, capturing store screenshots, running `eas build`/`submit`, the Apple Developer account.
- **Blocked on approval:** flipping the marketing "Coming soon" store badge to a live Play link.
- **Not feasible as AI tools:** calendar/Zoom OAuth connect (interactive), billing (payment), team-member role/remove (no backend route). The event-type overflow is handled by the earlier wrap fix; Insights tabs already prefetch, so no route-merge.
