### PR TITLE
Ship mobile white-screen + Google-auth fixes, marketing content, deploy hardening

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -7,7 +7,7 @@
     "version": "0.1.0",
     "orientation": "portrait",
     "userInterfaceStyle": "automatic",
-    "newArchEnabled": true,
+    "newArchEnabled": false,
     "icon": "./assets/icon.png",
     "splash": {
       "image": "./assets/splash-icon.png",

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -6,15 +6,18 @@
   "build": {
     "development": {
       "developmentClient": true,
-      "distribution": "internal"
+      "distribution": "internal",
+      "env": { "EXPO_PUBLIC_GOOGLE_AUTH": "1" }
     },
     "preview": {
       "distribution": "internal",
-      "android": { "buildType": "apk" }
+      "android": { "buildType": "apk" },
+      "env": { "EXPO_PUBLIC_GOOGLE_AUTH": "1" }
     },
     "production": {
       "autoIncrement": true,
-      "android": { "buildType": "app-bundle" }
+      "android": { "buildType": "app-bundle" },
+      "env": { "EXPO_PUBLIC_GOOGLE_AUTH": "1" }
     }
   },
   "submit": {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -5,8 +5,8 @@
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",
-    "ios": "expo start --ios",
-    "android": "expo start --android",
+    "ios": "expo run:ios",
+    "android": "expo run:android",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/web/app/(marketing)/for/[slug]/page.tsx
+++ b/apps/web/app/(marketing)/for/[slug]/page.tsx
@@ -1,0 +1,138 @@
+import { MarketingHeader } from "@/components/marketing/page-shell";
+import { buttonVariants } from "@/components/ui/button";
+import { PERSONAS, getPersona } from "@/lib/personas";
+import { ArrowRight, Check } from "lucide-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+export function generateStaticParams() {
+  return PERSONAS.map((p) => ({ slug: p.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const p = getPersona((await params).slug);
+  if (!p) return { title: "DayOtter" };
+  return { title: `${p.title} — DayOtter`, description: p.subtitle };
+}
+
+export default async function PersonaPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const p = getPersona(slug);
+  if (!p) notFound();
+  const others = PERSONAS.filter((x) => x.slug !== slug);
+
+  return (
+    <>
+      <MarketingHeader
+        eyebrow={`For ${p.label.toLowerCase()}`}
+        title={p.title}
+        subtitle={p.subtitle}
+      />
+
+      <div className="mx-auto max-w-4xl px-6 py-16">
+        <div className="mb-14 flex flex-wrap justify-center gap-3">
+          <Link href="/sign-up" className={buttonVariants({ variant: "primary" })}>
+            Get started free
+          </Link>
+          <Link href="/#how" className={buttonVariants({ variant: "outline" })}>
+            See how it works
+          </Link>
+        </div>
+
+        {/* The problem */}
+        <section>
+          <h2 className="font-display text-center text-3xl tracking-[-0.01em]">Sound familiar?</h2>
+          <div className="mt-8 grid gap-4 md:grid-cols-3">
+            {p.problems.map((pr) => (
+              <div
+                key={pr.title}
+                className="rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface-2)] p-5"
+              >
+                <p className="font-semibold text-[var(--color-text)]">{pr.title}</p>
+                <p className="mt-2 text-sm leading-relaxed text-[var(--color-muted)]">{pr.body}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* The fit */}
+        <section className="mt-20">
+          <h2 className="font-display text-center text-3xl tracking-[-0.01em]">
+            How DayOtter fits
+          </h2>
+          <div className="mt-8 grid gap-4 sm:grid-cols-2">
+            {p.solutions.map((s) => (
+              <div
+                key={s.title}
+                className="flex gap-3 rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)] p-5 shadow-[var(--shadow-card)]"
+              >
+                <Check size={18} className="mt-0.5 shrink-0 text-[var(--color-accent)]" />
+                <div>
+                  <p className="font-semibold text-[var(--color-text)]">{s.title}</p>
+                  <p className="mt-1 text-sm leading-relaxed text-[var(--color-muted)]">{s.body}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* How it works */}
+        <section className="mt-20">
+          <h2 className="font-display text-center text-3xl tracking-[-0.01em]">
+            Up and running in minutes
+          </h2>
+          <ol className="mx-auto mt-8 max-w-xl space-y-4">
+            {p.steps.map((step, i) => (
+              <li key={step} className="flex gap-4">
+                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[var(--color-accent-soft)] font-mono text-sm font-semibold text-[var(--color-accent)]">
+                  {i + 1}
+                </span>
+                <p className="pt-1 text-[15px] text-[var(--color-muted)]">{step}</p>
+              </li>
+            ))}
+          </ol>
+        </section>
+
+        {/* FAQ */}
+        <section className="mx-auto mt-20 max-w-2xl">
+          <div className="divide-y divide-[var(--color-border)] border-y border-[var(--color-border)]">
+            {p.faq.map((f) => (
+              <div key={f.q} className="py-5">
+                <p className="font-semibold text-[var(--color-text)]">{f.q}</p>
+                <p className="mt-2 text-sm leading-relaxed text-[var(--color-muted)]">{f.a}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* CTA */}
+        <section className="mt-16 text-center">
+          <Link href="/sign-up" className={buttonVariants({ variant: "primary", size: "lg" })}>
+            Start free — no credit card
+          </Link>
+        </section>
+
+        {/* Cross-links */}
+        <section className="mt-20 border-t border-[var(--color-border)] pt-10">
+          <p className="eyebrow text-center">DayOtter for</p>
+          <div className="mt-5 flex flex-wrap justify-center gap-2.5">
+            {others.map((o) => (
+              <Link
+                key={o.slug}
+                href={`/for/${o.slug}`}
+                className="inline-flex items-center gap-1.5 rounded-full border border-[var(--color-border)] px-3.5 py-1.5 text-sm text-[var(--color-muted)] transition-colors hover:text-[var(--color-text)]"
+              >
+                {o.label} <ArrowRight size={13} />
+              </Link>
+            ))}
+          </div>
+        </section>
+      </div>
+    </>
+  );
+}

--- a/apps/web/app/(marketing)/pricing/page.tsx
+++ b/apps/web/app/(marketing)/pricing/page.tsx
@@ -87,7 +87,7 @@ const FAQ = [
   },
   {
     q: "What's the difference between cloud and self-hosting?",
-    a: "The open-source edition you run yourself is fully featured and free. Our hosted cloud adds a free tier plus the $9/seat Pro plan, and a couple of managed-only extras (Managed AI, SSO, white-label, hosted messaging).",
+    a: "The open-source edition you run yourself is fully featured and free. Our hosted cloud adds a free tier plus the $9/seat Pro plan, and takes the ops off your hands — managed AI and hosted messaging today, with team extras like SSO and custom booking domains on the way.",
   },
   {
     q: "Can I cancel anytime?",

--- a/apps/web/app/(marketing)/privacy/page.tsx
+++ b/apps/web/app/(marketing)/privacy/page.tsx
@@ -13,7 +13,7 @@ export default function PrivacyPage() {
       <MarketingHeader
         eyebrow="Legal"
         title="Privacy Policy"
-        subtitle="Last updated July 11, 2026"
+        subtitle="Last updated July 14, 2026"
       />
       <Prose>
         <p>
@@ -53,11 +53,50 @@ export default function PrivacyPage() {
           reliable product.
         </p>
 
+        <h2>Otter, our AI assistant</h2>
+        <p>
+          When you use Otter — {BRAND.name}'s built-in assistant — the message you send and the
+          relevant scheduling context (your event types, availability, and upcoming bookings) are
+          sent to our AI provider, Anthropic, to generate a response. Otter is{" "}
+          <strong>confirm-first</strong>: it only ever drafts a change and waits for your explicit
+          confirmation — it never books, moves, or cancels anything on its own. Our AI provider does
+          not use your data to train its models, and we don't use Otter conversations for
+          advertising. AI features are optional — if you never use Otter, none of your data is sent
+          to an AI provider.
+        </p>
+
         <h2>How we share it</h2>
         <p>
-          We share data only with the processors needed to run the Service: calendar providers
-          (Google, Microsoft, Apple) you connect, email/SMS providers for reminders, and Stripe for
-          payments. We do not sell your personal data or share it for advertising.
+          We share data only with the processors needed to run the Service — never for advertising,
+          and we never sell your personal data. Those processors are listed below.
+        </p>
+
+        <h2>Subprocessors</h2>
+        <p>We rely on a small set of vendors to operate the Service:</p>
+        <ul>
+          <li>
+            <strong>Calendar &amp; conferencing</strong> — Google, Microsoft, Apple, and Zoom, for
+            the accounts you choose to connect.
+          </li>
+          <li>
+            <strong>Anthropic</strong> — powers Otter's AI responses, only when you use Otter.
+          </li>
+          <li>
+            <strong>Stripe</strong> — payments and subscription billing.
+          </li>
+          <li>
+            <strong>Resend</strong> — transactional email (confirmations and reminders).
+          </li>
+          <li>
+            <strong>Twilio</strong> — SMS one-time codes and reminders, if you enable them.
+          </li>
+          <li>
+            <strong>Cloudflare</strong> — bot protection on public booking pages.
+          </li>
+        </ul>
+        <p>
+          Some of these processors are based in the United States; where required, international
+          transfers rely on standard contractual clauses.
         </p>
 
         <h2>Security</h2>
@@ -65,6 +104,12 @@ export default function PrivacyPage() {
           OAuth tokens, notification secrets, and webhook signing keys are encrypted at rest. API
           keys are stored only as hashes. Access is scoped per user and organization. See our{" "}
           <a href="/security">security page</a> for details.
+        </p>
+
+        <h2>Cookies</h2>
+        <p>
+          We use a session cookie to keep you signed in, and — where enabled — a bot-protection
+          cookie on public booking pages. We don't use advertising or cross-site tracking cookies.
         </p>
 
         <h2>Retention</h2>

--- a/apps/web/app/(marketing)/terms/page.tsx
+++ b/apps/web/app/(marketing)/terms/page.tsx
@@ -13,7 +13,7 @@ export default function TermsPage() {
       <MarketingHeader
         eyebrow="Legal"
         title="Terms of Service"
-        subtitle="Last updated July 11, 2026"
+        subtitle="Last updated July 14, 2026"
       />
       <Prose>
         <p>
@@ -76,7 +76,15 @@ export default function TermsPage() {
           changes will be announced with reasonable notice.
         </p>
 
-        <h2>8. Disclaimers & liability</h2>
+        <h2>8. AI features</h2>
+        <p>
+          {BRAND.name} includes an AI assistant ("Otter") that drafts events, suggestions, and
+          replies. Otter is confirm-first — it proposes actions and only carries them out after you
+          confirm. AI output can be inaccurate or incomplete, so you are responsible for reviewing
+          any draft before confirming it. Don't rely on AI output as professional advice.
+        </p>
+
+        <h2>9. Disclaimers & liability</h2>
         <p>
           The Service is provided "as is" without warranties of any kind. To the maximum extent
           permitted by law, {BRAND.name} is not liable for indirect, incidental, or consequential
@@ -84,13 +92,13 @@ export default function TermsPage() {
           before the claim.
         </p>
 
-        <h2>9. Termination</h2>
+        <h2>10. Termination</h2>
         <p>
           You may stop using the Service at any time. We may suspend or terminate access if you
           breach these Terms. On termination you may export your data for a reasonable period.
         </p>
 
-        <h2>10. Contact</h2>
+        <h2>11. Contact</h2>
         <p>
           Questions about these Terms? Email <a href={`mailto:${BRAND.email}`}>{BRAND.email}</a>.
         </p>

--- a/apps/web/app/(marketing)/vs/[slug]/page.tsx
+++ b/apps/web/app/(marketing)/vs/[slug]/page.tsx
@@ -1,0 +1,133 @@
+import { MarketingHeader } from "@/components/marketing/page-shell";
+import { buttonVariants } from "@/components/ui/button";
+import { COMPARISONS, getComparison } from "@/lib/comparisons";
+import { Check, Minus } from "lucide-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+export function generateStaticParams() {
+  return COMPARISONS.map((c) => ({ slug: c.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const c = getComparison((await params).slug);
+  if (!c) return { title: "Compare — DayOtter" };
+  return {
+    title: `${c.title} (2026) — how they compare`,
+    description: c.subtitle,
+  };
+}
+
+const EDGE_STYLES = {
+  us: "text-[var(--color-accent)]",
+  them: "text-[var(--color-muted)]",
+  tie: "text-[var(--color-text)]",
+} as const;
+
+export default async function ComparisonPage({ params }: { params: Promise<{ slug: string }> }) {
+  const c = getComparison((await params).slug);
+  if (!c) notFound();
+
+  return (
+    <>
+      <MarketingHeader eyebrow="Compare" title={c.title} subtitle={c.subtitle} />
+
+      <div className="mx-auto max-w-3xl px-6 py-16">
+        <div className="space-y-4 text-[15px] leading-7 text-[var(--color-muted)]">
+          {c.intro.map((p) => (
+            <p key={p}>{p}</p>
+          ))}
+        </div>
+
+        <div className="mt-8 rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface-2)] p-5">
+          <p className="text-sm font-semibold text-[var(--color-text)]">What {c.name} does well</p>
+          <p className="mt-2 text-sm leading-relaxed text-[var(--color-muted)]">
+            {c.theirStrength}
+          </p>
+        </div>
+
+        {/* Comparison table */}
+        <div className="mt-12 overflow-x-auto rounded-[var(--radius-lg)] border border-[var(--color-border)]">
+          <table className="w-full min-w-[520px] border-collapse text-sm">
+            <thead>
+              <tr className="bg-[var(--color-surface-2)] text-left">
+                <th className="px-4 py-3 font-semibold text-[var(--color-muted)]">&nbsp;</th>
+                <th className="px-4 py-3 font-semibold text-[var(--color-accent)]">DayOtter</th>
+                <th className="px-4 py-3 font-semibold text-[var(--color-muted)]">{c.name}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {c.rows.map((r) => (
+                <tr key={r.label} className="border-t border-[var(--color-border)]">
+                  <td className="px-4 py-3 font-medium text-[var(--color-text)]">{r.label}</td>
+                  <td className={`px-4 py-3 ${EDGE_STYLES[r.edge ?? "tie"]}`}>{r.dayotter}</td>
+                  <td className="px-4 py-3 text-[var(--color-muted)]">{r.them}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Why DayOtter */}
+        <h2 className="font-display mt-14 text-2xl tracking-[-0.01em] text-[var(--color-text)]">
+          Why teams pick DayOtter
+        </h2>
+        <div className="mt-5 space-y-4">
+          {c.whyUs.map((w) => (
+            <div key={w.title} className="flex gap-3">
+              <Check size={18} className="mt-0.5 shrink-0 text-[var(--color-accent)]" />
+              <div>
+                <p className="font-semibold text-[var(--color-text)]">{w.title}</p>
+                <p className="mt-1 text-sm leading-relaxed text-[var(--color-muted)]">{w.body}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Verdict */}
+        <div className="mt-12 grid gap-4 sm:grid-cols-2">
+          <div className="rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface-2)] p-5">
+            <p className="flex items-center gap-2 text-sm font-semibold text-[var(--color-text)]">
+              <Minus size={15} /> Choose {c.name} if
+            </p>
+            <p className="mt-2 text-sm leading-relaxed text-[var(--color-muted)]">{c.chooseThem}</p>
+          </div>
+          <div className="rounded-[var(--radius-lg)] border border-[var(--color-accent)]/40 bg-[var(--color-surface)] p-5 shadow-[var(--shadow-raise)]">
+            <p className="flex items-center gap-2 text-sm font-semibold text-[var(--color-accent)]">
+              <Check size={15} /> Choose DayOtter if
+            </p>
+            <p className="mt-2 text-sm leading-relaxed text-[var(--color-text)]">{c.chooseUs}</p>
+          </div>
+        </div>
+
+        {/* FAQ */}
+        <h2 className="font-display mt-14 text-2xl tracking-[-0.01em] text-[var(--color-text)]">
+          Questions
+        </h2>
+        <div className="mt-5 divide-y divide-[var(--color-border)] border-y border-[var(--color-border)]">
+          {c.faq.map((f) => (
+            <div key={f.q} className="py-5">
+              <p className="font-semibold text-[var(--color-text)]">{f.q}</p>
+              <p className="mt-2 text-sm leading-relaxed text-[var(--color-muted)]">{f.a}</p>
+            </div>
+          ))}
+        </div>
+
+        {/* CTA */}
+        <div className="mt-12 flex flex-wrap items-center gap-3">
+          <Link href="/sign-up" className={buttonVariants({ variant: "primary" })}>
+            Try DayOtter free
+          </Link>
+          <Link href="/vs" className={buttonVariants({ variant: "outline" })}>
+            All comparisons
+          </Link>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/web/app/(marketing)/vs/page.tsx
+++ b/apps/web/app/(marketing)/vs/page.tsx
@@ -1,0 +1,47 @@
+import { MarketingHeader } from "@/components/marketing/page-shell";
+import { COMPARISONS } from "@/lib/comparisons";
+import { ArrowRight } from "lucide-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "DayOtter vs the alternatives — honest comparisons",
+  description:
+    "How DayOtter compares to Calendly, Cal.com, Motion and Reclaim. Where each one wins, plainly told.",
+};
+
+export default function ComparisonsHub() {
+  return (
+    <>
+      <MarketingHeader
+        eyebrow="Compare"
+        title="Honest comparisons"
+        subtitle="No hand-waving. Here's where each tool wins — and where DayOtter is the better call."
+      />
+      <section className="mx-auto max-w-4xl px-6 py-16">
+        <div className="grid gap-4 sm:grid-cols-2">
+          {COMPARISONS.map((c) => (
+            <Link
+              key={c.slug}
+              href={`/vs/${c.slug}`}
+              className="group flex flex-col rounded-[var(--radius-xl)] border border-[var(--color-border)] bg-[var(--color-surface)] p-6 shadow-[var(--shadow-card)] transition-all hover:-translate-y-1 hover:shadow-[var(--shadow-raise)]"
+            >
+              <p className="text-sm font-semibold text-[var(--color-faint)]">DayOtter vs</p>
+              <h2 className="font-display mt-1 text-2xl tracking-[-0.01em]">{c.name}</h2>
+              <p className="mt-2 flex-1 text-sm leading-relaxed text-[var(--color-muted)]">
+                {c.blurb}
+              </p>
+              <span className="mt-4 inline-flex items-center gap-1.5 text-sm font-medium text-[var(--color-accent)]">
+                See the comparison{" "}
+                <ArrowRight
+                  size={15}
+                  className="transition-transform group-hover:translate-x-0.5"
+                />
+              </span>
+            </Link>
+          ))}
+        </div>
+      </section>
+    </>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -3,7 +3,7 @@ import { Hero } from "@/components/marketing/hero";
 import { Marquee } from "@/components/marketing/marquee";
 import { MobileApps } from "@/components/marketing/mobile";
 import { MarketingNav } from "@/components/marketing/nav";
-import { CTA, Footer, HowItWorks, Manifesto } from "@/components/marketing/sections";
+import { CTA, Footer, HowItWorks, Manifesto, Shift } from "@/components/marketing/sections";
 import { OtterBand, WhyOtter } from "@/components/marketing/why";
 
 export default function HomePage() {
@@ -14,6 +14,7 @@ export default function HomePage() {
         <Hero />
         <Marquee />
         <Features />
+        <Shift />
         <WhyOtter />
         <MobileApps />
         <HowItWorks />

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -3,7 +3,7 @@ import { Hero } from "@/components/marketing/hero";
 import { Marquee } from "@/components/marketing/marquee";
 import { MobileApps } from "@/components/marketing/mobile";
 import { MarketingNav } from "@/components/marketing/nav";
-import { CTA, Footer, HowItWorks, Manifesto, Shift } from "@/components/marketing/sections";
+import { CTA, FAQ, Footer, HowItWorks, Manifesto, Shift } from "@/components/marketing/sections";
 import { OtterBand, WhyOtter } from "@/components/marketing/why";
 
 export default function HomePage() {
@@ -20,6 +20,7 @@ export default function HomePage() {
         <HowItWorks />
         <Manifesto />
         <OtterBand />
+        <FAQ />
         <CTA />
       </main>
       <Footer />

--- a/apps/web/components/marketing/features.tsx
+++ b/apps/web/components/marketing/features.tsx
@@ -56,14 +56,14 @@ function AIMock() {
   return (
     <div className="space-y-2.5">
       <div className="ml-auto w-fit max-w-[85%] rounded-[14px] rounded-br-sm bg-[var(--color-accent)] px-3.5 py-2 text-sm text-white">
-        "Book a 30-min call with mom Friday afternoon"
+        "Hold two hours for deep work tomorrow"
       </div>
       <div className="rounded-[12px] border border-[var(--color-border)] bg-[var(--color-surface-2)] p-3">
         <div className="flex items-center gap-2 text-xs text-[var(--color-muted)]">
-          <Sparkles size={13} className="text-[var(--color-accent)]" /> Draft — review before
-          booking
+          <Sparkles size={13} className="text-[var(--color-accent)]" /> Draft — nothing's booked
+          until you say so
         </div>
-        <p className="mt-1.5 text-sm font-medium">Call with mom · Fri, 3:00 PM</p>
+        <p className="mt-1.5 text-sm font-medium">Deep work · Tomorrow, 9:00–11:00 AM</p>
         <div className="mt-2.5 flex gap-2">
           <span className="rounded-sm bg-[var(--color-accent)] px-3 py-1 text-xs font-medium text-white">
             Confirm
@@ -81,33 +81,33 @@ export function Features() {
   return (
     <section id="features" className="relative mx-auto max-w-6xl px-6 py-24">
       <Reveal className="mx-auto max-w-2xl text-center">
-        <span className="eyebrow">Everything, one calm place</span>
+        <span className="eyebrow">Everything you need, nothing you don't</span>
         <h2 className="font-display mt-4 text-4xl leading-tight tracking-[-0.02em] sm:text-5xl">
-          A calendar that works the way you do.
+          One calm home for your whole schedule.
         </h2>
       </Reveal>
 
       <Stagger className="mt-14 grid grid-cols-1 gap-4 md:grid-cols-6">
         <Card
           className="md:col-span-4 md:row-span-2"
-          title="Shared team availability"
-          body="Find a time you're all free — collective and round-robin scheduling built in, never behind a paywall. Your founder wedge, out of the box."
+          title="Ask Otter anything"
+          body="“Book a call with Priya Thursday.” “Hold two hours for deep work.” “Move my 3pm.” Say it in plain words — Otter drafts it and waits for your OK. It never touches your calendar on its own."
         >
-          <TeamAvailabilityMock />
+          <AIMock />
         </Card>
 
         <Card
           className="md:col-span-2"
           title="Every calendar, in sync"
-          body="Unify Google, Outlook and Apple into one source of truth."
+          body="Google, Outlook and Apple — one source of truth."
         >
           <ProviderChips />
         </Card>
 
         <Card
           className="md:col-span-2"
-          title="Reminders that fire"
-          body="Automatic 1-day and 1-hour nudges. Durable — never dropped."
+          title="It covers for you"
+          body="Otter holds focus time on quiet mornings, and quietly warns your next meeting when you're running behind."
         >
           <ReminderMock />
         </Card>
@@ -115,17 +115,17 @@ export function Features() {
         <Card
           className="md:col-span-3"
           title="Let people book you"
-          body="Beautiful booking pages with buffers, intake questions and instant video links."
+          body="A booking page as calm as it is capable — buffers, intake questions, recurring meetings, instant video links."
         >
           <BookingMock />
         </Card>
 
         <Card
           className="md:col-span-3"
-          title="Scheduling, with a little AI"
-          body="Say it in plain words. DayOtter drafts the event — you confirm. It never touches your calendar on its own."
+          title="Schedule as a team"
+          body="Round-robin and collective booking, weighted your way. Routing forms send each visitor to the right person — never behind a paywall."
         >
-          <AIMock />
+          <TeamAvailabilityMock />
         </Card>
       </Stagger>
     </section>

--- a/apps/web/components/marketing/hero.tsx
+++ b/apps/web/components/marketing/hero.tsx
@@ -22,19 +22,18 @@ export function Hero() {
 
       <div className="relative mx-auto max-w-5xl px-6 pt-16 text-center sm:pt-24">
         <FadeUp>
-          <span className="eyebrow">Scheduling, minus the back-and-forth</span>
+          <span className="eyebrow">Meet Otter, your scheduling assistant</span>
         </FadeUp>
         <FadeUp delay={0.08}>
           <h1 className="font-display mx-auto mt-5 max-w-4xl text-[2.6rem] leading-[1.04] tracking-[-0.02em] sm:text-6xl lg:text-[4.5rem]">
-            Scheduling that respects <em className="text-[var(--color-accent)]">every calendar</em>{" "}
-            you own.
+            Say it once. <em className="text-[var(--color-accent)]">Otter handles the rest.</em>
           </h1>
         </FadeUp>
         <FadeUp delay={0.16}>
           <p className="mx-auto mt-6 max-w-xl text-lg leading-relaxed text-[var(--color-muted)]">
-            One calm home for your time — sync every calendar, share your availability, and let
-            people book you without the back-and-forth. Beautifully simple, on the cloud or your own
-            server.
+            Talk to your calendar like you'd talk to an assistant. Otter books the meeting, holds
+            your focus time, and clears the back-and-forth — and never changes a thing without your
+            OK. Or share one link and let people book you themselves.
           </p>
         </FadeUp>
         <FadeUp delay={0.24}>
@@ -49,7 +48,7 @@ export function Hero() {
         </FadeUp>
         <FadeUp delay={0.32}>
           <p className="mt-6 text-sm text-[var(--color-faint)]">
-            Free forever for individuals · No credit card
+            Free forever for individuals · No credit card · Open source
           </p>
         </FadeUp>
         <FadeUp delay={0.38}>

--- a/apps/web/components/marketing/sections.tsx
+++ b/apps/web/components/marketing/sections.tsx
@@ -4,8 +4,65 @@ import { BrandMark } from "@/components/brand-mark";
 import { Reveal } from "@/components/marketing/motion";
 import { buttonVariants } from "@/components/ui/button";
 import { BRAND, FOOTER_COLUMNS } from "@/lib/marketing";
-import { CalendarPlus, Clock, LinkIcon } from "lucide-react";
+import { CalendarPlus, Check, Clock, LinkIcon, X } from "lucide-react";
 import Link from "next/link";
+
+const BEFORE = [
+  "Five emails to find one time that works.",
+  "Meetings creep in; the real work never gets a slot.",
+  "You forget to tell your 3pm you're running late.",
+  "Double-booked across three different calendars.",
+  "A basic team round-robin costs $16 a seat.",
+];
+const AFTER = [
+  "Share one link — or just ask Otter to find the time.",
+  "Otter holds hours for deep work and defends them.",
+  "It messages your next meeting before you even notice.",
+  "Every calendar, one honest view of when you're free.",
+  "Team scheduling, routing and polls — free to self-host.",
+];
+
+/** The before/after story — the calm case for switching, plainly told. */
+export function Shift() {
+  return (
+    <section className="mx-auto max-w-5xl px-6 py-24">
+      <Reveal className="mx-auto max-w-2xl text-center">
+        <span className="eyebrow">The shift</span>
+        <h2 className="font-display mt-4 text-4xl leading-tight tracking-[-0.02em] sm:text-5xl">
+          From scattered to simply handled.
+        </h2>
+      </Reveal>
+      <div className="mt-14 grid gap-4 md:grid-cols-2">
+        <Reveal>
+          <div className="h-full rounded-[var(--radius-xl)] border border-[var(--color-border)] bg-[var(--color-surface-2)] p-7">
+            <p className="text-sm font-semibold text-[var(--color-faint)]">Without DayOtter</p>
+            <ul className="mt-5 space-y-3.5">
+              {BEFORE.map((t) => (
+                <li key={t} className="flex items-start gap-3 text-sm text-[var(--color-muted)]">
+                  <X size={16} className="mt-0.5 shrink-0 text-[var(--color-faint)]" />
+                  {t}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </Reveal>
+        <Reveal delay={0.1}>
+          <div className="h-full rounded-[var(--radius-xl)] border border-[var(--color-accent)]/40 bg-[var(--color-surface)] p-7 shadow-[var(--shadow-raise)]">
+            <p className="text-sm font-semibold text-[var(--color-accent)]">With DayOtter</p>
+            <ul className="mt-5 space-y-3.5">
+              {AFTER.map((t) => (
+                <li key={t} className="flex items-start gap-3 text-sm text-[var(--color-text)]">
+                  <Check size={16} className="mt-0.5 shrink-0 text-[var(--color-accent)]" />
+                  {t}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </Reveal>
+      </div>
+    </section>
+  );
+}
 
 const STEPS = [
   {

--- a/apps/web/components/marketing/sections.tsx
+++ b/apps/web/components/marketing/sections.tsx
@@ -162,7 +162,7 @@ export function CTA() {
 export function Footer() {
   return (
     <footer className="border-t border-[var(--color-border)]">
-      <div className="mx-auto grid max-w-6xl gap-10 px-6 py-14 md:grid-cols-[1.4fr_repeat(4,1fr)]">
+      <div className="mx-auto grid max-w-6xl grid-cols-2 gap-x-6 gap-y-10 px-6 py-14 sm:grid-cols-3 md:grid-cols-[1.4fr_repeat(5,1fr)]">
         <div>
           <Link href="/" className="flex items-center gap-2">
             <BrandMark size={28} />

--- a/apps/web/components/marketing/sections.tsx
+++ b/apps/web/components/marketing/sections.tsx
@@ -4,7 +4,7 @@ import { BrandMark } from "@/components/brand-mark";
 import { Reveal } from "@/components/marketing/motion";
 import { buttonVariants } from "@/components/ui/button";
 import { BRAND, FOOTER_COLUMNS } from "@/lib/marketing";
-import { CalendarPlus, Check, Clock, LinkIcon, X } from "lucide-react";
+import { CalendarPlus, Check, Clock, LinkIcon, Plus, X } from "lucide-react";
 import Link from "next/link";
 
 const BEFORE = [
@@ -120,6 +120,66 @@ export function Manifesto() {
           </em>
         </p>
         <p className="eyebrow mt-8">The DayOtter team</p>
+      </Reveal>
+    </section>
+  );
+}
+
+const HOME_FAQ = [
+  {
+    q: "Do I have to talk to the AI to use it?",
+    a: "Not at all. DayOtter is a complete scheduling tool on its own — booking pages, team round-robin, reminders, calendar sync. Otter is there when you want it: ask it to book, reschedule or hold focus time and it drafts the change for you. Never the other way around.",
+  },
+  {
+    q: "Will Otter ever change my calendar on its own?",
+    a: "No. Otter is confirm-first by design — it proposes, you approve. Nothing lands on your calendar, and nothing moves, without your explicit OK.",
+  },
+  {
+    q: "Is DayOtter really free?",
+    a: "Yes. Individuals get unlimited event types, calendar sync, group polls and reminders free, forever. Teams are $9 a seat each month — and if you self-host, every feature is free.",
+  },
+  {
+    q: "Which calendars does it work with?",
+    a: "Google, Outlook, Apple iCloud and any ICS feed — unified into one honest view of when you're actually free, across every timezone.",
+  },
+  {
+    q: "Can my whole team use it?",
+    a: "Yes. Weighted round-robin, collective availability, routing forms and group polls are built in — the team toolkit that runs $16–20 a seat elsewhere, here for $9.",
+  },
+  {
+    q: "Can I self-host it?",
+    a: "The core is open-source, Apache-2.0 licensed, and ships with Docker. Run it on your own servers with every Pro feature unlocked, or let us host it for you.",
+  },
+];
+
+/** Home-page FAQ — plain answers to the questions people actually ask. */
+export function FAQ() {
+  return (
+    <section id="faq" className="mx-auto max-w-3xl px-6 py-24">
+      <Reveal className="mx-auto max-w-2xl text-center">
+        <span className="eyebrow">Good questions</span>
+        <h2 className="font-display mt-4 text-4xl leading-tight tracking-[-0.02em] sm:text-5xl">
+          The honest answers.
+        </h2>
+      </Reveal>
+      <Reveal className="mt-12">
+        <div className="divide-y divide-[var(--color-border)] border-y border-[var(--color-border)]">
+          {HOME_FAQ.map((item) => (
+            <details
+              key={item.q}
+              className="group py-5 [&_summary::-webkit-details-marker]:hidden"
+            >
+              <summary className="flex cursor-pointer list-none items-center justify-between gap-4 font-semibold">
+                {item.q}
+                <Plus
+                  size={18}
+                  className="shrink-0 text-[var(--color-faint)] transition-transform duration-200 group-open:rotate-45"
+                />
+              </summary>
+              <p className="mt-3 text-sm leading-relaxed text-[var(--color-muted)]">{item.a}</p>
+            </details>
+          ))}
+        </div>
       </Reveal>
     </section>
   );

--- a/apps/web/components/marketing/why.tsx
+++ b/apps/web/components/marketing/why.tsx
@@ -1,10 +1,10 @@
 const BADGES = [
-  { img: "/brand/illustrations/badge-scheduling.png", label: "Easy scheduling" },
-  { img: "/brand/illustrations/badge-secure.png", label: "Secure & private" },
-  { img: "/brand/illustrations/badge-balance.png", label: "Work–life balance" },
-  { img: "/brand/illustrations/badge-timezone.png", label: "Timezone-friendly" },
-  { img: "/brand/illustrations/badge-reminders.png", label: "Smart reminders" },
-  { img: "/brand/illustrations/badge-track.png", label: "Stay on track" },
+  { img: "/brand/illustrations/badge-scheduling.png", label: "One link, done" },
+  { img: "/brand/illustrations/badge-secure.png", label: "Yours to self-host" },
+  { img: "/brand/illustrations/badge-balance.png", label: "Focus, protected" },
+  { img: "/brand/illustrations/badge-timezone.png", label: "Every timezone" },
+  { img: "/brand/illustrations/badge-reminders.png", label: "Reminders that fire" },
+  { img: "/brand/illustrations/badge-track.png", label: "Never double-booked" },
 ];
 
 /** A playful badge strip — the otter's take on "why DayOtter". */

--- a/apps/web/lib/comparisons.ts
+++ b/apps/web/lib/comparisons.ts
@@ -1,0 +1,324 @@
+/**
+ * Head-to-head comparison content, rendered at /vs and /vs/[slug]. Candid by
+ * design — concede what the competitor does well, then make the honest case for
+ * DayOtter. Grounded in the competitive analysis; update as the market moves.
+ */
+
+export interface CompareRow {
+  label: string;
+  dayotter: string;
+  them: string;
+  /** Who wins this row — tints the cell. */
+  edge?: "us" | "them" | "tie";
+}
+
+export interface Comparison {
+  slug: string;
+  /** Competitor display name, e.g. "Calendly". */
+  name: string;
+  /** One-line descriptor for the /vs hub card. */
+  blurb: string;
+  title: string;
+  subtitle: string;
+  /** 1–2 intro paragraphs. */
+  intro: string[];
+  /** What they genuinely do well — stated plainly. */
+  theirStrength: string;
+  rows: CompareRow[];
+  whyUs: { title: string; body: string }[];
+  /** Honest "pick them if / pick us if". */
+  chooseThem: string;
+  chooseUs: string;
+  faq: { q: string; a: string }[];
+}
+
+export const COMPARISONS: Comparison[] = [
+  {
+    slug: "calendly",
+    name: "Calendly",
+    blurb: "The category default — polished, but a crippled free tier and no self-host.",
+    title: "DayOtter vs Calendly",
+    subtitle:
+      "Calendly set the standard for booking links. DayOtter matches the scheduling and adds an AI assistant that actually does the work — at a third of the price, with a free plan you can live on.",
+    intro: [
+      "Calendly is the tool most people picture when they hear \"scheduling link.\" It's polished and dependable, and for years it was the safe default. The catch: its free plan gives you exactly one event type, the team features get expensive fast, and there's no way to run it yourself.",
+      "DayOtter covers the same core — booking pages, team round-robin, reminders, payments, calendar sync — then adds Otter, a proactive assistant you can just talk to. And the free plan is genuinely usable, not a demo.",
+    ],
+    theirStrength:
+      "Calendly's invitee experience is famously smooth, its CRM integrations (Salesforce, HubSpot) are mature, and its enterprise admin controls are battle-tested. If you're a large revenue org already standardized on Salesforce, it's a proven choice.",
+    rows: [
+      {
+        label: "Free plan",
+        dayotter: "Unlimited event types",
+        them: "One event type only",
+        edge: "us",
+      },
+      { label: "Price (teams)", dayotter: "$9 / seat", them: "$16–20 / seat", edge: "us" },
+      {
+        label: "AI assistant",
+        dayotter: "Otter — chat to book, protect focus, confirm-first",
+        them: "Routing only",
+        edge: "us",
+      },
+      {
+        label: "Time protection",
+        dayotter: "Focus auto-scheduling + running-late alerts",
+        them: "None",
+        edge: "us",
+      },
+      {
+        label: "Team scheduling",
+        dayotter: "Weighted round-robin & collective",
+        them: "Round-robin & collective",
+        edge: "tie",
+      },
+      { label: "Routing forms", dayotter: "Yes", them: "Yes", edge: "tie" },
+      {
+        label: "CRM (Salesforce/HubSpot)",
+        dayotter: "On the roadmap",
+        them: "Native, mature",
+        edge: "them",
+      },
+      { label: "Apple iCloud sync", dayotter: "Yes", them: "Dropped in 2024", edge: "us" },
+      { label: "Open source / self-host", dayotter: "Yes", them: "No", edge: "us" },
+    ],
+    whyUs: [
+      {
+        title: "A free plan you can actually use",
+        body: "Calendly's free tier stops at one event type. DayOtter gives you unlimited event types, calendar sync, group polls and reminders free, forever — solo users rarely need to pay at all.",
+      },
+      {
+        title: "An assistant, not just a link",
+        body: 'Tell Otter "block two hours for deep work" or "find 30 minutes with Priya" — it drafts it and waits for your OK. Calendly can share your availability; it can\'t take the work off your plate.',
+      },
+      {
+        title: "Your data, your call",
+        body: "DayOtter's core is open-source and self-hostable. Run it on your own servers with every feature unlocked, or use our cloud. Calendly is closed and cloud-only.",
+      },
+    ],
+    chooseThem:
+      "You're a large sales org deeply invested in Salesforce and need its most mature CRM routing and enterprise admin today.",
+    chooseUs:
+      "You want the same scheduling for a fraction of the price, a free plan that isn't a trap, an AI assistant that does the scheduling, and the option to self-host.",
+    faq: [
+      {
+        q: "Is DayOtter a drop-in Calendly replacement?",
+        a: "For the everyday flow — booking pages, team round-robin, reminders, payments, calendar sync — yes. The main gap today is native Salesforce/HubSpot CRM, which is on our roadmap.",
+      },
+      {
+        q: "How much cheaper is DayOtter?",
+        a: "Teams are $9/seat vs Calendly's $16–20/seat, and individuals are free with unlimited event types. Self-hosting is free with every feature.",
+      },
+      {
+        q: "Can I import my Calendly setup?",
+        a: "You recreate your event types in DayOtter (it takes a few minutes) and point your calendar connections over. There's no lock-in either way.",
+      },
+    ],
+  },
+  {
+    slug: "cal-com",
+    name: "Cal.com",
+    blurb: "Open-source and developer-grade — but its AI is a usage-priced voice add-on.",
+    title: "DayOtter vs Cal.com",
+    subtitle:
+      "Both are open-source with generous free plans. The difference is the assistant: DayOtter is built around a proactive AI EA that protects your time — Cal.com's AI is a separate, metered voice product.",
+    intro: [
+      "Cal.com is the open-source scheduler developers love — API-first, self-hostable, with a genuinely generous free tier and strong routing. On the fundamentals, DayOtter and Cal.com are close cousins.",
+      "Where they diverge is the assistant. Cal.com's AI (Cal.ai) is a usage-priced voice-agent add-on. DayOtter is designed from the ground up around Otter — a conversational assistant that books, protects focus, and handles overflow, confirm-first, at no per-minute cost.",
+    ],
+    theirStrength:
+      "Cal.com's API and webhook surface is excellent, its app ecosystem is large, and its enterprise/org tier (attribute routing, SAML, SCIM, HIPAA) is further along. If you're building a scheduling product on top of an API, it's a strong platform.",
+    rows: [
+      { label: "Open source / self-host", dayotter: "Yes", them: "Yes", edge: "tie" },
+      { label: "Generous free plan", dayotter: "Yes", them: "Yes", edge: "tie" },
+      {
+        label: "AI assistant",
+        dayotter: "Otter, included — chat + confirm-first",
+        them: "Cal.ai, usage-priced voice (~$0.29/min)",
+        edge: "us",
+      },
+      {
+        label: "Time protection",
+        dayotter: "Focus auto-scheduling + running-late alerts",
+        them: "None",
+        edge: "us",
+      },
+      { label: "Routing forms", dayotter: "Yes", them: "Yes (flagship)", edge: "tie" },
+      { label: "Team round-robin", dayotter: "Weighted", them: "Weighted", edge: "tie" },
+      {
+        label: "Developer platform / API",
+        dayotter: "Keys & webhooks",
+        them: "Deeper, platform API",
+        edge: "them",
+      },
+      {
+        label: "Enterprise (SSO/SCIM)",
+        dayotter: "On the roadmap",
+        them: "On Orgs tier",
+        edge: "them",
+      },
+      {
+        label: "Ease of setup",
+        dayotter: "Calm, opinionated",
+        them: "Powerful, more to configure",
+        edge: "us",
+      },
+    ],
+    whyUs: [
+      {
+        title: "The assistant is the product, not an add-on",
+        body: "With DayOtter, talking to Otter is the main way to get things done — book, reschedule, protect focus, all confirm-first, at no metered cost. Cal.com's AI is a separate voice product billed by the minute.",
+      },
+      {
+        title: "Time protection built in",
+        body: "Otter finds open time and holds it for deep work, and warns your next meeting when you're running behind — Reclaim/Motion territory that Cal.com doesn't touch.",
+      },
+      {
+        title: "Calmer out of the box",
+        body: "Cal.com is powerful and endlessly configurable. DayOtter is opinionated and quiet by default — you're booked in minutes without wiring up apps.",
+      },
+    ],
+    chooseThem:
+      "You're building on top of a scheduling API, want the deepest developer platform, or need mature enterprise org features (SAML/SCIM) right now.",
+    chooseUs:
+      "You want the open-source, self-hostable base plus a proactive AI assistant and time protection included — not a metered voice add-on.",
+    faq: [
+      {
+        q: "Both are open-source — what's the real difference?",
+        a: "The assistant and time protection. DayOtter is built around Otter (conversational, confirm-first, included) and defends your focus time. Cal.com's AI is a usage-priced voice add-on and it doesn't do focus scheduling.",
+      },
+      {
+        q: "Can I self-host DayOtter like Cal.com?",
+        a: "Yes — the core is Apache-2.0 and ships with Docker/compose. Self-hosting unlocks every feature for free.",
+      },
+    ],
+  },
+  {
+    slug: "motion",
+    name: "Motion",
+    blurb: "Powerful auto-scheduling — but pricey, desktop-first, and it reschedules you silently.",
+    title: "DayOtter vs Motion",
+    subtitle:
+      "Motion auto-plans your day with a powerful engine. DayOtter protects your time too — but asks before it acts, costs less, and also handles booking links and team scheduling.",
+    intro: [
+      "Motion is the heavyweight of AI auto-scheduling: it rearranges your tasks and meetings to fit. It's genuinely capable — and it's built for desktop power users who'll invest in learning it.",
+      "DayOtter shares the time-protection instinct but takes a calmer approach: Otter proposes, you confirm — it never silently moves your calendar. And it's also a full booking-link and team-scheduling tool, at roughly a third of the price.",
+    ],
+    theirStrength:
+      "Motion's auto-scheduling engine is powerful, and for a solo power user drowning in tasks who wants the software to just decide, it can be a real force multiplier on desktop.",
+    rows: [
+      {
+        label: "Approach",
+        dayotter: "Confirm-first — you approve every change",
+        them: "Can silently reschedule",
+        edge: "us",
+      },
+      { label: "Price", dayotter: "Free / $9 seat", them: "~$19–29 / month", edge: "us" },
+      { label: "Learning curve", dayotter: "Minutes", them: "Weeks", edge: "us" },
+      {
+        label: "Booking links (let others book you)",
+        dayotter: "Yes",
+        them: "Limited",
+        edge: "us",
+      },
+      { label: "Team round-robin & routing", dayotter: "Yes", them: "Limited", edge: "us" },
+      { label: "Focus auto-scheduling", dayotter: "Yes", them: "Yes (core)", edge: "tie" },
+      {
+        label: "Mobile experience",
+        dayotter: "Web today, apps coming",
+        them: "Poorly rated",
+        edge: "tie",
+      },
+      { label: "Open source / self-host", dayotter: "Yes", them: "No", edge: "us" },
+    ],
+    whyUs: [
+      {
+        title: "It asks first",
+        body: "The scariest thing about auto-schedulers is waking up to a rearranged calendar. Otter proposes changes and waits for your OK — you're always in control.",
+      },
+      {
+        title: "Scheduling and booking in one",
+        body: "Motion is a personal planner. DayOtter also lets people book you, runs team round-robin, routing forms and group polls — one tool instead of two.",
+      },
+      {
+        title: "A fraction of the cost",
+        body: "Motion is ~$19–29/month. DayOtter is free for individuals and $9/seat for teams, with self-hosting free.",
+      },
+    ],
+    chooseThem:
+      "You're a solo desktop power user who wants software to aggressively auto-plan a heavy task load and you'll invest weeks to master it.",
+    chooseUs:
+      "You want focus protection that asks before it acts, plus booking links and team scheduling, without the price tag or the learning curve.",
+    faq: [
+      {
+        q: "Does DayOtter auto-schedule my tasks like Motion?",
+        a: "Otter finds and protects focus/task time for you — but it proposes and you confirm, rather than silently rearranging your day.",
+      },
+      {
+        q: "Is DayOtter cheaper than Motion?",
+        a: "Considerably. Free for individuals, $9/seat for teams, vs Motion's ~$19–29/month — and DayOtter also does booking links and team scheduling.",
+      },
+    ],
+  },
+  {
+    slug: "reclaim",
+    name: "Reclaim",
+    blurb: "Great focus defense — but Google-only, and it doesn't do booking links or teams.",
+    title: "DayOtter vs Reclaim",
+    subtitle:
+      "Reclaim pioneered defending focus time on Google Calendar. DayOtter does focus protection too — plus booking links, team scheduling, and an assistant you can just talk to, across every calendar.",
+    intro: [
+      "Reclaim is beloved for guarding deep work and habits on Google Calendar. If your whole life is in Google and you want smart focus blocks, it's a great fit.",
+      "DayOtter brings the same focus-defense instinct but isn't Google-only, and it's a full scheduling platform: booking pages, team round-robin, routing, polls — with Otter, a conversational assistant, tying it together.",
+    ],
+    theirStrength:
+      "Reclaim's habit and focus-time automation on Google Calendar is mature and thoughtful, with smart defense of recurring routines. For a Google-native solo user focused purely on protecting time, it's excellent.",
+    rows: [
+      { label: "Focus / deep-work protection", dayotter: "Yes", them: "Yes (core)", edge: "tie" },
+      { label: "Running-late overflow alerts", dayotter: "Yes", them: "No", edge: "us" },
+      {
+        label: "Calendars supported",
+        dayotter: "Google, Outlook, Apple, ICS",
+        them: "Google-first",
+        edge: "us",
+      },
+      { label: "Booking links (let others book you)", dayotter: "Yes", them: "Yes", edge: "tie" },
+      { label: "Team round-robin & routing", dayotter: "Yes", them: "Limited", edge: "us" },
+      {
+        label: "Conversational AI assistant",
+        dayotter: "Otter — chat, confirm-first",
+        them: "No",
+        edge: "us",
+      },
+      { label: "Open source / self-host", dayotter: "Yes", them: "No", edge: "us" },
+    ],
+    whyUs: [
+      {
+        title: "Not just Google",
+        body: "Reclaim is happiest on Google Calendar. DayOtter unifies Google, Outlook, Apple and ICS into one honest view of your time.",
+      },
+      {
+        title: "A whole scheduling platform",
+        body: "Beyond focus blocks, DayOtter does booking pages, team round-robin, routing forms and group polls — Reclaim is focused on defending your own time.",
+      },
+      {
+        title: "Just talk to it",
+        body: "Ask Otter to protect time, book a meeting or move your 3pm. Reclaim automates rules; DayOtter adds a conversational, confirm-first assistant on top.",
+      },
+    ],
+    chooseThem:
+      "You live entirely in Google Calendar and want a mature, focused tool purely for defending deep-work and habits.",
+    chooseUs:
+      "You want focus protection across every calendar, plus booking links and team scheduling, with an assistant you can talk to.",
+    faq: [
+      {
+        q: "Does DayOtter protect focus time like Reclaim?",
+        a: "Yes — Otter finds open time and holds it for deep work, and adds running-late alerts when meetings run over. It works across Google, Outlook and Apple, not just Google.",
+      },
+    ],
+  },
+];
+
+export function getComparison(slug: string): Comparison | undefined {
+  return COMPARISONS.find((c) => c.slug === slug);
+}

--- a/apps/web/lib/comparisons.ts
+++ b/apps/web/lib/comparisons.ts
@@ -317,6 +317,88 @@ export const COMPARISONS: Comparison[] = [
       },
     ],
   },
+  {
+    slug: "google-calendar",
+    name: "Google Calendar",
+    blurb: "Where your events live — but its booking is bare-bones, with no team routing or AI.",
+    title: "DayOtter vs Google Calendar",
+    subtitle:
+      "Google Calendar is the calendar. DayOtter is the scheduling layer on top — booking pages, team routing, focus protection and an assistant — working with your Google Calendar, not replacing it.",
+    intro: [
+      "Google Calendar is where most of us actually keep our time, and its built-in \"appointment schedules\" let people grab a slot. For one person with simple needs, that can be enough.",
+      "But the moment you need team round-robin, routing, reminders across channels, payments, or an assistant that protects your focus, you've outgrown it. DayOtter adds all of that — and syncs straight into the Google Calendar you already live in.",
+    ],
+    theirStrength:
+      "Google Calendar is free, everyone already has it, and it's rock-solid at the basics — events, invites, and simple one-person appointment booking inside the Google ecosystem.",
+    rows: [
+      {
+        label: "Where your events live",
+        dayotter: "Syncs with Google (+ Outlook, Apple)",
+        them: "Native",
+        edge: "tie",
+      },
+      {
+        label: "Booking pages",
+        dayotter: "Unlimited, branded, with intake",
+        them: "Basic appointment schedules",
+        edge: "us",
+      },
+      { label: "Team round-robin & routing", dayotter: "Yes, weighted", them: "None", edge: "us" },
+      {
+        label: "Reminders (SMS / Slack / WhatsApp)",
+        dayotter: "Yes",
+        them: "Email only",
+        edge: "us",
+      },
+      { label: "Payments to book", dayotter: "Yes (Stripe)", them: "No", edge: "us" },
+      { label: "Focus auto-scheduling", dayotter: "Yes", them: "None", edge: "us" },
+      {
+        label: "AI assistant",
+        dayotter: "Otter — chat, confirm-first",
+        them: "None",
+        edge: "us",
+      },
+      {
+        label: "Calendars supported",
+        dayotter: "Google, Outlook, Apple, ICS",
+        them: "Google only",
+        edge: "us",
+      },
+      { label: "Price", dayotter: "Free / $9 seat", them: "Free", edge: "tie" },
+    ],
+    whyUs: [
+      {
+        title: "It builds on Google, not against it",
+        body: "DayOtter reads and writes your Google Calendar, so everything stays in the calendar you already check. You gain booking pages, routing and an assistant without leaving it behind.",
+      },
+      {
+        title: "Real booking, not a bare slot picker",
+        body: "Branded pages, intake questions, buffers, multiple event types, cross-channel reminders and payments — the things Google's appointment schedules simply don't do.",
+      },
+      {
+        title: "A team tool, and an assistant",
+        body: "Weighted round-robin, routing forms and group polls for teams, plus Otter to book meetings and defend your focus time by chat, confirm-first.",
+      },
+    ],
+    chooseThem:
+      "You're one person, you only use Google, and simple appointment slots inside Google Calendar are all you'll ever need.",
+    chooseUs:
+      "You want proper booking pages, team routing, cross-channel reminders, payments and an AI assistant — layered on top of the Google Calendar you already use.",
+    faq: [
+      {
+        q: "Does DayOtter replace Google Calendar?",
+        a: "No — it works with it. Connect your Google account and DayOtter syncs both ways, so your bookings show up in the calendar you already use.",
+      },
+      {
+        q: "Isn't Google's appointment scheduling free?",
+        a: "It is, and it's fine for simple one-person booking. DayOtter adds team round-robin, routing, cross-channel reminders, payments and an AI assistant — and is still free for individuals.",
+      },
+      {
+        q: "Will my DayOtter bookings show in Google Calendar?",
+        a: "Yes. Every booking writes straight to your connected Google Calendar (or Outlook or Apple), with the video link attached.",
+      },
+    ],
+  },
 ];
 
 export function getComparison(slug: string): Comparison | undefined {

--- a/apps/web/lib/marketing.ts
+++ b/apps/web/lib/marketing.ts
@@ -33,6 +33,7 @@ export const FOOTER_COLUMNS: { title: string; links: FooterLink[] }[] = [
     links: [
       { label: "vs Calendly", href: "/vs/calendly" },
       { label: "vs Cal.com", href: "/vs/cal-com" },
+      { label: "vs Google Calendar", href: "/vs/google-calendar" },
       { label: "vs Motion", href: "/vs/motion" },
       { label: "vs Reclaim", href: "/vs/reclaim" },
       { label: "All comparisons", href: "/vs" },
@@ -43,6 +44,8 @@ export const FOOTER_COLUMNS: { title: string; links: FooterLink[] }[] = [
     links: [
       { label: "Founders", href: "/for/founders" },
       { label: "Teams", href: "/for/teams" },
+      { label: "Sales teams", href: "/for/sales" },
+      { label: "Agencies", href: "/for/agencies" },
       { label: "Consultants", href: "/for/consultants" },
       { label: "Recruiters", href: "/for/recruiters" },
     ],

--- a/apps/web/lib/marketing.ts
+++ b/apps/web/lib/marketing.ts
@@ -22,27 +22,38 @@ export const FOOTER_COLUMNS: { title: string; links: FooterLink[] }[] = [
   {
     title: "Product",
     links: [
-      { label: "Pricing", href: "/pricing" },
       { label: "Features", href: "/#features" },
+      { label: "Pricing", href: "/pricing" },
       { label: "How it works", href: "/#how" },
-      { label: "Mobile app", href: "/#mobile" },
       { label: "Changelog", href: "/changelog" },
     ],
   },
   {
-    title: "Developers",
+    title: "Compare",
     links: [
-      { label: "Documentation", href: "/docs" },
-      { label: "Self-hosting", href: "/self-hosting" },
-      { label: "Status", href: "/status" },
-      { label: "GitHub", href: BRAND.github, external: true },
+      { label: "vs Calendly", href: "/vs/calendly" },
+      { label: "vs Cal.com", href: "/vs/cal-com" },
+      { label: "vs Motion", href: "/vs/motion" },
+      { label: "vs Reclaim", href: "/vs/reclaim" },
+      { label: "All comparisons", href: "/vs" },
     ],
   },
   {
-    title: "Company",
+    title: "For",
     links: [
-      { label: "About", href: "/about" },
+      { label: "Founders", href: "/for/founders" },
+      { label: "Teams", href: "/for/teams" },
+      { label: "Consultants", href: "/for/consultants" },
+      { label: "Recruiters", href: "/for/recruiters" },
+    ],
+  },
+  {
+    title: "Resources",
+    links: [
+      { label: "Docs", href: "/docs" },
+      { label: "Self-hosting", href: "/self-hosting" },
       { label: "Blog", href: "/blog" },
+      { label: "About", href: "/about" },
       { label: "Contact", href: "/contact" },
     ],
   },
@@ -52,7 +63,7 @@ export const FOOTER_COLUMNS: { title: string; links: FooterLink[] }[] = [
       { label: "Privacy", href: "/privacy" },
       { label: "Terms", href: "/terms" },
       { label: "Security", href: "/security" },
-      { label: "License", href: BRAND.githubLicense, external: true },
+      { label: "Status", href: "/status" },
     ],
   },
 ];
@@ -61,6 +72,7 @@ export const FOOTER_COLUMNS: { title: string; links: FooterLink[] }[] = [
 export const MARKETING_NAV: FooterLink[] = [
   { label: "Features", href: "/#features" },
   { label: "Pricing", href: "/pricing" },
+  { label: "Compare", href: "/vs" },
   { label: "Blog", href: "/blog" },
   { label: "Docs", href: "/docs" },
 ];

--- a/apps/web/lib/personas.ts
+++ b/apps/web/lib/personas.ts
@@ -236,6 +236,118 @@ export const PERSONAS: Persona[] = [
       },
     ],
   },
+  {
+    slug: "agencies",
+    label: "Agencies",
+    title: "Client scheduling that doesn't eat your billable hours.",
+    subtitle:
+      "Let clients book the right person on your team, keep every account's meetings straight, and hand the back-and-forth to Otter — so your hours go to the work, not the calendar.",
+    problems: [
+      {
+        title: "Booking eats billable time",
+        body: "Every client call starts with a scheduling thread. Multiply that across accounts and it's days a month you can't invoice.",
+      },
+      {
+        title: "Clients reach the wrong person",
+        body: "A new-business enquiry and a project check-in hit the same link, so the wrong person fields the wrong call.",
+      },
+      {
+        title: "Every account juggles its own calendar",
+        body: "Account leads, designers and devs each have their own availability, and lining them up for a client review is a puzzle.",
+      },
+    ],
+    solutions: [
+      {
+        title: "One link, routed to the right team",
+        body: "A short routing form sends new business, support and project calls to the right person or pod automatically.",
+      },
+      {
+        title: "Weighted round-robin across the team",
+        body: "Spread discovery calls fairly across account managers, weight your leads, and pause anyone at capacity.",
+      },
+      {
+        title: "Collective booking for reviews",
+        body: "Find a slot that works for the client and everyone on the project in one go, across all your calendars.",
+      },
+      {
+        title: "Otter runs the back-and-forth",
+        body: '"Move the Acme review to Thursday." Otter finds the time and reschedules — you confirm and get back to the work.',
+      },
+    ],
+    steps: [
+      "Add your team and connect everyone's calendars.",
+      "Build a routing form and set round-robin weights per pod.",
+      "Share one link — clients book the right person, every time.",
+    ],
+    faq: [
+      {
+        q: "Can different clients book different people?",
+        a: "Yes — a routing form asks a question or two and sends each client to the right account lead, pod or event type.",
+      },
+      {
+        q: "Does it handle our whole team's availability?",
+        a: "Yes. Collective and round-robin booking look across every connected calendar, so client meetings only land when the right people are actually free.",
+      },
+    ],
+  },
+  {
+    slug: "sales",
+    label: "Sales teams",
+    title: "Turn inbound into booked meetings — instantly, on the right rep.",
+    subtitle:
+      "Qualify and route leads the moment they land, distribute meetings fairly with weighted round-robin, and cut the no-shows — so your pipeline moves faster.",
+    problems: [
+      {
+        title: "Speed-to-lead is killing you",
+        body: "A lead fills a form, then waits for a rep to email back. By the time you reply, they've cooled — or booked a competitor.",
+      },
+      {
+        title: "Leads land on the wrong rep",
+        body: "Enterprise and SMB hit the same link, so your closers spend time on deals that were never theirs.",
+      },
+      {
+        title: "Round-robin isn't really fair",
+        body: "Meetings get spread evenly whether or not that's right — you can't book your top closers more or pause someone who's out.",
+      },
+    ],
+    solutions: [
+      {
+        title: "Qualify and book on the spot",
+        body: "A routing form scores the lead and drops them straight onto the right rep's live availability — no reply-and-wait.",
+      },
+      {
+        title: "Weighted round-robin",
+        body: "Send more meetings to your best closers, weight by territory or segment, and pause anyone who's away — always load-balanced.",
+      },
+      {
+        title: "Fewer no-shows",
+        body: "Automated reminders over email, SMS and Slack — plus optional deposits — keep booked meetings booked.",
+      },
+      {
+        title: "Wired into your stack",
+        body: "Push every booking to your tools with webhooks and our API, so the rest of your stack stays in sync.",
+      },
+    ],
+    steps: [
+      "Build a routing form that qualifies inbound.",
+      "Set round-robin weights across your reps.",
+      "Share the link — qualified leads book the right rep instantly.",
+    ],
+    faq: [
+      {
+        q: "How fast can a lead book after filling the form?",
+        a: "Immediately — the routing form sends a qualified lead straight to the right rep's live availability, so there's no reply-and-wait gap.",
+      },
+      {
+        q: "Can I weight meetings toward my best reps?",
+        a: "Yes — each rep has a weight you can tune by performance, territory or segment, and set to zero to pause anyone who's out.",
+      },
+      {
+        q: "Does it connect to our CRM?",
+        a: "You can push every booking to your stack today via webhooks and our API. Native Salesforce and HubSpot sync is on our roadmap.",
+      },
+    ],
+  },
 ];
 
 export function getPersona(slug: string): Persona | undefined {

--- a/apps/web/lib/personas.ts
+++ b/apps/web/lib/personas.ts
@@ -1,0 +1,243 @@
+/**
+ * Audience ("for X") landing content, rendered at /for/[slug]. Same template
+ * for each persona: the pain they feel, how DayOtter fits, how it works, an FAQ.
+ * Tailor the language to the reader — name their specific problem plainly.
+ */
+
+export interface Persona {
+  slug: string;
+  /** Short label for nav/cards, e.g. "Founders". */
+  label: string;
+  title: string;
+  subtitle: string;
+  /** Why generic scheduling fails this person — 3 concrete pains. */
+  problems: { title: string; body: string }[];
+  /** Why DayOtter fits — 4 tailored capabilities. */
+  solutions: { title: string; body: string }[];
+  /** Three plain steps. */
+  steps: string[];
+  faq: { q: string; a: string }[];
+}
+
+export const PERSONAS: Persona[] = [
+  {
+    slug: "founders",
+    label: "Founders",
+    title: "The scheduling assistant for founders who'd rather build than book.",
+    subtitle:
+      "Talk your week into place, protect deep work, and let investors and candidates book you — without the calendar becoming a second job.",
+    problems: [
+      {
+        title: "Calendar admin is a tax you don't notice",
+        body: "Five minutes here, ten there — by Friday you've spent an hour tending tools instead of talking to customers.",
+      },
+      {
+        title: "Deep work keeps getting eaten",
+        body: "Meetings creep in and the real work never gets a block. By end of week you're not sure where the time went.",
+      },
+      {
+        title: "The back-and-forth never ends",
+        body: '"Does Tuesday work?" "How about Thursday?" Every intro call costs three emails you don\'t have time for.',
+      },
+    ],
+    solutions: [
+      {
+        title: "Say it, Otter books it",
+        body: '"Investor call Tuesday 2pm, 45 minutes." One line, one confirm. Otter drafts it and never touches your calendar without your OK.',
+      },
+      {
+        title: "Deep work, defended",
+        body: "Ask Otter to hold two hours a morning for building — it treats them as real events, not soft suggestions.",
+      },
+      {
+        title: "One link for everyone",
+        body: "Share a booking page so candidates, investors and customers grab a slot themselves — buffers and video links included.",
+      },
+      {
+        title: "Free, and yours",
+        body: "Free for you, $9/seat when the team grows, and open-source if you'd rather self-host. No enterprise sales call.",
+      },
+    ],
+    steps: [
+      "Connect Google, Outlook or iCloud — Otter learns when you're actually free.",
+      "Tell Otter what to hold and share your booking link.",
+      "Confirm the drafts. Get back to building.",
+    ],
+    faq: [
+      {
+        q: "Will it move my calendar around on its own?",
+        a: "Never. Otter proposes; you approve. Nothing changes without your confirmation.",
+      },
+      {
+        q: "Is it really free for a solo founder?",
+        a: "Yes — unlimited event types, calendar sync, group polls and reminders, free forever. Pay only when you add teammates.",
+      },
+    ],
+  },
+  {
+    slug: "teams",
+    label: "Teams",
+    title: "Scheduling your whole team can actually run on.",
+    subtitle:
+      "Round-robin that's fair, routing that sends people to the right person, and shared availability — without a per-seat tax that punishes growth.",
+    problems: [
+      {
+        title: "Round-robin isn't really fair",
+        body: "Most tools spread meetings evenly whether or not that's what you want. You can't weight your senior reps or pause someone who's out.",
+      },
+      {
+        title: "Inbound lands on the wrong desk",
+        body: "Enterprise leads and quick questions hit the same link, so the wrong person spends time on the wrong meeting.",
+      },
+      {
+        title: "Team scheduling costs a fortune",
+        body: "The features you actually need sit behind $16–20/seat tiers that get expensive the moment you grow.",
+      },
+    ],
+    solutions: [
+      {
+        title: "Weighted round-robin",
+        body: "Distribute meetings by weight — book your closers more, pause anyone who's away — and it stays load-balanced automatically.",
+      },
+      {
+        title: "Routing forms",
+        body: "Ask a couple of questions up front, then send each visitor to the right person or event type. No lead lands in the wrong place.",
+      },
+      {
+        title: "Collective & shared availability",
+        body: "Find a time everyone's free for panels and group calls, across every connected calendar.",
+      },
+      {
+        title: "Fair pricing",
+        body: "$9/seat for the whole toolkit — half of Calendly — or self-host every feature for free.",
+      },
+    ],
+    steps: [
+      "Add your team and connect everyone's calendars.",
+      "Set weights, build a routing form, share the link.",
+      "Meetings land on the right person, every time.",
+    ],
+    faq: [
+      {
+        q: "Can I weight round-robin or pause someone?",
+        a: "Yes. Each member has a weight you can change any time; set it to 0 to pause them from the rotation.",
+      },
+      {
+        q: "How does routing decide where a booking goes?",
+        a: 'You write simple rules — "if they pick Enterprise, send them to sales" — checked top to bottom, with a fallback. It\'s all no-code.',
+      },
+    ],
+  },
+  {
+    slug: "consultants",
+    label: "Consultants & coaches",
+    title: "Booking, rescheduling and payments — handled, so you can do the work.",
+    subtitle:
+      "Let clients book recurring sessions, take payment up front, and let Otter handle the reschedules — all on a page that looks like you.",
+    problems: [
+      {
+        title: "Recurring clients, manual booking",
+        body: "Standing weekly sessions mean re-booking the same slot over and over, and chasing anyone who drifts.",
+      },
+      {
+        title: "No-shows and late payers",
+        body: "Free bookings get flaky. Without a deposit, a missed session is just lost income.",
+      },
+      {
+        title: "The reschedule shuffle",
+        body: '"Can we move to Thursday?" turns into a thread — and sometimes a double-booking.',
+      },
+    ],
+    solutions: [
+      {
+        title: "Recurring sessions in one booking",
+        body: "Offer a weekly or biweekly series — one confirmation books the whole run, on your calendar and theirs.",
+      },
+      {
+        title: "Take payment to book",
+        body: "Charge the full price or a deposit through Stripe before a slot is held. Fewer no-shows, paid up front.",
+      },
+      {
+        title: "Otter handles the changes",
+        body: '"Move my 3pm to Thursday." Otter finds the slot and reschedules — you just confirm.',
+      },
+      {
+        title: "A page that's yours",
+        body: "Your name, your colour, your intake questions, your buffers. Calm and professional, not a generic form.",
+      },
+    ],
+    steps: [
+      "Create a booking type — set duration, price and whether it recurs.",
+      "Share your link; clients book (and pay) themselves.",
+      "Let Otter handle reschedules and reminders.",
+    ],
+    faq: [
+      {
+        q: "Can clients book a recurring series?",
+        a: "Yes — mark a booking type as recurring (weekly, biweekly or monthly) and one booking schedules the whole series.",
+      },
+      {
+        q: "Can I charge for sessions?",
+        a: "Yes — connect Stripe and require full payment or a deposit before a booking is confirmed.",
+      },
+    ],
+  },
+  {
+    slug: "recruiters",
+    label: "Recruiters",
+    title: "Interview scheduling without the coordination headache.",
+    subtitle:
+      "Route candidates to the right interviewer, find a time across a panel, and share one link — so hiring loops move in hours, not days.",
+    problems: [
+      {
+        title: "Panel scheduling is a puzzle",
+        body: "Finding one slot that works for three interviewers and a candidate can take a dozen messages.",
+      },
+      {
+        title: "Candidates hit the wrong interviewer",
+        body: "A backend role and a design role share the same link, so people land with the wrong person.",
+      },
+      {
+        title: "Loops stall over timezones",
+        body: "Candidate in one timezone, panel in another — and every reschedule risks a double-booking.",
+      },
+    ],
+    solutions: [
+      {
+        title: "Group polls to find a time",
+        body: "Propose a few slots, let the panel and candidate vote, and lock in the winner — no back-and-forth thread.",
+      },
+      {
+        title: "Routing to the right interviewer",
+        body: "A short form sends each candidate to the right role and interviewer automatically.",
+      },
+      {
+        title: "Weighted round-robin",
+        body: "Spread first-round screens fairly across your team, weighted and load-balanced, pausing anyone who's out.",
+      },
+      {
+        title: "Timezone-safe by default",
+        body: "Every candidate sees times in their own timezone; you never do the mental math.",
+      },
+    ],
+    steps: [
+      "Set up interviewers, routing and round-robin weights.",
+      "Share the link — or send a poll for panel loops.",
+      "Confirm; everyone gets the invite and reminders.",
+    ],
+    faq: [
+      {
+        q: "How do I schedule a panel interview?",
+        a: "Use a group poll: propose a few times, the panel and candidate vote, and you finalize the most-supported slot into a booking.",
+      },
+      {
+        q: "Can I route candidates by role?",
+        a: "Yes — a routing form asks a question or two and sends each candidate to the right interviewer or event type.",
+      },
+    ],
+  },
+];
+
+export function getPersona(slug: string): Persona | undefined {
+  return PERSONAS.find((p) => p.slug === slug);
+}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -107,8 +107,30 @@ sudo certbot --nginx -d dayotter.com -d www.dayotter.com
 sudo certbot renew --dry-run
 ```
 
-Open **https://dayotter.com**. To update later: `git -C .. pull` then re-run the
-Step 3 `up -d --build` command.
+Open **https://dayotter.com**.
+
+### Redeploying / updating
+
+Do **not** just re-run `up -d --build`: `docker compose up -d` reuses the already
+completed one-shot `migrate` container instead of re-running it, so new app code
+can boot against an un-migrated database (missing columns → 500s everywhere).
+
+Use the script, which always builds, then runs a **fresh** migration one-shot,
+then (re)starts the stack — in that order:
+
+```bash
+git -C .. pull
+./deploy.sh          # build → run --rm migrate → up -d
+```
+
+Or run the equivalent by hand from `deploy/` (add `-f docker-compose.nginx.yml`
+when using the host-nginx overlay):
+
+```bash
+docker compose -f docker-compose.prod.yml --env-file .env build web worker
+docker compose -f docker-compose.prod.yml --env-file .env run --rm migrate
+docker compose -f docker-compose.prod.yml --env-file .env up -d
+```
 
 > Prefer to reuse an existing managed/Supabase Postgres instead of the bundled
 > one? Set `DATABASE_URL=postgresql://user:pass@host:5432/dayotter` in

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Build → migrate → (re)start the DayOtter stack, in that order.
+#
+# Why this exists: `docker compose up -d` REUSES the already-completed one-shot
+# `migrate` container instead of re-running it, so a plain redeploy can start new
+# app code against an un-migrated database — 500s everywhere. This script always
+# runs `run --rm migrate` (a fresh one-shot) before starting the app, so pending
+# migrations are guaranteed to apply. If a migration fails, the script stops
+# before touching the running app.
+#
+# Usage (from the repo root or the deploy/ dir):
+#   ./deploy/deploy.sh
+#
+set -euo pipefail
+cd "$(dirname "$0")"
+
+if [ ! -f .env ]; then
+  echo "error: deploy/.env not found. Copy .env.example and fill it in." >&2
+  exit 1
+fi
+
+FILES=(-f docker-compose.prod.yml)
+# Host-nginx deploys add the overlay (disables the bundled Caddy). Auto-detect it.
+if [ -f docker-compose.nginx.yml ]; then
+  FILES+=(-f docker-compose.nginx.yml)
+fi
+DC=(docker compose "${FILES[@]}" --env-file .env)
+
+echo "==> Building images"
+"${DC[@]}" build web worker
+
+echo "==> Applying database migrations (fresh one-shot)"
+"${DC[@]}" run --rm migrate
+
+echo "==> Starting / updating services"
+"${DC[@]}" up -d
+
+echo "==> Status"
+"${DC[@]}" ps
+
+echo "==> Done. Sanity-check the app:"
+echo "    curl -I http://127.0.0.1:3000"

--- a/scripts/feature-graphic.mjs
+++ b/scripts/feature-graphic.mjs
@@ -1,0 +1,67 @@
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import sharp from "sharp";
+
+const root = join(homedir(), "dayotter", "apps", "web", "public", "brand");
+const otter = readFileSync(join(root, "illustrations", "otter-plan.png")).toString("base64");
+
+// 1024x500 Google Play feature graphic. Text kept left, otter right, brand glow
+// behind it. Rendered from SVG, then flattened to a 24-bit PNG (no alpha).
+const svg = `
+<svg width="1024" height="500" viewBox="0 0 1024 500" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#191327"/>
+      <stop offset="1" stop-color="#0e0a16"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="74%" cy="52%" r="52%">
+      <stop offset="0" stop-color="#6743e6" stop-opacity="0.60"/>
+      <stop offset="1" stop-color="#6743e6" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="glow2" cx="6%" cy="8%" r="42%">
+      <stop offset="0" stop-color="#6743e6" stop-opacity="0.20"/>
+      <stop offset="1" stop-color="#6743e6" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="1024" height="500" fill="url(#bg)"/>
+  <rect width="1024" height="500" fill="url(#glow)"/>
+  <rect width="1024" height="500" fill="url(#glow2)"/>
+
+  <!-- faint dotted grid, subtle texture -->
+  <g fill="#ffffff" opacity="0.05">
+    ${Array.from({ length: 6 })
+      .flatMap((_, r) =>
+        Array.from({ length: 9 }).map((__, c) => `<circle cx="${70 + c * 60}" cy="${70 + r * 70}" r="2"/>`),
+      )
+      .join("")}
+  </g>
+
+  <!-- otter, right side, with a soft plate behind it -->
+  <ellipse cx="800" cy="255" rx="215" ry="215" fill="#6743e6" opacity="0.14"/>
+  <image x="618" y="55" width="360" height="360" preserveAspectRatio="xMidYMid meet"
+    href="data:image/png;base64,${otter}"/>
+
+  <!-- copy -->
+  <text x="82" y="150" font-family="Helvetica, Arial, sans-serif" font-size="19"
+    letter-spacing="4" font-weight="600" fill="#a892ff">AI SCHEDULING ASSISTANT</text>
+  <text x="80" y="248" font-family="Helvetica, Arial, sans-serif" font-size="86"
+    font-weight="700" fill="#ffffff" letter-spacing="-2">DayOtter</text>
+  <rect x="84" y="276" width="60" height="4" rx="2" fill="#6743e6"/>
+  <text x="82" y="330" font-family="Helvetica, Arial, sans-serif" font-size="31"
+    font-weight="500" fill="#e7e3f2">Scheduling that respects</text>
+  <text x="82" y="372" font-family="Helvetica, Arial, sans-serif" font-size="31"
+    font-weight="500" fill="#e7e3f2">your time.</text>
+  <text x="82" y="430" font-family="Helvetica, Arial, sans-serif" font-size="22"
+    font-weight="400" fill="#9a90b5">Book meetings, protect focus, done for you.</text>
+</svg>`;
+
+const out = join(homedir(), "DayOtter-feature-graphic.png");
+await sharp(Buffer.from(svg))
+  .resize(1024, 500)
+  .flatten({ background: "#0e0a16" }) // drop alpha → 24-bit
+  .png({ compressionLevel: 9 })
+  .toFile(out);
+
+const meta = await sharp(out).metadata();
+console.log(`wrote ${out} — ${meta.width}x${meta.height}, channels=${meta.channels}, alpha=${meta.hasAlpha}`);

--- a/scripts/play-normalize.mjs
+++ b/scripts/play-normalize.mjs
@@ -1,0 +1,38 @@
+// Normalize raw phone screenshots to Google Play-compliant phone screenshots.
+//
+// Play rules: PNG/JPEG, each side 320–3840px, long:short ratio must not exceed
+// 2:1. Raw captures here are 1080x2376 (2.2:1) — over the limit. We letterbox
+// each onto a 1080x2160 (exactly 2:1) canvas in the app's cream background so no
+// content is cropped, and strip alpha.
+import sharp from "sharp";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const BG = { r: 0xfa, g: 0xf9, b: 0xf6 }; // #FAF9F6 app background
+const CANVAS_W = 1080;
+const CANVAS_H = 2160;
+
+const inDir = join(homedir(), "play-shots-raw");
+const outDir = join(homedir(), "play-screenshots-final");
+mkdirSync(outDir, { recursive: true });
+
+// Ordered so the AI hero leads.
+const files = [
+  ["06-confirm.png", "1-ask-dayotter.png"],
+  ["01-home.png", "2-home.png"],
+  ["02-events.png", "3-booking-types.png"],
+  ["04-settings.png", "4-settings.png"],
+];
+
+for (const [src, dst] of files) {
+  const resized = await sharp(join(inDir, src))
+    .resize(CANVAS_W, CANVAS_H, { fit: "contain", background: BG })
+    .flatten({ background: BG })
+    .png()
+    .toBuffer();
+  await sharp(resized).toFile(join(outDir, dst));
+  const meta = await sharp(join(outDir, dst)).metadata();
+  console.log(`${dst}  ${meta.width}x${meta.height}  alpha=${meta.hasAlpha}`);
+}
+console.log("\nWrote to", outDir);

--- a/scripts/play-screenshots.mjs
+++ b/scripts/play-screenshots.mjs
@@ -1,0 +1,39 @@
+import { existsSync, mkdirSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import sharp from "sharp";
+
+// Normalize phone screenshots to Google Play's spec: 9:16 (portrait) or 16:9
+// (landscape), 1080x1920 / 1920x1080, 24-bit PNG (no alpha). "cover" keeps the
+// content's aspect and center-crops the excess (e.g. trims the 20:9 status/nav
+// bars) rather than squashing or letterboxing.
+const inDir = join(homedir(), "play-screenshots-in");
+const outDir = join(homedir(), "play-screenshots-out");
+if (!existsSync(inDir)) {
+  mkdirSync(inDir, { recursive: true });
+  console.log(`Created ${inDir}. Drop your phone screenshots (PNG/JPG) in there and re-run.`);
+  process.exit(0);
+}
+mkdirSync(outDir, { recursive: true });
+
+const files = readdirSync(inDir).filter((f) => /\.(png|jpe?g)$/i.test(f));
+if (files.length === 0) {
+  console.log(`No images in ${inDir}. Add 2–8 phone screenshots and re-run.`);
+  process.exit(0);
+}
+
+let i = 0;
+for (const f of files.sort()) {
+  const meta = await sharp(join(inDir, f)).metadata();
+  const portrait = (meta.height ?? 0) >= (meta.width ?? 0);
+  const [w, h] = portrait ? [1080, 1920] : [1920, 1080];
+  i += 1;
+  const out = join(outDir, `screenshot-${String(i).padStart(2, "0")}.png`);
+  await sharp(join(inDir, f))
+    .resize(w, h, { fit: "cover", position: "center" })
+    .flatten({ background: "#ffffff" })
+    .png()
+    .toFile(out);
+  console.log(`${f}  ->  ${out}  (${w}x${h})`);
+}
+console.log(`\nDone. ${i} Play-ready screenshot(s) in ${outDir}. Upload 2–8 of them.`);


### PR DESCRIPTION
Ships the work built after PR #13 was merged (main was still on an earlier state).

## Mobile (the reason to ship)
- **Fix white screen on launch** — disable New Architecture (`newArchEnabled: false`); it was crashing on boot (`Bridgeless` incompatibility). Verified on-device: boots to signed-in home, zero ReactNativeJS errors.
- **Enable Google sign-in** — set `EXPO_PUBLIC_GOOGLE_AUTH=1` across EAS build profiles (button was hidden because the flag was never set).
- Point `ios`/`android` npm scripts at `expo run:*` for local native builds.

## Deploy hardening
- `deploy/deploy.sh`: build → `run --rm migrate` → `up -d`, so a **fresh migration one-shot runs on every redeploy**. A plain `up -d` reuses the completed migrate container and boots new code against an un-migrated DB (root cause of the recent prod 500s).
- Document the redeploy sequence in `deploy/README.md`.

## Marketing content (planif.ai-inspired)
- Home rewrite (lead with Otter, warmer voice, before/after) + **home FAQ** section.
- `/vs/*` comparison pages (Calendly, Cal.com, **Google Calendar**, Motion, Reclaim).
- `/for/*` persona pages (founders, teams, **sales**, **agencies**, consultants, recruiters).
- Legal: disclose Otter/AI data handling + subprocessors; add cookies + AI terms.
- Soften pricing FAQ: SSO + custom booking domains framed as "on the way" (SSO is a hosted stub today).

## Play Store assets
- Scripts for the feature graphic + screenshot normalizer (1080×2160, 2:1-compliant).

Typecheck passes; new pages verified rendering in the dev preview.