### PR TITLE
DayOtter: routing forms, recurring meetings, RR weights, group polls, overflow, focus auto-scheduling + fixes

### DIFF
--- a/apps/web/app/(app)/dashboard/page.tsx
+++ b/apps/web/app/(app)/dashboard/page.tsx
@@ -1,4 +1,3 @@
-import { AiAssistant } from "@/components/ai-assistant";
 import { CopyLinkButton } from "@/components/copy-link-button";
 import { DashboardTour } from "@/components/dashboard-tour";
 import { MeetingAssistant } from "@/components/meeting-assistant";
@@ -214,8 +213,6 @@ export default async function DashboardPage() {
           </div>
         </Card>
       ) : null}
-
-      {aiEnabled ? <AiAssistant /> : null}
 
       <div className="mb-6 grid grid-cols-2 gap-3 sm:grid-cols-4">
         {QUICK_ACTIONS.map(({ href, label, icon: Icon }) => (

--- a/apps/web/app/(app)/layout.tsx
+++ b/apps/web/app/(app)/layout.tsx
@@ -1,6 +1,8 @@
 import { AppNav } from "@/components/app-nav";
 import { MobileNav } from "@/components/mobile-nav";
+import { OtterLauncher } from "@/components/otter-launcher";
 import { ToastProvider } from "@/components/ui/toast";
+import { aiEnabled } from "@/lib/ai/llm";
 import { getSession } from "@/lib/auth/session";
 import { redirect } from "next/navigation";
 import type { ReactNode } from "react";
@@ -31,6 +33,7 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
           </div>
         </main>
       </div>
+      {aiEnabled ? <OtterLauncher /> : null}
     </ToastProvider>
   );
 }

--- a/apps/web/app/(app)/layout.tsx
+++ b/apps/web/app/(app)/layout.tsx
@@ -13,18 +13,19 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
 
   return (
     <ToastProvider>
-      <div className="grain relative flex min-h-screen">
+      <div className="grain relative flex h-[100dvh] overflow-hidden">
         <AppNav user={{ name: session.user.name, email: session.user.email }} />
         <MobileNav />
         <main className="relative flex-1 overflow-y-auto">
-          {/* Subtle ambient wash so the app inherits the marketing atmosphere
-            instead of dying at flat ivory — far fainter than the hero (6% vs 22%). */}
+          {/* Ambient wash so the app inherits the marketing atmosphere instead of
+            dying at flat ivory. Two offset accent glows read fuller than a single
+            faint radial without shouting like the hero. */}
           <div
             aria-hidden
-            className="pointer-events-none absolute inset-x-0 top-0 h-72"
+            className="pointer-events-none absolute inset-x-0 top-0 h-[34rem]"
             style={{
               background:
-                "radial-gradient(60% 100% at 50% 0%, color-mix(in srgb, var(--color-accent) 6%, transparent), transparent 72%)",
+                "radial-gradient(80% 70% at 18% -8%, color-mix(in srgb, var(--color-accent) 14%, transparent), transparent 56%), radial-gradient(72% 62% at 96% 0%, color-mix(in srgb, var(--color-accent) 9%, transparent), transparent 58%)",
             }}
           />
           {/* Top/bottom padding on mobile clears the fixed top bar + bottom tab bar. */}

--- a/apps/web/app/(app)/settings/billing/page.tsx
+++ b/apps/web/app/(app)/settings/billing/page.tsx
@@ -37,7 +37,7 @@ export default async function BillingPage() {
     return (
       <div>
         <PageHeader title="Billing" description="Your DayOtter edition and plan." />
-        <Card className="max-w-xl">
+        <Card className="max-w-2xl">
           <CardBody className="space-y-4 p-6">
             <div className="flex items-center gap-2 font-medium">
               <Heart size={16} className="text-[var(--color-accent)]" /> Self-hosted — everything
@@ -63,7 +63,7 @@ export default async function BillingPage() {
   return (
     <div>
       <PageHeader title="Billing" description="Manage your DayOtter plan." />
-      <Card className="max-w-xl">
+      <Card className="max-w-2xl">
         <CardBody className="space-y-5 p-6">
           <div className="flex items-baseline justify-between">
             <div>

--- a/apps/web/app/(app)/settings/layout.tsx
+++ b/apps/web/app/(app)/settings/layout.tsx
@@ -10,8 +10,10 @@ export default function SettingsLayout({ children }: { children: ReactNode }) {
         title="Settings"
         description="Manage your account, preferences, and calendars."
       />
-      <SettingsNav />
-      {children}
+      <div className="lg:grid lg:grid-cols-[196px_minmax(0,1fr)] lg:gap-10">
+        <SettingsNav />
+        <div className="min-w-0">{children}</div>
+      </div>
     </>
   );
 }

--- a/apps/web/app/api/calendars/connect/[provider]/callback/route.ts
+++ b/apps/web/app/api/calendars/connect/[provider]/callback/route.ts
@@ -1,6 +1,7 @@
 import { connectCalendarAccount } from "@/lib/calendar/calendar-connect";
 import { verifyState } from "@/lib/calendar/oauth-state";
 import { providerConfig } from "@/lib/calendar/providers";
+import { env } from "@/lib/server/env";
 import { GoogleCalendarAdapter, MicrosoftCalendarAdapter } from "@dayotter/calendar";
 import { NextResponse } from "next/server";
 
@@ -16,7 +17,10 @@ export async function GET(request: Request, { params }: { params: Promise<{ prov
   const url = new URL(request.url);
   const code = url.searchParams.get("code");
   const state = url.searchParams.get("state");
-  const settings = new URL("/settings/calendars", request.url);
+  // Build the redirect target from the configured public origin, NOT request.url
+  // — behind a reverse proxy the request host is the internal container name
+  // (e.g. c5b9330a…:3000), which would send the user to an unreachable URL.
+  const settings = new URL("/settings/calendars", env.APP_URL);
 
   if (url.searchParams.get("error")) {
     // Reflect only the provider's short error *code*, never arbitrary text.

--- a/apps/web/components/ai-assistant.tsx
+++ b/apps/web/components/ai-assistant.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { Card, CardBody } from "@/components/ui/card";
 import { FormError } from "@/components/ui/form";
 import { Input, Label } from "@/components/ui/input";
 import type { ChatAction, ChatToolAction } from "@/lib/ai/chat";
 import { track } from "@/lib/analytics";
 import { useSpeechInput } from "@/lib/use-speech";
-import { Mic, Send, Sparkles, Volume2, VolumeX } from "lucide-react";
+import { Mic, Send, Sparkles, Volume2, VolumeX, X } from "lucide-react";
 import { DateTime } from "luxon";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -54,7 +53,11 @@ function speak(text: string) {
  * renders a confirm-first action card whenever it proposes a calendar change.
  * The assistant only proposes; the human always confirms before anything runs.
  */
-export function AiAssistant() {
+export function AiAssistant({
+  variant = "card",
+  onClose,
+}: { variant?: "card" | "panel"; onClose?: () => void } = {}) {
+  const panel = variant === "panel";
   const router = useRouter();
   const [messages, setMessages] = useState<Msg[]>([]);
   const [input, setInput] = useState("");
@@ -309,267 +312,279 @@ export function AiAssistant() {
   const intent = action?.draft.intent;
 
   return (
-    <Card className="mb-6">
-      <CardBody className="p-0">
-        {/* Header */}
-        <div className="flex items-center gap-2 border-b border-[var(--color-border)] px-5 py-3.5">
-          <span className="flex h-7 w-7 items-center justify-center rounded-full bg-[var(--color-accent-soft)] text-[var(--color-accent)]">
-            <Sparkles size={15} />
-          </span>
-          <div className="min-w-0 flex-1">
-            <p className="text-sm font-semibold leading-none">Ask Otter</p>
-            <p className="mt-1 text-xs text-[var(--color-faint)]">
-              Your scheduling assistant — you confirm before anything changes
-            </p>
-          </div>
+    <div
+      className={
+        panel
+          ? "flex h-full min-h-0 flex-col"
+          : "mb-6 overflow-hidden rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-card)]"
+      }
+    >
+      {/* Header */}
+      <div className="flex items-center gap-2 border-b border-[var(--color-border)] px-5 py-3.5">
+        <span className="flex h-7 w-7 items-center justify-center rounded-full bg-[var(--color-accent-soft)] text-[var(--color-accent)]">
+          <Sparkles size={15} />
+        </span>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-semibold leading-none">Ask Otter</p>
+          <p className="mt-1 text-xs text-[var(--color-faint)]">
+            Your scheduling assistant — you confirm before anything changes
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={toggleSpeak}
+          aria-pressed={speakReplies}
+          title={speakReplies ? "Spoken replies on" : "Spoken replies off"}
+          className={
+            speakReplies
+              ? "rounded-md p-1.5 text-[var(--color-accent)]"
+              : "rounded-md p-1.5 text-[var(--color-faint)] hover:text-[var(--color-text)]"
+          }
+        >
+          {speakReplies ? <Volume2 size={16} /> : <VolumeX size={16} />}
+        </button>
+        {onClose ? (
           <button
             type="button"
-            onClick={toggleSpeak}
-            aria-pressed={speakReplies}
-            title={speakReplies ? "Spoken replies on" : "Spoken replies off"}
-            className={
-              speakReplies
-                ? "rounded-md p-1.5 text-[var(--color-accent)]"
-                : "rounded-md p-1.5 text-[var(--color-faint)] hover:text-[var(--color-text)]"
-            }
+            onClick={onClose}
+            aria-label="Close"
+            className="rounded-md p-1.5 text-[var(--color-faint)] hover:text-[var(--color-text)]"
           >
-            {speakReplies ? <Volume2 size={16} /> : <VolumeX size={16} />}
+            <X size={16} />
           </button>
-        </div>
+        ) : null}
+      </div>
 
-        {/* Thread */}
-        <div ref={scrollRef} className="max-h-[380px] min-h-[132px] overflow-y-auto px-5 py-4">
-          {messages.length === 0 ? (
-            <div>
-              <p className="text-sm text-[var(--color-muted)]">
-                Hi! Ask about your schedule, or tell me to book, move, or cancel something.
-              </p>
-              <div className="mt-3 flex flex-wrap gap-2">
-                {SUGGESTIONS.map((s) => (
-                  <button
-                    key={s}
-                    type="button"
-                    onClick={() => void send(s)}
-                    className="rounded-full border border-[var(--color-border-strong)] px-3 py-1.5 text-xs text-[var(--color-muted)] transition-colors hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]"
-                  >
-                    {s}
-                  </button>
-                ))}
-              </div>
-            </div>
-          ) : (
-            <div className="space-y-3">
-              {messages.map((m, i) => (
-                <div
-                  key={i}
-                  className={m.role === "user" ? "flex justify-end" : "flex justify-start"}
+      {/* Thread */}
+      <div
+        ref={scrollRef}
+        className={`overflow-y-auto px-5 py-4 ${panel ? "min-h-0 flex-1" : "max-h-[380px] min-h-[132px]"}`}
+      >
+        {messages.length === 0 ? (
+          <div>
+            <p className="text-sm text-[var(--color-muted)]">
+              Hi! Ask about your schedule, or tell me to book, move, or cancel something.
+            </p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {SUGGESTIONS.map((s) => (
+                <button
+                  key={s}
+                  type="button"
+                  onClick={() => void send(s)}
+                  className="rounded-full border border-[var(--color-border-strong)] px-3 py-1.5 text-xs text-[var(--color-muted)] transition-colors hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]"
                 >
-                  <div
-                    className={
-                      m.role === "user"
-                        ? "max-w-[85%] rounded-2xl rounded-br-sm bg-[var(--color-accent)] px-3.5 py-2 text-sm text-white"
-                        : "max-w-[85%] rounded-2xl rounded-bl-sm bg-[var(--color-surface-2)] px-3.5 py-2 text-sm text-[var(--color-text)]"
-                    }
-                  >
-                    {m.content || (
-                      <span className="inline-flex gap-1">
-                        <Dot /> <Dot /> <Dot />
-                      </span>
-                    )}
-                  </div>
-                </div>
+                  {s}
+                </button>
               ))}
             </div>
-          )}
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {messages.map((m, i) => (
+              <div
+                key={i}
+                className={m.role === "user" ? "flex justify-end" : "flex justify-start"}
+              >
+                <div
+                  className={
+                    m.role === "user"
+                      ? "max-w-[85%] rounded-2xl rounded-br-sm bg-[var(--color-accent)] px-3.5 py-2 text-sm text-white"
+                      : "max-w-[85%] rounded-2xl rounded-bl-sm bg-[var(--color-surface-2)] px-3.5 py-2 text-sm text-[var(--color-text)]"
+                  }
+                >
+                  {m.content || (
+                    <span className="inline-flex gap-1">
+                      <Dot /> <Dot /> <Dot />
+                    </span>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
 
-          {/* Confirm-first action card */}
-          {action && intent === "create" ? (
-            <div className="mt-3 space-y-3 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] p-4 shadow-[var(--shadow-card)]">
-              <span className="inline-block rounded-full bg-[var(--color-accent-soft)] px-2 py-0.5 text-xs font-medium text-[var(--color-accent)]">
-                {KIND_LABEL[action.draft.kind] ?? "Meeting"}
-                {action.matchedEventType ? ` · ${action.matchedEventType.title}` : ""}
-              </span>
+        {/* Confirm-first action card */}
+        {action && intent === "create" ? (
+          <div className="mt-3 space-y-3 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] p-4 shadow-[var(--shadow-card)]">
+            <span className="inline-block rounded-full bg-[var(--color-accent-soft)] px-2 py-0.5 text-xs font-medium text-[var(--color-accent)]">
+              {KIND_LABEL[action.draft.kind] ?? "Meeting"}
+              {action.matchedEventType ? ` · ${action.matchedEventType.title}` : ""}
+            </span>
+            <div>
+              <Label htmlFor="otter-title">Title</Label>
+              <Input id="otter-title" value={title} onChange={(e) => setTitle(e.target.value)} />
+            </div>
+            <div className="grid grid-cols-2 gap-3">
               <div>
-                <Label htmlFor="otter-title">Title</Label>
-                <Input id="otter-title" value={title} onChange={(e) => setTitle(e.target.value)} />
+                <Label htmlFor="otter-start">Starts</Label>
+                <Input
+                  id="otter-start"
+                  type="datetime-local"
+                  value={startLocal}
+                  onChange={(e) => setStartLocal(e.target.value)}
+                />
               </div>
-              <div className="grid grid-cols-2 gap-3">
-                <div>
-                  <Label htmlFor="otter-start">Starts</Label>
-                  <Input
-                    id="otter-start"
-                    type="datetime-local"
-                    value={startLocal}
-                    onChange={(e) => setStartLocal(e.target.value)}
-                  />
-                </div>
-                <div>
-                  <Label htmlFor="otter-dur">Duration (min)</Label>
-                  <Input
-                    id="otter-dur"
-                    type="number"
-                    min={5}
-                    max={1440}
-                    value={duration}
-                    onChange={(e) => setDuration(Number(e.target.value) || 30)}
-                  />
-                </div>
-              </div>
-              {action.draft.attendees.length > 0 ? (
-                <p className="text-xs text-[var(--color-muted)]">
-                  With: {action.draft.attendees.map((a) => a.name || a.email).join(", ")}
-                </p>
-              ) : null}
-              <div className="flex gap-2">
-                <Button size="sm" onClick={confirmCreate} disabled={busy}>
-                  {busy ? "Adding…" : "Add to calendar"}
-                </Button>
-                <Button size="sm" variant="ghost" onClick={() => setAction(null)} disabled={busy}>
-                  Discard
-                </Button>
+              <div>
+                <Label htmlFor="otter-dur">Duration (min)</Label>
+                <Input
+                  id="otter-dur"
+                  type="number"
+                  min={5}
+                  max={1440}
+                  value={duration}
+                  onChange={(e) => setDuration(Number(e.target.value) || 30)}
+                />
               </div>
             </div>
-          ) : null}
-
-          {action && intent === "reschedule" && action.target ? (
-            <div className="mt-3 space-y-3 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] p-4 shadow-[var(--shadow-card)]">
-              <span className="inline-block rounded-full bg-[var(--color-accent-soft)] px-2 py-0.5 text-xs font-medium text-[var(--color-accent)]">
-                Reschedule
-              </span>
-              <p className="text-sm">
-                Move <strong>{action.target.title}</strong> from{" "}
-                <span className="text-[var(--color-muted)]">{fmtWhen(action.target.startISO)}</span>{" "}
-                to:
+            {action.draft.attendees.length > 0 ? (
+              <p className="text-xs text-[var(--color-muted)]">
+                With: {action.draft.attendees.map((a) => a.name || a.email).join(", ")}
               </p>
-              <Input
-                type="datetime-local"
-                value={newStartLocal}
-                onChange={(e) => setNewStartLocal(e.target.value)}
-              />
-              <div className="flex gap-2">
-                <Button size="sm" onClick={confirmReschedule} disabled={busy}>
-                  {busy ? "Rescheduling…" : "Reschedule"}
-                </Button>
-                <Button size="sm" variant="ghost" onClick={() => setAction(null)} disabled={busy}>
-                  Discard
-                </Button>
-              </div>
+            ) : null}
+            <div className="flex gap-2">
+              <Button size="sm" onClick={confirmCreate} disabled={busy}>
+                {busy ? "Adding…" : "Add to calendar"}
+              </Button>
+              <Button size="sm" variant="ghost" onClick={() => setAction(null)} disabled={busy}>
+                Discard
+              </Button>
             </div>
-          ) : null}
+          </div>
+        ) : null}
 
-          {action && intent === "cancel" && action.target ? (
-            <div className="mt-3 space-y-3 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] p-4 shadow-[var(--shadow-card)]">
-              <span className="inline-block rounded-full bg-[color-mix(in_srgb,var(--color-danger)_15%,transparent)] px-2 py-0.5 text-xs font-medium text-[var(--color-danger)]">
-                Cancel
-              </span>
-              <p className="text-sm">
-                Cancel <strong>{action.target.title}</strong> on{" "}
-                <span className="text-[var(--color-muted)]">{fmtWhen(action.target.startISO)}</span>
-                ? This notifies attendees.
-              </p>
-              <div className="flex gap-2">
-                <Button size="sm" variant="danger" onClick={confirmCancel} disabled={busy}>
-                  {busy ? "Cancelling…" : "Cancel meeting"}
-                </Button>
-                <Button size="sm" variant="ghost" onClick={() => setAction(null)} disabled={busy}>
-                  Keep it
-                </Button>
-              </div>
+        {action && intent === "reschedule" && action.target ? (
+          <div className="mt-3 space-y-3 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] p-4 shadow-[var(--shadow-card)]">
+            <span className="inline-block rounded-full bg-[var(--color-accent-soft)] px-2 py-0.5 text-xs font-medium text-[var(--color-accent)]">
+              Reschedule
+            </span>
+            <p className="text-sm">
+              Move <strong>{action.target.title}</strong> from{" "}
+              <span className="text-[var(--color-muted)]">{fmtWhen(action.target.startISO)}</span>{" "}
+              to:
+            </p>
+            <Input
+              type="datetime-local"
+              value={newStartLocal}
+              onChange={(e) => setNewStartLocal(e.target.value)}
+            />
+            <div className="flex gap-2">
+              <Button size="sm" onClick={confirmReschedule} disabled={busy}>
+                {busy ? "Rescheduling…" : "Reschedule"}
+              </Button>
+              <Button size="sm" variant="ghost" onClick={() => setAction(null)} disabled={busy}>
+                Discard
+              </Button>
             </div>
-          ) : null}
+          </div>
+        ) : null}
 
-          {/* Generic confirm-first action (booking types, availability, prefs, focus). */}
-          {toolAction ? (
-            <div
-              className={`mt-3 space-y-3 rounded-lg border p-4 shadow-[var(--shadow-card)] ${
+        {action && intent === "cancel" && action.target ? (
+          <div className="mt-3 space-y-3 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] p-4 shadow-[var(--shadow-card)]">
+            <span className="inline-block rounded-full bg-[color-mix(in_srgb,var(--color-danger)_15%,transparent)] px-2 py-0.5 text-xs font-medium text-[var(--color-danger)]">
+              Cancel
+            </span>
+            <p className="text-sm">
+              Cancel <strong>{action.target.title}</strong> on{" "}
+              <span className="text-[var(--color-muted)]">{fmtWhen(action.target.startISO)}</span>?
+              This notifies attendees.
+            </p>
+            <div className="flex gap-2">
+              <Button size="sm" variant="danger" onClick={confirmCancel} disabled={busy}>
+                {busy ? "Cancelling…" : "Cancel meeting"}
+              </Button>
+              <Button size="sm" variant="ghost" onClick={() => setAction(null)} disabled={busy}>
+                Keep it
+              </Button>
+            </div>
+          </div>
+        ) : null}
+
+        {/* Generic confirm-first action (booking types, availability, prefs, focus). */}
+        {toolAction ? (
+          <div
+            className={`mt-3 space-y-3 rounded-lg border p-4 shadow-[var(--shadow-card)] ${
+              toolAction.confirmLevel === "danger"
+                ? "border-[color-mix(in_srgb,var(--color-danger)_40%,transparent)] bg-[color-mix(in_srgb,var(--color-danger)_5%,transparent)]"
+                : "border-[var(--color-border)] bg-[var(--color-surface)]"
+            }`}
+          >
+            <span
+              className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${
                 toolAction.confirmLevel === "danger"
-                  ? "border-[color-mix(in_srgb,var(--color-danger)_40%,transparent)] bg-[color-mix(in_srgb,var(--color-danger)_5%,transparent)]"
-                  : "border-[var(--color-border)] bg-[var(--color-surface)]"
+                  ? "bg-[color-mix(in_srgb,var(--color-danger)_15%,transparent)] text-[var(--color-danger)]"
+                  : "bg-[var(--color-accent-soft)] text-[var(--color-accent)]"
               }`}
             >
-              <span
-                className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${
-                  toolAction.confirmLevel === "danger"
-                    ? "bg-[color-mix(in_srgb,var(--color-danger)_15%,transparent)] text-[var(--color-danger)]"
-                    : "bg-[var(--color-accent-soft)] text-[var(--color-accent)]"
-                }`}
+              {toolAction.title}
+            </span>
+            <p className="text-sm">{toolAction.summary}.</p>
+            <div className="flex gap-2">
+              <Button
+                size="sm"
+                variant={toolAction.confirmLevel === "danger" ? "danger" : "primary"}
+                onClick={confirmToolAction}
+                disabled={busy}
               >
-                {toolAction.title}
-              </span>
-              <p className="text-sm">{toolAction.summary}.</p>
-              <div className="flex gap-2">
-                <Button
-                  size="sm"
-                  variant={toolAction.confirmLevel === "danger" ? "danger" : "primary"}
-                  onClick={confirmToolAction}
-                  disabled={busy}
-                >
-                  {busy
-                    ? "Working…"
-                    : toolAction.confirmLevel === "danger"
-                      ? "Confirm delete"
-                      : "Confirm"}
-                </Button>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  onClick={() => setToolAction(null)}
-                  disabled={busy}
-                >
-                  Discard
-                </Button>
-              </div>
+                {busy
+                  ? "Working…"
+                  : toolAction.confirmLevel === "danger"
+                    ? "Confirm delete"
+                    : "Confirm"}
+              </Button>
+              <Button size="sm" variant="ghost" onClick={() => setToolAction(null)} disabled={busy}>
+                Discard
+              </Button>
             </div>
-          ) : null}
-        </div>
+          </div>
+        ) : null}
+      </div>
 
-        {/* Composer */}
-        <div className="border-t border-[var(--color-border)] px-3 py-3">
-          {error ? (
-            <div className="mb-2">
-              <FormError>{error}</FormError>
-            </div>
-          ) : null}
-          <form
-            onSubmit={(e) => {
-              e.preventDefault();
-              void send(input);
-            }}
-            className="flex items-center gap-2"
-          >
-            <Input
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              placeholder={speech.listening ? "Listening…" : "Message Otter…"}
-              disabled={streaming}
-            />
-            {speech.supported ? (
-              <button
-                type="button"
-                onClick={speech.toggle}
-                aria-label={speech.listening ? "Stop listening" : "Speak"}
-                aria-pressed={speech.listening}
-                className={
-                  speech.listening
-                    ? "flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-[var(--color-danger)] bg-[color-mix(in_srgb,var(--color-danger)_10%,transparent)] text-[var(--color-danger)]"
-                    : "flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-[var(--color-border-strong)] text-[var(--color-muted)] hover:text-[var(--color-text)]"
-                }
-              >
-                <Mic size={16} className={speech.listening ? "animate-pulse" : undefined} />
-              </button>
-            ) : null}
-            <Button
-              type="submit"
-              disabled={streaming || !input.trim()}
-              aria-label="Send"
-              className="h-10 w-10 shrink-0 px-0"
+      {/* Composer */}
+      <div className="border-t border-[var(--color-border)] px-3 py-3">
+        {error ? (
+          <div className="mb-2">
+            <FormError>{error}</FormError>
+          </div>
+        ) : null}
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            void send(input);
+          }}
+          className="flex items-center gap-2"
+        >
+          <Input
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder={speech.listening ? "Listening…" : "Message Otter…"}
+            disabled={streaming}
+          />
+          {speech.supported ? (
+            <button
+              type="button"
+              onClick={speech.toggle}
+              aria-label={speech.listening ? "Stop listening" : "Speak"}
+              aria-pressed={speech.listening}
+              className={
+                speech.listening
+                  ? "flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-[var(--color-danger)] bg-[color-mix(in_srgb,var(--color-danger)_10%,transparent)] text-[var(--color-danger)]"
+                  : "flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-[var(--color-border-strong)] text-[var(--color-muted)] hover:text-[var(--color-text)]"
+              }
             >
-              <Send size={16} />
-            </Button>
-          </form>
-        </div>
-      </CardBody>
-    </Card>
+              <Mic size={16} className={speech.listening ? "animate-pulse" : undefined} />
+            </button>
+          ) : null}
+          <Button
+            type="submit"
+            disabled={streaming || !input.trim()}
+            aria-label="Send"
+            className="h-10 w-10 shrink-0 px-0"
+          >
+            <Send size={16} />
+          </Button>
+        </form>
+      </div>
+    </div>
   );
 }
 

--- a/apps/web/components/app-nav.tsx
+++ b/apps/web/components/app-nav.tsx
@@ -26,7 +26,7 @@ export function AppNav({ user }: { user: { name?: string | null; email: string }
   const router = useRouter();
 
   return (
-    <aside className="hidden w-64 shrink-0 flex-col border-r border-[var(--color-border)] bg-[var(--color-surface)] p-3 lg:flex">
+    <aside className="hidden h-full w-64 shrink-0 flex-col overflow-y-auto border-r border-[var(--color-border)] bg-[var(--color-surface)] p-3 lg:flex">
       <Link href="/dashboard" className="flex items-center gap-2 px-2 py-3">
         <BrandMark size={34} />
         <span className="font-display text-[17px] tracking-[-0.01em]">DayOtter</span>

--- a/apps/web/components/automations-form.tsx
+++ b/apps/web/components/automations-form.tsx
@@ -108,7 +108,7 @@ export function AutomationsForm() {
   }
 
   return (
-    <Card className="max-w-xl">
+    <Card className="max-w-2xl">
       <CardHeader
         title="Automations"
         description="Rules that protect your time automatically — reserve prep before interviews, or block every Friday afternoon for deep work."

--- a/apps/web/components/availability-editor.tsx
+++ b/apps/web/components/availability-editor.tsx
@@ -2,6 +2,7 @@
 import { FormError } from "@/components/ui/form";
 
 import { Button } from "@/components/ui/button";
+import { Select } from "@/components/ui/select";
 import { cn } from "@/lib/cn";
 import { Check, Copy, Plus, X } from "lucide-react";
 import { useMemo, useState } from "react";
@@ -158,21 +159,20 @@ export function AvailabilityEditor({
         <label htmlFor="timezone" className="mb-1.5 block text-sm font-medium">
           Timezone
         </label>
-        <select
+        <Select
           id="timezone"
           value={timezone}
           onChange={(e) => {
             setTimezone(e.target.value);
             setSaved(false);
           }}
-          className="h-10 w-full rounded-md border border-[var(--color-border-strong)] bg-[var(--color-bg)] px-3 text-sm text-[var(--color-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
         >
           {zones.map((z) => (
             <option key={z} value={z}>
               {z}
             </option>
           ))}
-        </select>
+        </Select>
       </div>
 
       <div className="mb-3 flex flex-wrap items-center gap-2">

--- a/apps/web/components/change-password-form.tsx
+++ b/apps/web/components/change-password-form.tsx
@@ -42,7 +42,7 @@ export function ChangePasswordForm() {
   }
 
   return (
-    <Card className="mt-6 max-w-xl">
+    <Card className="mt-6 max-w-2xl">
       <CardHeader title="Password" description="Change the password you use to sign in." />
       <CardBody className="p-6 pt-0">
         <form onSubmit={onSubmit} className="space-y-4">

--- a/apps/web/components/event-type-form.tsx
+++ b/apps/web/components/event-type-form.tsx
@@ -42,9 +42,6 @@ const NOTICE_OPTIONS = [
   { value: 1440, label: "1 day" },
   { value: 2880, label: "2 days" },
 ];
-const selectClass =
-  "w-full rounded-md border border-[var(--color-border-strong)] bg-[var(--color-bg)] px-3 py-2 text-sm text-[var(--color-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]";
-
 export interface EventTypeInitial {
   id?: string;
   title: string;
@@ -372,18 +369,17 @@ export function EventTypeForm({
 
           <div>
             <Label htmlFor="location">Location</Label>
-            <select
+            <Select
               id="location"
               value={location}
               onChange={(e) => setLocation(e.target.value as LocationTypeValue)}
-              className={selectClass}
             >
               {LOCATION_TYPES.map((loc) => (
                 <option key={loc} value={loc}>
                   {LOCATION_LABELS[loc]}
                 </option>
               ))}
-            </select>
+            </Select>
             {needsDetail ? (
               <Input
                 className="mt-2"
@@ -457,18 +453,17 @@ export function EventTypeForm({
                   </div>
                   <div>
                     <Label htmlFor="min-notice">Minimum notice</Label>
-                    <select
+                    <Select
                       id="min-notice"
                       value={minimumNotice}
                       onChange={(e) => setMinimumNotice(Number(e.target.value))}
-                      className={selectClass}
                     >
                       {NOTICE_OPTIONS.map((o) => (
                         <option key={o.value} value={o.value}>
                           {o.label}
                         </option>
                       ))}
-                    </select>
+                    </Select>
                   </div>
                   <div>
                     <Label htmlFor="booking-window">Bookable up to</Label>
@@ -486,11 +481,10 @@ export function EventTypeForm({
                   </div>
                   <div>
                     <Label htmlFor="slot-interval">Show slots every</Label>
-                    <select
+                    <Select
                       id="slot-interval"
                       value={slotInterval ?? 0}
                       onChange={(e) => setSlotInterval(Number(e.target.value) || null)}
-                      className={selectClass}
                     >
                       <option value={0}>Every {duration} min (default)</option>
                       {[10, 15, 20, 30, 60].map((v) => (
@@ -498,7 +492,7 @@ export function EventTypeForm({
                           {v} min
                         </option>
                       ))}
-                    </select>
+                    </Select>
                   </div>
                   <div>
                     <Label htmlFor="min-gap">Gap between bookings</Label>

--- a/apps/web/components/notification-channels-form.tsx
+++ b/apps/web/components/notification-channels-form.tsx
@@ -196,7 +196,7 @@ export function NotificationChannelsForm({
   }
 
   return (
-    <Card className="max-w-xl">
+    <Card className="max-w-2xl">
       <CardHeader
         title="Notification channels"
         description="Get meeting reminders where you actually are — Slack, WhatsApp, SMS, or your phone. Email reminders are always on."

--- a/apps/web/components/otter-launcher.tsx
+++ b/apps/web/components/otter-launcher.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { AiAssistant } from "@/components/ai-assistant";
+import { type ReactNode, useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+
+/**
+ * The primary way to reach Otter — a floating otter button on every app page
+ * that opens the assistant in a slide-over (right drawer on desktop, bottom
+ * sheet on mobile). Talk or type; Otter does the scheduling. Rendered globally
+ * from the app layout, gated on `aiEnabled`.
+ */
+export function OtterLauncher() {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  return (
+    <>
+      {open ? null : (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          aria-label="Ask Otter"
+          className="group fixed bottom-24 right-4 z-40 flex items-center gap-2.5 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] py-1.5 pl-1.5 pr-2.5 shadow-[var(--shadow-raise)] transition-transform hover:-translate-y-0.5 lg:bottom-6 lg:right-6"
+        >
+          <span className="relative flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden rounded-full ring-2 ring-[var(--color-accent)]">
+            {/* biome-ignore lint/a11y/useAltText: decorative otter avatar */}
+            <img
+              src="/brand/illustrations/otter-focus.png"
+              alt=""
+              className="h-full w-full object-cover"
+            />
+            <span className="absolute inset-0 animate-ping rounded-full ring-2 ring-[var(--color-accent)] opacity-20" />
+          </span>
+          <span className="pr-1 text-sm font-medium text-[var(--color-text)]">Ask Otter</span>
+        </button>
+      )}
+
+      {open ? <Portal>{drawer(() => setOpen(false))}</Portal> : null}
+    </>
+  );
+}
+
+function drawer(onClose: () => void): ReactNode {
+  return (
+    <div className="fixed inset-0 z-50">
+      <button
+        type="button"
+        aria-label="Close assistant"
+        onClick={onClose}
+        className="absolute inset-0 cursor-default bg-[color-mix(in_srgb,var(--color-text)_38%,transparent)] backdrop-blur-[2px]"
+      />
+      <div className="animate-dialog-in absolute inset-x-0 bottom-0 flex h-[85vh] flex-col overflow-hidden rounded-t-[var(--radius-xl)] border-t border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-pop)] sm:inset-y-0 sm:right-0 sm:left-auto sm:h-full sm:w-[440px] sm:rounded-none sm:border-l sm:border-t-0">
+        <AiAssistant variant="panel" onClose={onClose} />
+      </div>
+    </div>
+  );
+}
+
+function Portal({ children }: { children: ReactNode }) {
+  if (typeof document === "undefined") return null;
+  return createPortal(children, document.body);
+}

--- a/apps/web/components/preferences-form.tsx
+++ b/apps/web/components/preferences-form.tsx
@@ -132,7 +132,7 @@ export function PreferencesForm({
   }
 
   return (
-    <Card className="max-w-xl">
+    <Card className="max-w-2xl">
       <CardBody className="p-6">
         <form onSubmit={onSubmit} className="space-y-5">
           <div>

--- a/apps/web/components/profile-form.tsx
+++ b/apps/web/components/profile-form.tsx
@@ -82,7 +82,7 @@ export function ProfileForm({
   }
 
   return (
-    <Card className="max-w-xl">
+    <Card className="max-w-2xl">
       <CardBody className="p-6">
         <form onSubmit={onSubmit} className="space-y-4">
           <div>

--- a/apps/web/components/settings-nav.tsx
+++ b/apps/web/components/settings-nav.tsx
@@ -5,11 +5,15 @@ import { cn } from "@/lib/cn";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
-/** Horizontal tab strip for the Settings area. */
+/**
+ * Settings sub-nav — a scrollable underline tab strip on mobile, a vertical
+ * pill rail on large screens (so the settings pane fills the width instead of
+ * stranding a narrow column against the left edge).
+ */
 export function SettingsNav() {
   const pathname = usePathname();
   return (
-    <div className="mb-6 flex gap-1 overflow-x-auto border-b border-[var(--color-border)]">
+    <nav className="mb-6 flex gap-1 overflow-x-auto border-b border-[var(--color-border)] lg:mb-0 lg:flex-col lg:gap-0.5 lg:overflow-visible lg:border-b-0 lg:pt-1">
       {SETTINGS_NAV.map(({ href, label }) => {
         const active = pathname === href || pathname.startsWith(`${href}/`);
         return (
@@ -17,16 +21,16 @@ export function SettingsNav() {
             key={href}
             href={href}
             className={cn(
-              "-mb-px border-b-2 px-3 py-2.5 text-sm transition-colors",
+              "shrink-0 whitespace-nowrap border-b-2 border-transparent px-3 py-2.5 text-sm transition-colors lg:rounded-md lg:border-b-0 lg:py-2",
               active
-                ? "border-[var(--color-accent)] font-medium text-[var(--color-text)]"
-                : "border-transparent text-[var(--color-muted)] hover:text-[var(--color-text)]",
+                ? "border-[var(--color-accent)] font-medium text-[var(--color-text)] lg:bg-[var(--color-accent-soft)] lg:text-[var(--color-accent)]"
+                : "text-[var(--color-muted)] hover:text-[var(--color-text)] lg:hover:bg-[var(--color-surface-2)]",
             )}
           >
             {label}
           </Link>
         );
       })}
-    </div>
+    </nav>
   );
 }

--- a/apps/web/components/slot-grid.tsx
+++ b/apps/web/components/slot-grid.tsx
@@ -227,7 +227,7 @@ export function SlotGrid({
         </div>
       ) : null}
 
-      <div className="grid gap-5 sm:grid-cols-[220px_1fr] sm:gap-6">
+      <div className="grid gap-5 sm:grid-cols-[176px_1fr] sm:gap-6">
         <div className="flex gap-1.5 overflow-x-auto pb-1 sm:max-h-80 sm:flex-col sm:overflow-x-visible sm:overflow-y-auto sm:pb-0 sm:pr-1">
           {days.map((d) => {
             const dt = DateTime.fromISO(d);
@@ -255,30 +255,32 @@ export function SlotGrid({
           })}
         </div>
 
-        <div className="grid max-h-80 grid-cols-4 gap-2 overflow-y-auto pr-1 sm:grid-cols-3">
-          {daySlots.map((s) => {
-            const isRecommended = recommendedSet.has(s.start);
-            const conflict = hasConflict(s);
-            return (
-              <button
-                key={s.start}
-                type="button"
-                onClick={() => onSelect(s)}
-                title={conflict ? t(locale, "busyTooltip") : undefined}
-                className={cn(
-                  "inline-flex items-center justify-center gap-1 rounded-md border py-2 text-sm transition-colors hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]",
-                  conflict
-                    ? "border-[var(--color-border)] text-[var(--color-faint)] line-through decoration-[var(--color-faint)]"
-                    : isRecommended
-                      ? "border-[var(--color-accent)]/50 text-[var(--color-accent)]"
-                      : "border-[var(--color-border-strong)]",
-                )}
-              >
-                {isRecommended && !conflict ? <Sparkles size={11} /> : null}
-                {DateTime.fromISO(s.start).setZone(zone).setLocale(locale).toFormat("h:mm a")}
-              </button>
-            );
-          })}
+        <div className="@container">
+          <div className="grid max-h-80 grid-cols-2 gap-2 overflow-y-auto pr-1 @[300px]:grid-cols-3 @[460px]:grid-cols-4">
+            {daySlots.map((s) => {
+              const isRecommended = recommendedSet.has(s.start);
+              const conflict = hasConflict(s);
+              return (
+                <button
+                  key={s.start}
+                  type="button"
+                  onClick={() => onSelect(s)}
+                  title={conflict ? t(locale, "busyTooltip") : undefined}
+                  className={cn(
+                    "inline-flex items-center justify-center gap-1 whitespace-nowrap rounded-md border py-2.5 text-sm tabular-nums transition-colors hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]",
+                    conflict
+                      ? "border-[var(--color-border)] text-[var(--color-faint)] line-through decoration-[var(--color-faint)]"
+                      : isRecommended
+                        ? "border-[var(--color-accent)]/50 text-[var(--color-accent)]"
+                        : "border-[var(--color-border-strong)]",
+                  )}
+                >
+                  {isRecommended && !conflict ? <Sparkles size={11} /> : null}
+                  {DateTime.fromISO(s.start).setZone(zone).setLocale(locale).toFormat("h:mm a")}
+                </button>
+              );
+            })}
+          </div>
         </div>
       </div>
     </div>

--- a/apps/web/components/ui/select.tsx
+++ b/apps/web/components/ui/select.tsx
@@ -1,24 +1,235 @@
-import { cn } from "@/lib/cn";
-import { ChevronDown } from "lucide-react";
-import type { SelectHTMLAttributes } from "react";
+"use client";
 
-/** Design-system select — matches Input's height, radius, border, and focus ring. */
-export function Select({ className, children, ...props }: SelectHTMLAttributes<HTMLSelectElement>) {
+import { cn } from "@/lib/cn";
+import { Check, ChevronDown } from "lucide-react";
+import {
+  Children,
+  type ReactNode,
+  type SelectHTMLAttributes,
+  isValidElement,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+type Opt = { value: string; label: string; disabled?: boolean };
+
+/** Flatten `<option>` children (including mapped arrays) into a plain list. */
+function parseOptions(children: ReactNode): Opt[] {
+  const out: Opt[] = [];
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child) || child.type !== "option") return;
+    const props = child.props as {
+      value?: string | number;
+      children?: ReactNode;
+      disabled?: boolean;
+    };
+    out.push({
+      value: String(props.value ?? ""),
+      label: typeof props.children === "string" ? props.children : String(props.children ?? ""),
+      disabled: props.disabled,
+    });
+  });
+  return out;
+}
+
+/**
+ * Design-system select — a fully themed listbox (not the OS-native dropdown),
+ * so the open menu matches the app instead of rendering system chrome. Keeps the
+ * native `<select>` API: pass `<option>` children, read `e.target.value` in
+ * `onChange`. Long lists (>8 options, e.g. timezones) get a filter box.
+ */
+export function Select({
+  className,
+  children,
+  value,
+  defaultValue,
+  onChange,
+  disabled,
+  id,
+  name,
+  required,
+  "aria-label": ariaLabel,
+}: SelectHTMLAttributes<HTMLSelectElement>) {
+  const options = useMemo(() => parseOptions(children), [children]);
+  const controlled = value !== undefined;
+  const [internal, setInternal] = useState<string>(String(defaultValue ?? ""));
+  const current = controlled ? String(value ?? "") : internal;
+
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [active, setActive] = useState(0);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const filterRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const listId = useId();
+  const showFilter = options.length > 8;
+
+  const selected = options.find((o) => o.value === current) ?? null;
+  const placeholder = options.find((o) => o.disabled && o.value === "");
+  const filtered = useMemo(() => {
+    if (!query) return options;
+    const q = query.toLowerCase();
+    return options.filter((o) => o.label.toLowerCase().includes(q));
+  }, [options, query]);
+
+  function commit(v: string) {
+    if (!controlled) setInternal(v);
+    // Synthesize the minimal shape call sites read (`e.target.value`).
+    onChange?.({
+      target: { value: v },
+      currentTarget: { value: v },
+    } as unknown as React.ChangeEvent<HTMLSelectElement>);
+    setOpen(false);
+    setQuery("");
+  }
+
+  // Close on outside click / Escape.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [open]);
+
+  // On open, focus the filter (long lists) and highlight the current option.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally re-runs only when `open` toggles
+  useEffect(() => {
+    if (!open) return;
+    const idx = filtered.findIndex((o) => o.value === current);
+    setActive(idx >= 0 ? idx : 0);
+    if (showFilter) requestAnimationFrame(() => filterRef.current?.focus());
+    else requestAnimationFrame(() => listRef.current?.focus());
+  }, [open]);
+
+  function move(delta: number) {
+    setActive((a) => {
+      let next = a;
+      for (let i = 0; i < filtered.length; i++) {
+        next = (next + delta + filtered.length) % filtered.length;
+        if (!filtered[next]?.disabled) break;
+      }
+      return next;
+    });
+  }
+
+  function onKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      move(1);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      move(-1);
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const opt = filtered[active];
+      if (opt && !opt.disabled) commit(opt.value);
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      setOpen(false);
+    }
+  }
+
   return (
-    <div className="relative">
-      <select
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        id={id}
+        disabled={disabled}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={ariaLabel}
+        onClick={() => !disabled && setOpen((o) => !o)}
         className={cn(
-          "h-10 w-full appearance-none rounded-md border border-[var(--color-border-strong)] bg-[var(--color-bg)] pl-3 pr-9 text-sm text-[var(--color-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]",
+          "flex h-10 w-full items-center justify-between gap-2 rounded-md border border-[var(--color-border-strong)] bg-[var(--color-bg)] pl-3 pr-3 text-left text-sm text-[var(--color-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] disabled:cursor-not-allowed disabled:opacity-60",
           className,
         )}
-        {...props}
       >
-        {children}
-      </select>
-      <ChevronDown
-        size={15}
-        className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[var(--color-faint)]"
-      />
+        <span
+          className={cn(
+            "truncate",
+            !selected || selected === placeholder ? "text-[var(--color-faint)]" : "",
+          )}
+        >
+          {selected ? selected.label : (placeholder?.label ?? "")}
+        </span>
+        <ChevronDown
+          size={15}
+          className={cn(
+            "shrink-0 text-[var(--color-faint)] transition-transform",
+            open ? "rotate-180" : "",
+          )}
+        />
+      </button>
+
+      {open ? (
+        <div className="animate-dialog-in absolute z-50 mt-1.5 w-full overflow-hidden rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-pop)]">
+          {showFilter ? (
+            <div className="border-b border-[var(--color-border)] p-2">
+              <input
+                ref={filterRef}
+                value={query}
+                onChange={(e) => {
+                  setQuery(e.target.value);
+                  setActive(0);
+                }}
+                onKeyDown={onKeyDown}
+                placeholder="Search…"
+                className="h-8 w-full rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-bg)] px-2.5 text-sm text-[var(--color-text)] placeholder:text-[var(--color-faint)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-accent)]"
+              />
+            </div>
+          ) : null}
+          {/* biome-ignore lint/a11y/useSemanticElements: themed listbox replacing the native select */}
+          <div
+            role="listbox"
+            ref={listRef}
+            id={listId}
+            aria-label={ariaLabel}
+            tabIndex={-1}
+            onKeyDown={onKeyDown}
+            className="max-h-64 overflow-y-auto p-1 focus-visible:outline-none"
+          >
+            {filtered.length === 0 ? (
+              <p className="px-2.5 py-4 text-center text-sm text-[var(--color-faint)]">
+                No matches
+              </p>
+            ) : (
+              filtered.map((o, i) => {
+                const isSel = o.value === current;
+                const isActive = i === active;
+                return (
+                  // biome-ignore lint/a11y/useSemanticElements: option row inside a custom listbox
+                  <button
+                    role="option"
+                    key={o.value || `opt-${i}`}
+                    type="button"
+                    aria-selected={isSel}
+                    disabled={o.disabled}
+                    onMouseEnter={() => setActive(i)}
+                    onClick={() => !o.disabled && commit(o.value)}
+                    className={cn(
+                      "flex w-full items-center justify-between gap-2 rounded-[var(--radius-sm)] px-2.5 py-1.5 text-left text-sm transition-colors disabled:cursor-not-allowed disabled:text-[var(--color-faint)]",
+                      isActive && !o.disabled ? "bg-[var(--color-surface-2)]" : "",
+                      isSel ? "font-medium text-[var(--color-accent)]" : "text-[var(--color-text)]",
+                    )}
+                  >
+                    <span className="truncate">{o.label}</span>
+                    {isSel ? <Check size={15} className="shrink-0" /> : null}
+                  </button>
+                );
+              })
+            )}
+          </div>
+        </div>
+      ) : null}
+
+      {/* Mirror value into a hidden native control so real <form> submits still
+          carry it (most call sites are JS-controlled, but this keeps parity). */}
+      {name ? <input type="hidden" name={name} value={current} required={required} /> : null}
     </div>
   );
 }

--- a/apps/web/components/workflows-form.tsx
+++ b/apps/web/components/workflows-form.tsx
@@ -168,7 +168,7 @@ export function WorkflowsForm() {
   }
 
   return (
-    <Card className="max-w-xl">
+    <Card className="max-w-2xl">
       <CardHeader
         title="Workflows"
         description="Automated emails to attendees around each booking — a reminder before, a thank-you or follow-up after. Applies to every event type unless you scope it."


### PR DESCRIPTION
A large batch closing the competitive gaps vs Cal.com/Calendly and pressing the AI-EA wedge. Everything verified in the in-app browser; typecheck + lint clean.

## Tier-1 competitive must-wins (this round)
- **Routing forms** — qualify inbound with a few questions, then route each visitor to the right booking page (ordered rules + fallback). Builder, public form, response logging. *Verified: built a form, submitted publicly, landed on the matched booking page.*
- **Recurring meetings** — one booking schedules a repeating series (weekly/biweekly/monthly × N), each occurrence with its own reminders + calendar event, linked by a recurrence id. *Verified: weekly ×3 produced 3 occurrences one week apart under one series id.*
- **Round-robin weights** — the picker was already weighted + load-balanced; added per-member weight editing on the team page (0 = paused), propagated to existing event types. Post-meeting (`after_event`) workflows already existed and are UI-configurable.

## AI-EA wedge + earlier
- **Otter primary surface**, **focus/task auto-scheduling**, **proactive overflow notice**, **group polls / find-a-time** — all shipped + verified.

## Fixes
- Booking side-effects were silently failing: added **Resend** email support (+ loud warning), surfaced silent **calendar-sync** errors in Settings → Calendars, documented the Google Meet location requirement.
- Six UI bugs (sidebar logout, dull dashboard, settings whitespace, **OAuth callback host**, off-theme dropdowns, congested booking grid) + a Select label bug ('30, min').

## Deploy notes
- Set `RESEND_API_KEY` + `EMAIL_FROM` (verified domain) in `deploy/.env`.
- Run migrations 0030–0032 (polls, routing forms, recurring columns).