### PR TITLE
Proactive Otter + Automations/Workflows reconcile

### DIFF
--- a/apps/web/app/(app)/dashboard/page.tsx
+++ b/apps/web/app/(app)/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { MeetingAssistant } from "@/components/meeting-assistant";
 import { OverflowButton } from "@/components/overflow-button";
 import { EmptyState, PageHeader } from "@/components/page-header";
 import { PendingInvites } from "@/components/pending-invites";
+import { ProactiveOtter } from "@/components/proactive-otter";
 import { RunningLateButton } from "@/components/running-late-button";
 import { SectionHeading } from "@/components/section-heading";
 import { SetupChecklist } from "@/components/setup-checklist";
@@ -156,6 +157,8 @@ export default async function DashboardPage() {
 
       <SetupChecklist hasCalendar={hasCalendar} hasHours={hasHours} hasEventType={hasEventType} />
       <DashboardTour />
+
+      <ProactiveOtter />
 
       {showStats ? (
         <div className="mb-6 grid grid-cols-2 gap-3 sm:grid-cols-4">

--- a/apps/web/app/(app)/settings/automations/page.tsx
+++ b/apps/web/app/(app)/settings/automations/page.tsx
@@ -1,12 +1,36 @@
 import { AutomationsForm } from "@/components/automations-form";
 import { ProGate } from "@/components/upgrade-prompt";
+import { WorkflowsForm } from "@/components/workflows-form";
 
 export const dynamic = "force-dynamic";
 
+/**
+ * Automations — one home for every "when X, do Y" rule. Two coherent sections:
+ * scheduling rules (reserve time / hold focus blocks) and attendee messages
+ * (before/after-event emails). Previously these were two separate settings pages
+ * (Automations + Workflows) that users conflated; unified here.
+ */
 export default function AutomationsSettingsPage() {
   return (
     <ProGate feature="automation">
-      <AutomationsForm />
+      <div className="flex flex-col gap-10">
+        <section>
+          <h2 className="text-lg font-semibold">Scheduling rules</h2>
+          <p className="mb-4 mt-1 text-sm text-[var(--color-muted)]">
+            Reserve prep time and buffers around your bookings, and hold recurring focus blocks.
+          </p>
+          <AutomationsForm />
+        </section>
+
+        <section id="messages">
+          <h2 className="text-lg font-semibold">Attendee messages</h2>
+          <p className="mb-4 mt-1 text-sm text-[var(--color-muted)]">
+            Send automated emails before and after a meeting — reminders and follow-ups, on your own
+            templates.
+          </p>
+          <WorkflowsForm />
+        </section>
+      </div>
     </ProGate>
   );
 }

--- a/apps/web/app/(app)/settings/workflows/page.tsx
+++ b/apps/web/app/(app)/settings/workflows/page.tsx
@@ -1,12 +1,6 @@
-import { ProGate } from "@/components/upgrade-prompt";
-import { WorkflowsForm } from "@/components/workflows-form";
+import { redirect } from "next/navigation";
 
-export const dynamic = "force-dynamic";
-
+/** Workflows merged into the unified Automations page. Keep the URL working. */
 export default function WorkflowsSettingsPage() {
-  return (
-    <ProGate feature="workflows">
-      <WorkflowsForm />
-    </ProGate>
-  );
+  redirect("/settings/automations#messages");
 }

--- a/apps/web/app/api/otter/suggestions/route.ts
+++ b/apps/web/app/api/otter/suggestions/route.ts
@@ -1,0 +1,82 @@
+import { getProactiveSuggestions } from "@/lib/ai/proactive";
+import { writeBookingToCalendar } from "@/lib/calendar/host-calendar";
+import { jsonError, withUser } from "@/lib/server/http";
+import { logger } from "@dayotter/core";
+import { eq, getDb, schema } from "@dayotter/db";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+export const dynamic = "force-dynamic";
+
+/** Proactive suggestions to show the user right now. */
+export const GET = withUser(async (u) => {
+  const suggestions = await getProactiveSuggestions(u.id);
+  return NextResponse.json({ suggestions });
+});
+
+const actSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("focus"),
+    startISO: z.string().datetime(),
+    durationMinutes: z.number().int().min(15).max(480),
+    title: z.string().max(120).default("Deep work"),
+  }),
+  z.object({ type: z.literal("enable_overflow") }),
+  z.object({ type: z.literal("enable_briefing") }),
+]);
+
+/** Act on a suggestion (confirm-first — always from an explicit user tap). */
+export const POST = withUser(async (u, request) => {
+  const parsed = actSchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) return jsonError("Unknown suggestion", 400);
+  const d = parsed.data;
+  const db = getDb();
+
+  try {
+    if (d.type === "focus") {
+      const start = new Date(d.startISO);
+      const end = new Date(start.getTime() + d.durationMinutes * 60_000);
+      // Hold it as a real focus time_block (the availability engine treats these
+      // as busy), then best-effort mirror it to the calendar.
+      await db.insert(schema.timeBlocks).values({
+        userId: u.id,
+        title: d.title,
+        kind: "focus",
+        startsAt: start,
+        endsAt: end,
+        seriesId: null,
+      });
+      const user = await db.query.users.findFirst({
+        where: eq(schema.users.id, u.id),
+        columns: { timezone: true },
+      });
+      await writeBookingToCalendar(u.id, {
+        title: d.title,
+        start,
+        end,
+        timezone: user?.timezone ?? "UTC",
+        attendees: [],
+      }).catch(() => null);
+      return NextResponse.json({ ok: true, message: "Focus time held." });
+    }
+
+    // Preference toggles — upsert so a user without a prefs row still works.
+    const set =
+      d.type === "enable_overflow"
+        ? { overflowNotifyEnabled: true }
+        : { briefingEnabled: true, briefingHour: 8 };
+    await db
+      .insert(schema.userPreferences)
+      .values({ userId: u.id, ...set })
+      .onConflictDoUpdate({ target: schema.userPreferences.userId, set });
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    logger.error("proactive suggestion action failed", {
+      event: "proactive_action_failed",
+      userId: u.id,
+      type: d.type,
+      err,
+    });
+    return jsonError("Couldn't do that. Please try again.", 502);
+  }
+});

--- a/apps/web/components/nav-items.ts
+++ b/apps/web/components/nav-items.ts
@@ -43,7 +43,6 @@ export const SETTINGS_NAV = [
   { href: "/settings/preferences", label: "Preferences" },
   { href: "/settings/notifications", label: "Notifications" },
   { href: "/settings/automations", label: "Automations" },
-  { href: "/settings/workflows", label: "Workflows" },
   { href: "/settings/packages", label: "Packages" },
   { href: "/settings/calendars", label: "Calendars" },
   { href: "/settings/billing", label: "Billing" },

--- a/apps/web/components/proactive-otter.tsx
+++ b/apps/web/components/proactive-otter.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardBody, CardHeader } from "@/components/ui/card";
+import { FormError } from "@/components/ui/form";
+import { track } from "@/lib/analytics";
+import { Sparkles } from "lucide-react";
+import { useEffect, useState } from "react";
+
+type Suggestion =
+  | {
+      id: string;
+      type: "focus";
+      title: string;
+      detail: string;
+      startISO: string;
+      durationMinutes: number;
+    }
+  | { id: string; type: "enable_overflow"; title: string; detail: string }
+  | { id: string; type: "enable_briefing"; title: string; detail: string };
+
+const DISMISS_KEY = "otter:dismissed";
+const CONFIRM_LABEL: Record<Suggestion["type"], string> = {
+  focus: "Protect",
+  enable_overflow: "Turn on",
+  enable_briefing: "Enable",
+};
+
+function loadDismissed(): Set<string> {
+  try {
+    return new Set(JSON.parse(localStorage.getItem(DISMISS_KEY) ?? "[]") as string[]);
+  } catch {
+    return new Set();
+  }
+}
+
+/**
+ * Proactive Otter — the assistant surfacing a couple of high-value things to do
+ * right now (protect open focus time, turn on running-late alerts, start a
+ * morning briefing), each confirm-first. Renders nothing when there's nothing
+ * worth nudging. Dismissed suggestions are remembered locally so it stays calm.
+ */
+export function ProactiveOtter() {
+  const [items, setItems] = useState<Suggestion[] | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    fetch("/api/otter/suggestions")
+      .then((r) => r.json())
+      .then((d) => {
+        if (!active) return;
+        const dismissed = loadDismissed();
+        setItems(((d.suggestions ?? []) as Suggestion[]).filter((s) => !dismissed.has(s.id)));
+      })
+      .catch(() => active && setItems([]));
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  function remove(id: string) {
+    setItems((prev) => (prev ?? []).filter((s) => s.id !== id));
+  }
+
+  function dismiss(id: string) {
+    try {
+      const next = loadDismissed();
+      next.add(id);
+      localStorage.setItem(DISMISS_KEY, JSON.stringify([...next]));
+    } catch {
+      // best-effort — still hide it this session
+    }
+    track("Otter Suggestion Dismissed");
+    remove(id);
+  }
+
+  async function confirm(s: Suggestion) {
+    setBusy(s.id);
+    setError(null);
+    const payload =
+      s.type === "focus"
+        ? {
+            type: "focus",
+            startISO: s.startISO,
+            durationMinutes: s.durationMinutes,
+            title: "Deep work",
+          }
+        : { type: s.type };
+    const res = await fetch("/api/otter/suggestions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    setBusy(null);
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      setError(typeof data.error === "string" ? data.error : "Couldn't do that");
+      return;
+    }
+    track("Otter Suggestion Accepted", { type: s.type });
+    remove(s.id);
+  }
+
+  if (!items || items.length === 0) return null;
+
+  return (
+    <Card className="mb-6">
+      <CardHeader
+        title={
+          <span className="flex items-center gap-2">
+            <Sparkles size={15} className="text-[var(--color-accent)]" /> Otter noticed
+          </span>
+        }
+        description="A few things worth doing — nothing happens until you say so."
+      />
+      <CardBody className="space-y-2">
+        {error ? <FormError>{error}</FormError> : null}
+        {items.map((s) => (
+          <div
+            key={s.id}
+            className="flex items-center justify-between gap-4 rounded-md border border-[var(--color-border)] px-4 py-3"
+          >
+            <div className="min-w-0">
+              <p className="text-sm font-medium">{s.title}</p>
+              <p className="truncate text-xs text-[var(--color-muted)]">{s.detail}</p>
+            </div>
+            <div className="flex shrink-0 items-center gap-2">
+              <Button size="sm" onClick={() => confirm(s)} disabled={busy === s.id}>
+                {busy === s.id ? "…" : CONFIRM_LABEL[s.type]}
+              </Button>
+              <button
+                type="button"
+                onClick={() => dismiss(s.id)}
+                className="text-xs text-[var(--color-faint)] transition-colors hover:text-[var(--color-muted)]"
+              >
+                Dismiss
+              </button>
+            </div>
+          </div>
+        ))}
+      </CardBody>
+    </Card>
+  );
+}

--- a/apps/web/lib/ai/proactive.ts
+++ b/apps/web/lib/ai/proactive.ts
@@ -1,0 +1,101 @@
+import { deepWorkSuggestions } from "@/lib/booking/focus-suggestions";
+import { and, asc, eq, getDb, gte, lt, schema } from "@dayotter/db";
+import { DateTime } from "luxon";
+
+/**
+ * Proactive Otter — the assistant noticing things worth doing, unprompted, and
+ * proposing them confirm-first. Everything here only READS; the surface (the
+ * dashboard card + /api/otter/suggestions) executes on the user's explicit OK.
+ */
+
+export type ProactiveSuggestion =
+  | {
+      id: string;
+      type: "focus";
+      title: string;
+      detail: string;
+      /** Payload for the "protect" action. */
+      startISO: string;
+      durationMinutes: number;
+    }
+  | { id: string; type: "enable_overflow"; title: string; detail: string }
+  | { id: string; type: "enable_briefing"; title: string; detail: string };
+
+/** Are there back-to-back meetings in the next week (a running-late risk)? */
+async function hasBackToBack(userId: string): Promise<boolean> {
+  const now = new Date();
+  const weekOut = new Date(now.getTime() + 7 * 86_400_000);
+  const rows = await getDb().query.bookings.findMany({
+    where: and(
+      eq(schema.bookings.hostId, userId),
+      eq(schema.bookings.status, "confirmed"),
+      gte(schema.bookings.startsAt, now),
+      lt(schema.bookings.startsAt, weekOut),
+    ),
+    orderBy: asc(schema.bookings.startsAt),
+    columns: { startsAt: true, endsAt: true },
+  });
+  for (let i = 0; i < rows.length - 1; i++) {
+    const gapMin = (rows[i + 1]!.startsAt.getTime() - rows[i]!.endsAt.getTime()) / 60_000;
+    if (gapMin >= 0 && gapMin <= 5) return true;
+  }
+  return false;
+}
+
+const FOCUS_BLOCK_MINUTES = 90;
+
+/**
+ * Compute the proactive nudges to show a user right now. Capped and ordered so
+ * the surface stays calm — a couple of high-value proposals, not a firehose.
+ */
+export async function getProactiveSuggestions(userId: string): Promise<ProactiveSuggestion[]> {
+  const db = getDb();
+  const [user, prefs] = await Promise.all([
+    db.query.users.findFirst({ where: eq(schema.users.id, userId), columns: { timezone: true } }),
+    db.query.userPreferences.findFirst({
+      where: eq(schema.userPreferences.userId, userId),
+      columns: { overflowNotifyEnabled: true, briefingEnabled: true },
+    }),
+  ]);
+  const tz = user?.timezone ?? "UTC";
+  const out: ProactiveSuggestion[] = [];
+
+  // 1. Open deep-work windows worth protecting (top 2).
+  const focus = await deepWorkSuggestions(userId, { days: 5, blockMinutes: FOCUS_BLOCK_MINUTES });
+  for (const s of focus.slice(0, 2)) {
+    const start = DateTime.fromISO(s.startISO).setZone(tz);
+    const end = DateTime.fromISO(s.endISO).setZone(tz);
+    out.push({
+      id: `focus:${s.startISO}`,
+      type: "focus",
+      title: "Protect deep-work time",
+      detail: `${start.toFormat("ccc, LLL d")} · ${start.toFormat("h:mm")}–${end.toFormat("h:mm a")} is free`,
+      startISO: s.startISO,
+      durationMinutes: Math.round(end.diff(start, "minutes").minutes),
+    });
+  }
+
+  // 2. Back-to-back meetings but running-late alerts are off.
+  if (!prefs?.overflowNotifyEnabled && (await hasBackToBack(userId))) {
+    out.push({
+      id: "enable_overflow",
+      type: "enable_overflow",
+      title: "Turn on running-late alerts",
+      detail:
+        "You've got back-to-back meetings coming up. I can warn your next guests if one runs over.",
+    });
+  }
+
+  // 3. No morning briefing yet.
+  if (!prefs?.briefingEnabled) {
+    out.push({
+      id: "enable_briefing",
+      type: "enable_briefing",
+      title: "Start the day with a briefing",
+      detail:
+        "Each morning I can text you the day ahead — meetings and the focus time you've held.",
+    });
+  }
+
+  return out;
+}


### PR DESCRIPTION
Two audit items: the top feature and streamline #4.

## Proactive Otter (Add #1 — the biggest lever)
Otter was purely reactive. Now it notices things worth doing, unprompted, and proposes them confirm-first on the dashboard.
- `lib/ai/proactive.ts` — read-only suggestion engine: open deep-work windows to protect, plus contextual nudges (turn on running-late alerts when you have back-to-back meetings; start a morning briefing) gated on current prefs.
- `/api/otter/suggestions` — GET the nudges, POST to act (focus → **real time_block** + best-effort calendar write; toggles upsert the pref).
- `components/proactive-otter.tsx` — "Otter noticed" dashboard card, confirm/dismiss (dismissals remembered locally).
- **Verified end-to-end:** suggestions computed from real calendar/prefs; focus creates a time_block; enable_briefing flips the pref.

## Automations + Workflows reconcile (Streamline #4, Stage 1)
Users conflated the two overlapping "when X, do Y" features. Unified the UI without touching the engines/schema:
- `/settings/automations` hosts both under clear sections — **Scheduling rules** (prep/buffer/weekly focus) and **Attendee messages** (before/after-event emails).
- `/settings/workflows` → redirects to the unified page; dropped the separate nav entry.
- Deferred (Stage 2/3): collapse the duplicated follow-up-email path + the real schema merge (per-user vs per-org ownership). Mobile still has separate screens.

Typecheck passes; biome-formatted.