### PR TITLE
Host packages manager + 'Ask Otter by text' number registration

### DIFF
--- a/apps/web/app/(app)/settings/notifications/page.tsx
+++ b/apps/web/app/(app)/settings/notifications/page.tsx
@@ -1,4 +1,5 @@
 import { NotificationChannelsForm } from "@/components/notification-channels-form";
+import { OtterTextPanel } from "@/components/otter-text-panel";
 import { getSession } from "@/lib/auth/session";
 import { maskChannel } from "@/lib/notifications/channel-input";
 import { decryptJson } from "@dayotter/core";
@@ -10,10 +11,23 @@ export const dynamic = "force-dynamic";
 
 export default async function NotificationsSettingsPage() {
   const session = await getSession();
-  const rows = await getDb().query.notificationChannels.findMany({
-    where: eq(schema.notificationChannels.userId, session!.user.id),
-    orderBy: asc(schema.notificationChannels.createdAt),
-  });
+  const [rows, user] = await Promise.all([
+    getDb().query.notificationChannels.findMany({
+      where: eq(schema.notificationChannels.userId, session!.user.id),
+      orderBy: asc(schema.notificationChannels.createdAt),
+    }),
+    getDb().query.users.findFirst({
+      where: eq(schema.users.id, session!.user.id),
+      columns: { phoneNumber: true, phoneNumberVerified: true },
+    }),
+  ]);
+
+  // The public Otter texting number (the Twilio SMS/WhatsApp number users text).
+  const otterNumber =
+    process.env.OTTER_SMS_NUMBER ??
+    process.env.TWILIO_SMS_FROM ??
+    process.env.TWILIO_WHATSAPP_FROM ??
+    null;
 
   const channels = rows.map((c) => {
     let label: string = c.type;
@@ -34,5 +48,14 @@ export default async function NotificationsSettingsPage() {
     };
   });
 
-  return <NotificationChannelsForm initialChannels={channels} available={availableChannels()} />;
+  return (
+    <div className="flex flex-col gap-6">
+      <OtterTextPanel
+        phoneNumber={user?.phoneNumber ?? null}
+        verified={user?.phoneNumberVerified ?? false}
+        otterNumber={otterNumber?.replace(/^whatsapp:/, "") ?? null}
+      />
+      <NotificationChannelsForm initialChannels={channels} available={availableChannels()} />
+    </div>
+  );
 }

--- a/apps/web/app/(app)/settings/packages/page.tsx
+++ b/apps/web/app/(app)/settings/packages/page.tsx
@@ -1,0 +1,19 @@
+import { PackagesManager } from "@/components/packages-manager";
+import { getSession } from "@/lib/auth/session";
+import { and, asc, eq, getDb, schema } from "@dayotter/db";
+
+export const dynamic = "force-dynamic";
+
+export default async function PackagesSettingsPage() {
+  const session = await getSession();
+  const eventTypes = await getDb().query.eventTypes.findMany({
+    where: and(
+      eq(schema.eventTypes.ownerId, session!.user.id),
+      eq(schema.eventTypes.isActive, true),
+    ),
+    columns: { id: true, title: true },
+    orderBy: asc(schema.eventTypes.title),
+  });
+
+  return <PackagesManager eventTypes={eventTypes.map((e) => ({ id: e.id, title: e.title }))} />;
+}

--- a/apps/web/components/nav-items.ts
+++ b/apps/web/components/nav-items.ts
@@ -44,6 +44,7 @@ export const SETTINGS_NAV = [
   { href: "/settings/notifications", label: "Notifications" },
   { href: "/settings/automations", label: "Automations" },
   { href: "/settings/workflows", label: "Workflows" },
+  { href: "/settings/packages", label: "Packages" },
   { href: "/settings/calendars", label: "Calendars" },
   { href: "/settings/billing", label: "Billing" },
   { href: "/settings/developer", label: "Developer" },

--- a/apps/web/components/otter-text-panel.tsx
+++ b/apps/web/components/otter-text-panel.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardBody } from "@/components/ui/card";
+import { FormError } from "@/components/ui/form";
+import { Input, Label } from "@/components/ui/input";
+import { authClient } from "@/lib/auth/auth-client";
+import { MessageSquare } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+const phoneAuthEnabled = process.env.NEXT_PUBLIC_PHONE_AUTH === "1";
+
+/**
+ * "Ask Otter by text" — register/verify the phone number that inbound WhatsApp/
+ * SMS messages are matched to (users.phone_number). Verifying uses the same OTP
+ * flow as phone sign-in; on an active session it attaches the number to this
+ * account.
+ */
+export function OtterTextPanel({
+  phoneNumber,
+  verified,
+  otterNumber,
+}: {
+  phoneNumber: string | null;
+  verified: boolean;
+  otterNumber: string | null;
+}) {
+  const router = useRouter();
+  const [step, setStep] = useState<"idle" | "phone" | "code">("idle");
+  const [phone, setPhone] = useState(phoneNumber ?? "");
+  const [code, setCode] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const registered = Boolean(phoneNumber) && verified;
+
+  async function sendCode(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    const { error } = await authClient.phoneNumber.sendOtp({ phoneNumber: phone.trim() });
+    setLoading(false);
+    if (error) {
+      setError(error.message ?? "Couldn't send a code to that number. Check it and try again.");
+      return;
+    }
+    setStep("code");
+  }
+
+  async function verify(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    const { error } = await authClient.phoneNumber.verify({
+      phoneNumber: phone.trim(),
+      code: code.trim(),
+    });
+    setLoading(false);
+    if (error) {
+      setError(error.message ?? "That code didn't match. Request a new one and try again.");
+      return;
+    }
+    setStep("idle");
+    setCode("");
+    router.refresh();
+  }
+
+  return (
+    <Card className="max-w-2xl">
+      <CardBody className="p-6">
+        <div className="flex items-center gap-2">
+          <MessageSquare size={18} className="text-[var(--color-accent)]" />
+          <h2 className="text-lg font-semibold">Ask Otter by text</h2>
+        </div>
+        <p className="mt-1.5 text-sm text-[var(--color-muted)]">
+          Text Otter to book, reschedule, or check your day over WhatsApp and SMS — confirm-first,
+          just like in the app.
+        </p>
+
+        {registered ? (
+          <div className="mt-4 rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface-2)] p-4 text-sm">
+            <p>
+              <span className="font-medium text-[var(--color-accent)]">✓ Registered.</span>{" "}
+              <span className="text-[var(--color-muted)]">{phoneNumber}</span>
+            </p>
+            {otterNumber ? (
+              <p className="mt-1 text-[var(--color-muted)]">
+                Text Otter at{" "}
+                <span className="font-medium text-[var(--color-text)]">{otterNumber}</span>.
+              </p>
+            ) : (
+              <p className="mt-1 text-[var(--color-faint)]">
+                Your host needs to set the Otter texting number to finish setup.
+              </p>
+            )}
+          </div>
+        ) : !phoneAuthEnabled ? (
+          <p className="mt-4 rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface-2)] p-4 text-sm text-[var(--color-muted)]">
+            Texting Otter needs phone support enabled on this server (Twilio). Ask your admin to
+            turn it on.
+          </p>
+        ) : step === "idle" ? (
+          <Button type="button" className="mt-4" onClick={() => setStep("phone")}>
+            {phoneNumber ? "Verify your number" : "Register a number"}
+          </Button>
+        ) : step === "phone" ? (
+          <form onSubmit={sendCode} className="mt-4 space-y-3">
+            <div>
+              <Label htmlFor="otter-phone">Phone number</Label>
+              <Input
+                id="otter-phone"
+                type="tel"
+                inputMode="tel"
+                autoComplete="tel"
+                required
+                value={phone}
+                onChange={(e) => setPhone(e.target.value)}
+                placeholder="+14155551234"
+              />
+              <p className="mt-1.5 text-xs text-[var(--color-faint)]">
+                Include your country code. We'll text you a one-time code.
+              </p>
+            </div>
+            <FormError>{error}</FormError>
+            <Button type="submit" disabled={loading}>
+              {loading ? "Sending code…" : "Send code"}
+            </Button>
+          </form>
+        ) : (
+          <form onSubmit={verify} className="mt-4 space-y-3">
+            <div>
+              <Label htmlFor="otter-otp">Enter the code</Label>
+              <Input
+                id="otter-otp"
+                type="text"
+                inputMode="numeric"
+                autoComplete="one-time-code"
+                required
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                placeholder="123456"
+              />
+              <p className="mt-1.5 text-xs text-[var(--color-faint)]">
+                Sent to {phone}.{" "}
+                <button
+                  type="button"
+                  onClick={() => {
+                    setStep("phone");
+                    setCode("");
+                    setError(null);
+                  }}
+                  className="text-[var(--color-accent)] hover:underline"
+                >
+                  Change number
+                </button>
+              </p>
+            </div>
+            <FormError>{error}</FormError>
+            <Button type="submit" disabled={loading}>
+              {loading ? "Verifying…" : "Verify"}
+            </Button>
+          </form>
+        )}
+      </CardBody>
+    </Card>
+  );
+}

--- a/apps/web/components/packages-manager.tsx
+++ b/apps/web/components/packages-manager.tsx
@@ -1,0 +1,288 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardBody } from "@/components/ui/card";
+import { FormError } from "@/components/ui/form";
+import { Input, Label } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
+import { useCallback, useEffect, useState } from "react";
+
+interface EventTypeOpt {
+  id: string;
+  title: string;
+}
+interface PackageRow {
+  id: string;
+  eventTypeId: string;
+  name: string;
+  sessionCount: number;
+  priceAmount: number;
+  currency: string;
+  isActive: boolean;
+}
+interface CreditRow {
+  id: string;
+  eventTypeId: string;
+  clientEmail: string;
+  total: number;
+  used: number;
+  remaining: number;
+}
+
+function money(minor: number, currency: string): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: currency.toUpperCase(),
+  }).format(minor / 100);
+}
+
+/**
+ * Host-facing management for prepaid session packages: create offerings tied to
+ * an event type, see outstanding client balances, and grant credits manually
+ * (for clients who paid offline).
+ */
+export function PackagesManager({ eventTypes }: { eventTypes: EventTypeOpt[] }) {
+  const [packages, setPackages] = useState<PackageRow[]>([]);
+  const [credits, setCredits] = useState<CreditRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Create-offering form.
+  const [eventTypeId, setEventTypeId] = useState(eventTypes[0]?.id ?? "");
+  const [name, setName] = useState("");
+  const [sessions, setSessions] = useState(5);
+  const [price, setPrice] = useState(250);
+  const [saving, setSaving] = useState(false);
+
+  // Grant form (per package).
+  const [grantEmail, setGrantEmail] = useState<Record<string, string>>({});
+
+  const titleFor = useCallback(
+    (id: string) => eventTypes.find((e) => e.id === id)?.title ?? "Unknown event type",
+    [eventTypes],
+  );
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch("/api/packages", { cache: "no-store" });
+      if (!res.ok) throw new Error("Couldn't load packages");
+      const data = (await res.json()) as { packages: PackageRow[]; credits: CreditRow[] };
+      setPackages(data.packages);
+      setCredits(data.credits);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Something went wrong");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function createPackage(e: React.FormEvent) {
+    e.preventDefault();
+    if (!eventTypeId) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/packages", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          eventTypeId,
+          name: name.trim(),
+          sessionCount: sessions,
+          priceAmount: Math.round(price * 100),
+          currency: "usd",
+        }),
+      });
+      if (!res.ok) {
+        const d = await res.json().catch(() => ({}));
+        throw new Error(typeof d.error === "string" ? d.error : "Couldn't create package");
+      }
+      setName("");
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Something went wrong");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function grant(packageId: string) {
+    const email = (grantEmail[packageId] ?? "").trim();
+    if (!email) return;
+    setError(null);
+    try {
+      const res = await fetch("/api/packages/grant", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ packageId, clientEmail: email }),
+      });
+      if (!res.ok) {
+        const d = await res.json().catch(() => ({}));
+        throw new Error(typeof d.error === "string" ? d.error : "Couldn't grant credits");
+      }
+      setGrantEmail((m) => ({ ...m, [packageId]: "" }));
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Something went wrong");
+    }
+  }
+
+  if (eventTypes.length === 0) {
+    return (
+      <Card className="max-w-2xl">
+        <CardBody className="p-6 text-sm text-[var(--color-muted)]">
+          Create a booking type first — packages are sold against one of your event types.
+        </CardBody>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="flex max-w-2xl flex-col gap-6">
+      {error ? <FormError>{error}</FormError> : null}
+
+      {/* Create an offering */}
+      <Card>
+        <CardBody className="p-6">
+          <h2 className="text-lg font-semibold">New package</h2>
+          <p className="mt-1 text-sm text-[var(--color-muted)]">
+            Sell a bundle of sessions for one of your booking types. Clients spend a credit each
+            time they book it.
+          </p>
+          <form onSubmit={createPackage} className="mt-5 flex flex-col gap-4">
+            <div>
+              <Label htmlFor="pkg-et">Booking type</Label>
+              <Select
+                id="pkg-et"
+                value={eventTypeId}
+                onChange={(e) => setEventTypeId(e.target.value)}
+              >
+                {eventTypes.map((et) => (
+                  <option key={et.id} value={et.id}>
+                    {et.title}
+                  </option>
+                ))}
+              </Select>
+            </div>
+            <div>
+              <Label htmlFor="pkg-name">Name</Label>
+              <Input
+                id="pkg-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Coaching 5-pack"
+                required
+              />
+            </div>
+            <div className="flex gap-4">
+              <div className="flex-1">
+                <Label htmlFor="pkg-sessions">Sessions</Label>
+                <Input
+                  id="pkg-sessions"
+                  type="number"
+                  min={1}
+                  max={100}
+                  value={sessions}
+                  onChange={(e) => setSessions(Number(e.target.value))}
+                />
+              </div>
+              <div className="flex-1">
+                <Label htmlFor="pkg-price">Price (USD)</Label>
+                <Input
+                  id="pkg-price"
+                  type="number"
+                  min={0}
+                  step="0.01"
+                  value={price}
+                  onChange={(e) => setPrice(Number(e.target.value))}
+                />
+              </div>
+            </div>
+            <Button type="submit" disabled={saving || !name.trim()}>
+              {saving ? "Creating…" : "Create package"}
+            </Button>
+          </form>
+        </CardBody>
+      </Card>
+
+      {/* Offerings + grant */}
+      <Card>
+        <CardBody className="p-6">
+          <h2 className="text-lg font-semibold">Your packages</h2>
+          {loading ? (
+            <p className="mt-3 text-sm text-[var(--color-muted)]">Loading…</p>
+          ) : packages.length === 0 ? (
+            <p className="mt-3 text-sm text-[var(--color-muted)]">No packages yet.</p>
+          ) : (
+            <ul className="mt-4 flex flex-col gap-4">
+              {packages.map((p) => (
+                <li
+                  key={p.id}
+                  className="rounded-[var(--radius-md)] border border-[var(--color-border)] p-4"
+                >
+                  <div className="flex items-baseline justify-between gap-3">
+                    <span className="font-medium">{p.name}</span>
+                    <span className="text-sm text-[var(--color-muted)]">
+                      {p.sessionCount} sessions · {money(p.priceAmount, p.currency)}
+                    </span>
+                  </div>
+                  <p className="mt-0.5 text-xs text-[var(--color-faint)]">
+                    {titleFor(p.eventTypeId)}
+                  </p>
+                  <div className="mt-3 flex gap-2">
+                    <Input
+                      type="email"
+                      placeholder="Grant to client email…"
+                      value={grantEmail[p.id] ?? ""}
+                      onChange={(e) => setGrantEmail((m) => ({ ...m, [p.id]: e.target.value }))}
+                    />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => grant(p.id)}
+                      disabled={!(grantEmail[p.id] ?? "").trim()}
+                    >
+                      Grant
+                    </Button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardBody>
+      </Card>
+
+      {/* Client balances */}
+      <Card>
+        <CardBody className="p-6">
+          <h2 className="text-lg font-semibold">Client balances</h2>
+          {credits.length === 0 ? (
+            <p className="mt-3 text-sm text-[var(--color-muted)]">
+              No credits issued yet. Grant a package above, or share a package purchase link.
+            </p>
+          ) : (
+            <ul className="mt-4 divide-y divide-[var(--color-border)]">
+              {credits.map((c) => (
+                <li key={c.id} className="flex items-center justify-between gap-3 py-3 text-sm">
+                  <span>
+                    <span className="font-medium">{c.clientEmail}</span>
+                    <span className="block text-xs text-[var(--color-faint)]">
+                      {titleFor(c.eventTypeId)}
+                    </span>
+                  </span>
+                  <span className={c.remaining === 0 ? "text-[var(--color-faint)]" : ""}>
+                    {c.used} of {c.total} used
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardBody>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
The two follow-up UIs flagged in #15 — the package/number APIs existed; this adds the host-facing surfaces.

## Packages manager (`/settings/packages`)
- Create a package offering for one of your booking types (name, session count, price).
- See your offerings and outstanding **client balances** ("N of M used").
- **Grant credits manually** to a client (for offline/invoice sales).
- Added to the settings nav.

## "Ask Otter by text" (Notifications settings)
- Registers/verifies the phone number that inbound WhatsApp/SMS is matched to (`users.phone_number`), reusing the existing phone OTP flow.
- Shows registration status + the number to text; gracefully explains when the server hasn't enabled phone support (Twilio).

## Verification
- Web typechecks; biome-formatted.
- **Packages API tested end-to-end** against the local DB via a seeded session: create offering → grant → balance surfaces as "0 of 5 used".
- Both settings pages compile and serve (auth-guard redirects cleanly when signed out).
- The OTP send/verify path needs Twilio configured (not testable locally); it reuses the proven `phone-auth-panel` client calls.