### PR TITLE
Streamline Otter: one interpret core + engine-backed host bookings

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -25,7 +25,7 @@
     },
     "android": {
       "package": "com.dayotter.app",
-      "versionCode": 4,
+      "versionCode": 5,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#12305F"

--- a/apps/web/app/(app)/event-types/page.tsx
+++ b/apps/web/app/(app)/event-types/page.tsx
@@ -6,7 +6,8 @@ import { buttonVariants } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { getSession } from "@/lib/auth/session";
 import { eventColorVar } from "@/lib/booking/event-type-input";
-import { desc, eq, getDb, schema } from "@dayotter/db";
+import { notPersonalType } from "@/lib/booking/personal-event-type";
+import { and, desc, eq, getDb, schema } from "@dayotter/db";
 import { Clock, ExternalLink, Pencil, Plus } from "lucide-react";
 import Link from "next/link";
 
@@ -17,7 +18,7 @@ export default async function EventTypesPage() {
   const db = getDb();
 
   const eventTypes = await db.query.eventTypes.findMany({
-    where: eq(schema.eventTypes.ownerId, session!.user.id),
+    where: and(eq(schema.eventTypes.ownerId, session!.user.id), notPersonalType),
     orderBy: desc(schema.eventTypes.createdAt),
   });
   const handle = (session!.user as { handle?: string | null }).handle;

--- a/apps/web/app/api/ai/command/route.ts
+++ b/apps/web/app/api/ai/command/route.ts
@@ -1,11 +1,9 @@
-import { runSchedulingAgent } from "@/lib/ai/agent";
-import { type BookingContext, aiEnabled, parseCommand } from "@/lib/ai/command-parse";
-import { retrieveCalendarContext } from "@/lib/ai/retrieval";
+import { aiEnabled } from "@/lib/ai/command-parse";
+import { interpretOtterCommand } from "@/lib/ai/interpret";
 import { requireFeature } from "@/lib/billing/require-feature";
 import { jsonError, withUser } from "@/lib/server/http";
 import { enforceRateLimit } from "@/lib/server/rate-limit";
 import { logger } from "@dayotter/core";
-import { DateTime } from "luxon";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
@@ -14,20 +12,10 @@ export const dynamic = "force-dynamic";
 const body = z.object({ text: z.string().min(1).max(500) });
 
 /**
- * Does the request need the host's real availability to answer? If so we run the
- * read-only agentic loop (which can look up free slots) instead of a single-shot
- * parse. Cheap heuristic — the agent still just proposes; the human confirms.
- */
-function needsAvailability(text: string): boolean {
-  return /\b(free|available|availability|open(ing)?|slot|sometime|any\s?time|whenever|earliest|soonest|next\s+(free|open|available))\b/i.test(
-    text,
-  );
-}
-
-/**
  * Natural-language command → an editable draft (create / reschedule / cancel).
  * Confirm-first: this only interprets against the user's own upcoming bookings;
- * it never writes. The client confirms, then calls the write endpoints.
+ * it never writes. The client confirms, then calls the write endpoints. Shares
+ * the Otter interpret core (lib/ai/interpret) with the mobile bar and SMS.
  */
 export const POST = withUser(async (u, request) => {
   if (!aiEnabled) return jsonError("AI scheduling isn't enabled on this server.", 503);
@@ -45,52 +33,11 @@ export const POST = withUser(async (u, request) => {
   const parsed = body.safeParse(await request.json().catch(() => null));
   if (!parsed.success) return jsonError("Enter a request", 400);
 
-  // RAG-lite: retrieve only the bookings relevant to this request (soonest +
-  // keyword matches) instead of dumping the whole calendar — smaller, faster,
-  // more accurate. This retrieved list is the source of truth for booking refs.
-  const ctx = await retrieveCalendarContext(u.id, parsed.data.text);
-  const tz = ctx.timezone;
-
-  const contexts: BookingContext[] = ctx.bookings.map((b, i) => ({
-    ref: i + 1,
-    title: b.title,
-    whenLocal: DateTime.fromJSDate(b.startsAt).setZone(tz).toFormat("ccc, LLL d 'at' h:mm a"),
-    attendees: b.attendees,
-  }));
-
-  const commandArgs = {
-    text: parsed.data.text,
-    timezone: tz,
-    now: new Date(),
-    bookings: contexts,
-    eventTypes: ctx.eventTypes,
-  };
-  let draft: Awaited<ReturnType<typeof parseCommand>>;
   try {
-    // Availability-dependent requests → the agentic loop (can look up free
-    // slots); everything else → the faster single-shot parse.
-    draft = needsAvailability(parsed.data.text)
-      ? await runSchedulingAgent({ ...commandArgs, userId: u.id })
-      : await parseCommand(commandArgs);
-  } catch (err) {
-    logger.error("ai command parse failed", { event: "ai_command_failed", userId: u.id, err });
-    return jsonError("Couldn't understand that. Try rephrasing, or manage it manually.", 502);
-  }
+    const { draft, target, matchedEventType } = await interpretOtterCommand(u.id, parsed.data.text);
 
-  // For a create that named one of the user's event types, surface the match so
-  // the client can show it and the create uses the type's real duration.
-  let matchedEventType: { title: string; slug: string; durationMinutes: number } | null = null;
-  if (draft.intent === "create" && draft.eventTypeSlug) {
-    const et = ctx.eventTypes.find((e) => e.slug === draft.eventTypeSlug);
-    if (et) matchedEventType = et;
-  }
-
-  // For manage intents, resolve the model's ref to a real booking the user owns
-  // and attach a summary so the client can render a clear confirmation.
-  let target: { uid: string; title: string; startISO: string } | null = null;
-  if (draft.intent === "reschedule" || draft.intent === "cancel") {
-    const b = ctx.bookings[draft.bookingRef - 1];
-    if (!b) {
+    // Manage intent that couldn't be resolved to a real booking → tell the user.
+    if ((draft.intent === "reschedule" || draft.intent === "cancel") && !target) {
       return NextResponse.json({
         draft: {
           ...draft,
@@ -101,8 +48,10 @@ export const POST = withUser(async (u, request) => {
         target: null,
       });
     }
-    target = { uid: b.uid, title: b.title, startISO: b.startsAt.toISOString() };
-  }
 
-  return NextResponse.json({ draft, target, matchedEventType });
+    return NextResponse.json({ draft, target, matchedEventType });
+  } catch (err) {
+    logger.error("ai command parse failed", { event: "ai_command_failed", userId: u.id, err });
+    return jsonError("Couldn't understand that. Try rephrasing, or manage it manually.", 502);
+  }
 });

--- a/apps/web/app/api/ai/schedule/create/route.ts
+++ b/apps/web/app/api/ai/schedule/create/route.ts
@@ -1,5 +1,5 @@
 import { aiEnabled } from "@/lib/ai/schedule-parse";
-import { writeBookingToCalendar } from "@/lib/calendar/host-calendar";
+import { createHostBooking } from "@/lib/booking/host-booking";
 import { jsonError, withUser } from "@/lib/server/http";
 import { logger } from "@dayotter/core";
 import { eq, getDb, schema } from "@dayotter/db";
@@ -17,12 +17,15 @@ const body = z.object({
     .array(z.object({ name: z.string(), email: z.string() }))
     .max(20)
     .default([]),
+  /** Optional: a real event type the create maps to (so its workflows apply). */
+  eventTypeSlug: z.string().max(200).optional(),
 });
 
 /**
- * Write a confirmed AI draft to the user's calendar. This is the human-confirmed
- * step — the AI never reaches here on its own. Best-effort: needs a connected
- * calendar to land the event.
+ * Write a confirmed AI draft as a real DayOtter booking. This is the
+ * human-confirmed step — the AI never reaches here on its own. Goes through the
+ * host-booking engine so the meeting shows in the app and gets reminders,
+ * overflow and scribe (not just a raw calendar event).
  */
 export const POST = withUser(async (u, request) => {
   if (!aiEnabled) return jsonError("AI scheduling isn't enabled on this server.", 503);
@@ -44,19 +47,19 @@ export const POST = withUser(async (u, request) => {
     .map((a) => ({ email: a.email, name: a.name || undefined }));
 
   try {
-    const written = await writeBookingToCalendar(u.id, {
+    const result = await createHostBooking({
+      userId: u.id,
       title: d.title,
-      description: d.notes,
       start,
       end,
       timezone: user?.timezone ?? "UTC",
+      notes: d.notes,
       attendees,
+      eventTypeSlug: d.eventTypeSlug,
     });
-    if (!written) {
-      return jsonError("Connect a calendar first so events have somewhere to land.", 409);
-    }
+    if (!result) return jsonError("Couldn't add the event. Please try again.", 502);
     logger.info("ai event created", { event: "ai_event_created", userId: u.id });
-    return NextResponse.json({ ok: true, meetingUrl: written.meetingUrl });
+    return NextResponse.json({ ok: true, uid: result.uid, meetingUrl: result.meetingUrl });
   } catch (err) {
     logger.error("ai event create failed", { event: "ai_event_create_failed", userId: u.id, err });
     return jsonError("Couldn't add the event. Please try again.", 502);

--- a/apps/web/app/api/event-types/route.ts
+++ b/apps/web/app/api/event-types/route.ts
@@ -1,9 +1,10 @@
 import { getSession } from "@/lib/auth/session";
 import { eventTypeInputSchema } from "@/lib/booking/event-type-input";
+import { notPersonalType } from "@/lib/booking/personal-event-type";
 import { resolveScheduleId } from "@/lib/booking/schedule";
 import { ensureUserWorkspace } from "@/lib/bootstrap";
 import { sha256hex } from "@dayotter/core";
-import { desc, eq, getDb, schema } from "@dayotter/db";
+import { and, desc, eq, getDb, schema } from "@dayotter/db";
 import { NextResponse } from "next/server";
 
 export const dynamic = "force-dynamic";
@@ -14,7 +15,7 @@ export async function GET() {
   if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const rows = await getDb().query.eventTypes.findMany({
-    where: eq(schema.eventTypes.ownerId, session.user.id),
+    where: and(eq(schema.eventTypes.ownerId, session.user.id), notPersonalType),
     orderBy: desc(schema.eventTypes.createdAt),
   });
   const handle = (session.user as { handle?: string | null }).handle ?? null;

--- a/apps/web/app/api/workflows/route.ts
+++ b/apps/web/app/api/workflows/route.ts
@@ -1,7 +1,8 @@
 import { requireFeature } from "@/lib/billing/require-feature";
+import { notPersonalType } from "@/lib/booking/personal-event-type";
 import { ensureUserWorkspace } from "@/lib/bootstrap";
 import { jsonError, withUser } from "@/lib/server/http";
-import { asc, eq, getDb, inArray, schema } from "@dayotter/db";
+import { and, asc, eq, getDb, inArray, schema } from "@dayotter/db";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
@@ -10,7 +11,7 @@ export const dynamic = "force-dynamic";
 /** Event-type ids owned by the user's org — used to validate workflow scoping. */
 async function ownedEventTypeIds(organizationId: string): Promise<Set<string>> {
   const rows = await getDb().query.eventTypes.findMany({
-    where: eq(schema.eventTypes.organizationId, organizationId),
+    where: and(eq(schema.eventTypes.organizationId, organizationId), notPersonalType),
     columns: { id: true },
   });
   return new Set(rows.map((r) => r.id));

--- a/apps/web/lib/ai/interpret.ts
+++ b/apps/web/lib/ai/interpret.ts
@@ -1,0 +1,74 @@
+import { DateTime } from "luxon";
+import { runSchedulingAgent } from "./agent";
+import { type BookingContext, type CommandDraft, parseCommand } from "./command-parse";
+import { retrieveCalendarContext } from "./retrieval";
+
+/**
+ * The single Otter "brain" for turning a natural-language scheduling request
+ * into a confirm-first draft. Shared by every surface that isn't the streaming
+ * chat — the web command bar (/api/ai/command), the mobile Ask bar, and inbound
+ * WhatsApp/SMS — so they all interpret identically. The caller renders/executes
+ * the draft; this never writes.
+ */
+
+export interface OtterTarget {
+  uid: string;
+  title: string;
+  startISO: string;
+}
+
+export interface OtterInterpretation {
+  draft: CommandDraft;
+  timezone: string;
+  /** For reschedule/cancel: the resolved existing booking (null if unresolved). */
+  target: OtterTarget | null;
+  /** For create: the matched event type, when the request named one. */
+  matchedEventType: { title: string; slug: string; durationMinutes: number } | null;
+}
+
+/**
+ * Availability-dependent requests ("find a free slot", "when am I open") go
+ * through the read-only agentic loop, which can look up real free slots;
+ * everything else uses the faster single-shot parse. Either way it only drafts.
+ */
+export function needsAvailability(text: string): boolean {
+  return /\b(free|available|availability|open(ing)?|slot|sometime|any\s?time|whenever|earliest|soonest|next\s+(free|open|available))\b/i.test(
+    text,
+  );
+}
+
+export async function interpretOtterCommand(
+  userId: string,
+  text: string,
+): Promise<OtterInterpretation> {
+  // RAG-lite: retrieve only the bookings relevant to this request. This
+  // retrieved list is the source of truth for the model's booking refs.
+  const ctx = await retrieveCalendarContext(userId, text);
+  const tz = ctx.timezone;
+
+  const bookings: BookingContext[] = ctx.bookings.map((b, i) => ({
+    ref: i + 1,
+    title: b.title,
+    whenLocal: DateTime.fromJSDate(b.startsAt).setZone(tz).toFormat("ccc, LLL d 'at' h:mm a"),
+    attendees: b.attendees,
+  }));
+
+  const args = { text, timezone: tz, now: new Date(), bookings, eventTypes: ctx.eventTypes };
+  const draft = needsAvailability(text)
+    ? await runSchedulingAgent({ ...args, userId })
+    : await parseCommand(args);
+
+  let matchedEventType: OtterInterpretation["matchedEventType"] = null;
+  if (draft.intent === "create" && draft.eventTypeSlug) {
+    const et = ctx.eventTypes.find((e) => e.slug === draft.eventTypeSlug);
+    if (et) matchedEventType = et;
+  }
+
+  let target: OtterTarget | null = null;
+  if (draft.intent === "reschedule" || draft.intent === "cancel") {
+    const b = ctx.bookings[draft.bookingRef - 1];
+    if (b) target = { uid: b.uid, title: b.title, startISO: b.startsAt.toISOString() };
+  }
+
+  return { draft, timezone: tz, target, matchedEventType };
+}

--- a/apps/web/lib/ai/tools/exec.ts
+++ b/apps/web/lib/ai/tools/exec.ts
@@ -1,6 +1,7 @@
 import { computeAnalytics } from "@/lib/booking/analytics";
 import { eventTypeInputSchema } from "@/lib/booking/event-type-input";
 import { findFocusBlocks } from "@/lib/booking/focus-suggestions";
+import { notPersonalType } from "@/lib/booking/personal-event-type";
 import { resolveScheduleId } from "@/lib/booking/schedule";
 import { ensureUserWorkspace } from "@/lib/bootstrap";
 import {
@@ -39,7 +40,7 @@ export async function executeReadTool(
   switch (name) {
     case "list_booking_types": {
       const rows = await db.query.eventTypes.findMany({
-        where: eq(schema.eventTypes.ownerId, userId),
+        where: and(eq(schema.eventTypes.ownerId, userId), notPersonalType),
         columns: { id: true, title: true, slug: true, durationMinutes: true, isActive: true },
         orderBy: desc(schema.eventTypes.createdAt),
       });

--- a/apps/web/lib/booking/host-booking.ts
+++ b/apps/web/lib/booking/host-booking.ts
@@ -1,0 +1,169 @@
+import { randomUUID } from "node:crypto";
+import { primaryOrg } from "@/lib/billing/entitlements";
+import { writeBookingToCalendar } from "@/lib/calendar/host-calendar";
+import { logger } from "@dayotter/core";
+import { and, eq, getDb, schema } from "@dayotter/db";
+import { PERSONAL_EVENT_TYPE_SLUG } from "./personal-event-type";
+import {
+  hostWantsOverflowNotice,
+  hostWantsScribe,
+  reminderOffsetsForHost,
+  scheduleBookingReminders,
+  scheduleOverflowCheck,
+  scheduleScribe,
+} from "./reminders";
+
+const PERSONAL_SLUG = PERSONAL_EVENT_TYPE_SLUG;
+
+async function getOrCreatePersonalEventType(
+  userId: string,
+  organizationId: string,
+): Promise<string> {
+  const db = getDb();
+  const existing = await db.query.eventTypes.findFirst({
+    where: and(eq(schema.eventTypes.ownerId, userId), eq(schema.eventTypes.slug, PERSONAL_SLUG)),
+    columns: { id: true },
+  });
+  if (existing) return existing.id;
+  const [row] = await db
+    .insert(schema.eventTypes)
+    .values({
+      organizationId,
+      ownerId: userId,
+      slug: PERSONAL_SLUG,
+      title: "Personal",
+      durationMinutes: 30,
+      isPrivate: true,
+      isActive: false,
+    })
+    .returning({ id: schema.eventTypes.id });
+  return row!.id;
+}
+
+export interface HostBookingInput {
+  userId: string;
+  title: string;
+  start: Date;
+  end: Date;
+  timezone: string;
+  notes?: string;
+  attendees?: { email: string; name?: string }[];
+  /** Slug of a real event type this maps to (so its workflows apply); else the
+   * hidden Personal type. */
+  eventTypeSlug?: string;
+}
+
+export interface HostBookingResult {
+  uid: string;
+  meetingUrl?: string;
+}
+
+/**
+ * Create a real DayOtter booking on behalf of the host — the path Otter's
+ * "book / hold" confirmations run through (and any future manual "add event").
+ * Unlike a public booking it skips availability gating (the host is
+ * deliberately blocking their own time) but it gets the full treatment: a
+ * `bookings` row (so it shows in the app), a best-effort calendar write, and
+ * reminders/overflow/scribe. Returns null only if the host has no organization.
+ */
+export async function createHostBooking(
+  input: HostBookingInput,
+): Promise<HostBookingResult | null> {
+  const db = getDb();
+  const org = await primaryOrg(input.userId);
+  if (!org) return null;
+
+  // Resolve the event type: a real matched one (so its workflows apply), else a
+  // hidden per-user Personal type.
+  let eventTypeId: string | null = null;
+  if (input.eventTypeSlug && input.eventTypeSlug !== PERSONAL_SLUG) {
+    const et = await db.query.eventTypes.findFirst({
+      where: and(
+        eq(schema.eventTypes.ownerId, input.userId),
+        eq(schema.eventTypes.slug, input.eventTypeSlug),
+      ),
+      columns: { id: true },
+    });
+    eventTypeId = et?.id ?? null;
+  }
+  if (!eventTypeId) eventTypeId = await getOrCreatePersonalEventType(input.userId, org.id);
+
+  const uid = randomUUID();
+  const [booking] = await db
+    .insert(schema.bookings)
+    .values({
+      organizationId: org.id,
+      eventTypeId,
+      hostId: input.userId,
+      title: input.title,
+      description: input.notes,
+      startsAt: input.start,
+      endsAt: input.end,
+      timezone: input.timezone,
+      status: "confirmed",
+      uid,
+    })
+    .returning();
+  if (!booking) return null;
+
+  const attendees = (input.attendees ?? []).filter((a) => a.email.includes("@"));
+  if (attendees.length > 0) {
+    await db.insert(schema.bookingAttendees).values(
+      attendees.map((a) => ({
+        bookingId: booking.id,
+        email: a.email,
+        name: a.name ?? null,
+        timezone: input.timezone,
+      })),
+    );
+  }
+
+  // Calendar write (best-effort) + record the reference for later move/delete.
+  let meetingUrl: string | undefined;
+  try {
+    const written = await writeBookingToCalendar(input.userId, {
+      title: input.title,
+      description: input.notes,
+      start: input.start,
+      end: input.end,
+      timezone: input.timezone,
+      attendees: attendees.map((a) => ({ email: a.email, name: a.name })),
+    });
+    if (written) {
+      meetingUrl = written.meetingUrl;
+      if (meetingUrl) {
+        await db
+          .update(schema.bookings)
+          .set({ meetingUrl })
+          .where(eq(schema.bookings.id, booking.id));
+      }
+      await db.insert(schema.bookingReferences).values({
+        bookingId: booking.id,
+        calendarId: written.calendarId,
+        provider: written.provider,
+        externalEventId: written.externalEventId,
+      });
+    }
+  } catch (err) {
+    logger.error("host booking calendar write failed", {
+      event: "host_booking_calendar_failed",
+      bookingId: booking.id,
+      err,
+    });
+  }
+
+  // Full lifecycle: reminders, plus overflow / scribe when opted in.
+  await scheduleBookingReminders(
+    booking.id,
+    input.start,
+    await reminderOffsetsForHost(input.userId),
+  );
+  if (await hostWantsOverflowNotice(input.userId)) {
+    await scheduleOverflowCheck(booking.id, input.end);
+  }
+  if (await hostWantsScribe(input.userId)) {
+    await scheduleScribe(booking.id, input.end);
+  }
+
+  return { uid, meetingUrl };
+}

--- a/apps/web/lib/booking/personal-event-type.ts
+++ b/apps/web/lib/booking/personal-event-type.ts
@@ -1,0 +1,12 @@
+import { ne, schema } from "@dayotter/db";
+
+/**
+ * Reserved slug for the hidden, per-user event type that Otter's ad-hoc "book /
+ * hold" meetings hang off of (so `bookings.eventTypeId` stays non-null without
+ * modelling ad-hoc events specially). It is `isPrivate` + `isActive: false`, and
+ * every user-facing listing excludes it via `notPersonalType`.
+ */
+export const PERSONAL_EVENT_TYPE_SLUG = "__personal";
+
+/** Drizzle predicate: exclude the hidden Personal type from an event-type list. */
+export const notPersonalType = ne(schema.eventTypes.slug, PERSONAL_EVENT_TYPE_SLUG);

--- a/apps/web/lib/messaging/otter-sms.ts
+++ b/apps/web/lib/messaging/otter-sms.ts
@@ -1,7 +1,7 @@
 import { interpretOtterCommand } from "@/lib/ai/interpret";
 import { cancelBooking } from "@/lib/booking/cancel-booking";
+import { createHostBooking } from "@/lib/booking/host-booking";
 import { rescheduleBooking } from "@/lib/booking/reschedule-booking";
-import { writeBookingToCalendar } from "@/lib/calendar/host-calendar";
 import { logger } from "@dayotter/core";
 import { DateTime } from "luxon";
 
@@ -19,6 +19,7 @@ export type PendingAction =
       notes: string;
       attendees: { name: string; email: string }[];
       timezone: string;
+      eventTypeSlug?: string;
     }
   | { intent: "reschedule"; uid: string; newStartISO: string; title: string; timezone: string }
   | { intent: "cancel"; uid: string; title: string };
@@ -63,6 +64,7 @@ export async function interpretForSms(userId: string, text: string): Promise<Int
         notes: draft.notes,
         attendees: draft.attendees,
         timezone: tz,
+        eventTypeSlug: draft.eventTypeSlug || undefined,
       },
     };
   }
@@ -101,17 +103,17 @@ export async function executePending(userId: string, pending: PendingAction): Pr
       const attendees = pending.attendees
         .filter((a) => a.email.includes("@"))
         .map((a) => ({ email: a.email, name: a.name || undefined }));
-      const written = await writeBookingToCalendar(userId, {
+      const result = await createHostBooking({
+        userId,
         title: pending.title,
-        description: pending.notes || undefined,
         start,
         end,
         timezone: pending.timezone,
+        notes: pending.notes || undefined,
         attendees,
+        eventTypeSlug: pending.eventTypeSlug,
       });
-      if (!written) {
-        return "I couldn't add that — connect a calendar in DayOtter first, then try again.";
-      }
+      if (!result) return "I couldn't add that right now — please try again, or use the app.";
       return `Done ✓ "${pending.title}" is on your calendar for ${whenLabel(pending.startISO, pending.timezone)}.`;
     }
 

--- a/apps/web/lib/messaging/otter-sms.ts
+++ b/apps/web/lib/messaging/otter-sms.ts
@@ -1,6 +1,4 @@
-import { runSchedulingAgent } from "@/lib/ai/agent";
-import { type BookingContext, parseCommand } from "@/lib/ai/command-parse";
-import { retrieveCalendarContext } from "@/lib/ai/retrieval";
+import { interpretOtterCommand } from "@/lib/ai/interpret";
 import { cancelBooking } from "@/lib/booking/cancel-booking";
 import { rescheduleBooking } from "@/lib/booking/reschedule-booking";
 import { writeBookingToCalendar } from "@/lib/calendar/host-calendar";
@@ -32,40 +30,18 @@ export interface InterpretResult {
   pending?: PendingAction;
 }
 
-const needsAvailability = (text: string): boolean =>
-  /\b(free|available|availability|open(ing)?|slot|sometime|any\s?time|whenever|earliest|soonest|next\s+(free|open|available))\b/i.test(
-    text,
-  );
-
 function whenLabel(iso: string, tz: string): string {
   return DateTime.fromISO(iso).setZone(tz).toFormat("ccc, LLL d 'at' h:mm a");
 }
 
 /**
- * Interpret an inbound message with Otter and return a reply. For an actionable
- * request it returns a `pending` action and a "reply YES to confirm" prompt —
- * confirm-first, over text.
+ * Interpret an inbound message with Otter and return a reply. Uses the same
+ * interpret core as the web/mobile command bar, so texting Otter behaves
+ * identically. For an actionable request it returns a `pending` action and a
+ * "reply YES to confirm" prompt — confirm-first, over text.
  */
 export async function interpretForSms(userId: string, text: string): Promise<InterpretResult> {
-  const ctx = await retrieveCalendarContext(userId, text);
-  const tz = ctx.timezone;
-  const contexts: BookingContext[] = ctx.bookings.map((b, i) => ({
-    ref: i + 1,
-    title: b.title,
-    whenLocal: DateTime.fromJSDate(b.startsAt).setZone(tz).toFormat("ccc, LLL d 'at' h:mm a"),
-    attendees: b.attendees,
-  }));
-  const args = {
-    text,
-    timezone: tz,
-    now: new Date(),
-    bookings: contexts,
-    eventTypes: ctx.eventTypes,
-  };
-
-  const draft = needsAvailability(text)
-    ? await runSchedulingAgent({ ...args, userId })
-    : await parseCommand(args);
+  const { draft, timezone: tz, target } = await interpretOtterCommand(userId, text);
 
   if (!draft.understood || draft.intent === "none") {
     return {
@@ -91,20 +67,19 @@ export async function interpretForSms(userId: string, text: string): Promise<Int
     };
   }
 
-  const b = ctx.bookings[draft.bookingRef - 1];
-  if (!b) {
+  if (!target) {
     return { reply: "I couldn't tell which meeting you meant — try naming it or its time." };
   }
 
   if (draft.intent === "reschedule") {
     const when = whenLabel(draft.newStartISO, tz);
     return {
-      reply: `I'll move "${b.title}" to ${when}. Reply YES to confirm, or NO to cancel.`,
+      reply: `I'll move "${target.title}" to ${when}. Reply YES to confirm, or NO to cancel.`,
       pending: {
         intent: "reschedule",
-        uid: b.uid,
+        uid: target.uid,
         newStartISO: draft.newStartISO,
-        title: b.title,
+        title: target.title,
         timezone: tz,
       },
     };
@@ -112,8 +87,8 @@ export async function interpretForSms(userId: string, text: string): Promise<Int
 
   // cancel
   return {
-    reply: `I'll cancel "${b.title}". Reply YES to confirm, or NO to cancel.`,
-    pending: { intent: "cancel", uid: b.uid, title: b.title },
+    reply: `I'll cancel "${target.title}". Reply YES to confirm, or NO to cancel.`,
+    pending: { intent: "cancel", uid: target.uid, title: target.title },
   };
 }
 


### PR DESCRIPTION
First two items of the post-audit streamline pass.

## #1 — One shared Otter interpret core
`/api/ai/command` (web + mobile) and the WhatsApp/SMS handler duplicated the exact interpret logic (retrieval, context build, parse-vs-agent selection, booking-ref resolution). Extracted `lib/ai/interpret.ts` (`interpretOtterCommand`); both now call the same brain, so every non-chat surface interprets identically. Response shape unchanged.

## #2 — Otter creates are real DayOtter bookings
Before, Otter's "book / hold" confirmations went straight to the calendar via `writeBookingToCalendar` and **never created a booking** — so they didn't show in Upcoming and got no reminders/overflow/scribe (visible on the phone: created meetings never appeared).

- `createHostBooking()` inserts a real `bookings` row (skips public availability gating — the host is blocking their own time), writes to the calendar, and schedules the full lifecycle.
- Ad-hoc meetings hang off a hidden per-user `__personal` event type so `bookings.eventTypeId` stays non-null and every eventType join keeps working; excluded from all user-facing event-type listings (`notPersonalType`).
- `/api/ai/schedule/create` and the SMS create path both route through it; a named event type's slug is carried through so its workflows still apply.

## Verification
- Full monorepo typechecks; biome-formatted.
- `createHostBooking` tested against the local DB: creates a confirmed booking + attendees + 2 reminders; `__personal` is hidden from `/api/event-types`.

## Not included (next streamline items)
Dual phone-number stores, automations/workflows overlap, preferences grouping, SSO/white-label stubs — and the mobile 16 KB page-size warning (needs an Expo SDK 53+ upgrade, tracked separately).