### PR TITLE
chore(mobile): bump Android versionCode to 4 (Play rejected duplicate 3)

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -25,7 +25,7 @@
     },
     "android": {
       "package": "com.dayotter.app",
-      "versionCode": 3,
+      "versionCode": 4,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#12305F"


### PR DESCRIPTION
Play rejected the resubmission because versionCode 3 was already uploaded. Bumps to 4 so a new build can be submitted. Rebuild the AAB, then resubmit.