### PR TITLE
polish(ai): more natural and accurate AI features

### DIFF
--- a/apps/web/app/api/webhooks/twilio/voice/route.ts
+++ b/apps/web/app/api/webhooks/twilio/voice/route.ts
@@ -67,7 +67,7 @@ export async function POST(request: Request): Promise<Response> {
       knowledge,
       history: [],
     };
-    const greeting = `Thanks for calling ${host.name}. How can I help you today?`;
+    const greeting = `Hi, thanks for calling ${host.name}. I can answer a few questions or help you book a time — what can I do for you?`;
     state.history.push({ role: "receptionist", text: greeting });
     await connection.set(stateKey, JSON.stringify(state), "EX", STATE_TTL);
     return sayAndGather(greeting, ACTION_PATH);

--- a/apps/web/lib/ai/memory/extractors.ts
+++ b/apps/web/lib/ai/memory/extractors.ts
@@ -1,10 +1,10 @@
-import { and, desc, eq, gte, inArray, schema } from "@dayotter/db";
-import { getDb } from "@dayotter/db";
+import { and, desc, eq, getDb, gte, inArray, schema } from "@dayotter/db";
 import { DateTime } from "luxon";
 import type { MemoryExtractor, MemoryFact } from "./types";
 
 /** Window of history each extractor learns from. */
 const LOOKBACK_DAYS = 90;
+const WEEKDAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
 
 /** Load the user's recent host bookings once, shared across extractors. */
 async function recentBookings(userId: string) {
@@ -22,39 +22,50 @@ async function recentBookings(userId: string) {
 }
 type RecentBooking = Awaited<ReturnType<typeof recentBookings>>[number];
 
-function mode<T>(items: T[]): T | null {
+function mode<T>(items: T[]): { value: T; share: number } | null {
+  if (items.length === 0) return null;
   const counts = new Map<T, number>();
   for (const i of items) counts.set(i, (counts.get(i) ?? 0) + 1);
   let best: T | null = null;
   let bestN = 0;
   for (const [k, n] of counts) if (n > bestN) (best = k), (bestN = n);
-  return best;
+  return best === null ? null : { value: best, share: bestN / items.length };
+}
+
+const plural = (n: number, w: string) => `${n} ${w}${n === 1 ? "" : "s"}`;
+
+/** Join names naturally: "Dana", "Dana and Priya", "Dana, Priya and Sam". */
+function naturalList(names: string[]): string {
+  if (names.length <= 1) return names[0] ?? "";
+  if (names.length === 2) return `${names[0]} and ${names[1]}`;
+  return `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`;
 }
 
 /**
  * The built-in extractors. Each derives one fact from a user's history. To teach
  * Otter something new, add an extractor here — nothing else needs to change.
- * Keep them cheap (they run on refresh) and honest (return null without signal).
+ * Keep them cheap (they run on refresh) and honest: only claim a pattern when
+ * it's a *clear* one, so Otter never states something wobbly as fact.
  */
 export const EXTRACTORS: MemoryExtractor[] = [
-  // How long the user's meetings usually run.
+  // How long the user's meetings usually run — only when it's genuinely typical.
   {
     key: "typical_duration",
     async extract(userId): Promise<MemoryFact | null> {
       const rows = await recentBookings(userId);
-      if (rows.length < 3) return null;
+      if (rows.length < 4) return null;
       const durations = rows.map((b) =>
         Math.round((b.endsAt.getTime() - b.startsAt.getTime()) / 60_000),
       );
-      const common = mode(durations);
-      if (!common) return null;
-      const share = durations.filter((d) => d === common).length / durations.length;
+      const m = mode(durations);
+      // Don't claim a "usual" length when meetings are all over the place.
+      if (!m || m.share < 0.5) return null;
       return {
         kind: "pattern",
         key: "typical_duration",
-        value: { minutes: common, share },
-        label: `Usually meets for ${common} minutes`,
-        confidence: Math.min(0.9, 0.4 + share / 2),
+        value: { minutes: m.value, share: m.share },
+        label: `Meetings are usually ${m.value} minutes`,
+        confidence: Math.min(0.9, 0.5 + m.share / 2),
       };
     },
   },
@@ -76,39 +87,63 @@ export const EXTRACTORS: MemoryExtractor[] = [
         .filter((c) => c.count >= 2)
         .sort((a, b) => b.count - a.count);
       if (top.length === 0) return null;
-      const names = top.slice(0, 3).map((c) => c.name);
+      const label = `Meets often with ${naturalList(top.slice(0, 3).map((c) => c.name))}`;
       return {
         kind: "contact",
         key: "frequent_contacts",
         value: top.slice(0, 5),
-        label: `Often meets with ${names.join(", ")}`,
-        confidence: 0.7,
+        label,
+        confidence: Math.min(0.85, 0.55 + top[0]!.count / 20),
       };
     },
   },
 
-  // The part of the day the user takes most meetings (in their timezone).
+  // The part of the day the user takes most meetings — only if it clearly leans.
   {
     key: "active_hours",
     async extract(userId): Promise<MemoryFact | null> {
       const rows = await recentBookings(userId);
-      if (rows.length < 4) return null;
-      const hours = rows.map((b) => DateTime.fromJSDate(b.startsAt).setZone(b.timezone).hour);
+      if (rows.length < 5) return null;
       const buckets = { morning: 0, afternoon: 0, evening: 0 };
-      for (const h of hours) {
+      for (const b of rows) {
+        const h = DateTime.fromJSDate(b.startsAt).setZone(b.timezone).hour;
         if (h < 12) buckets.morning++;
         else if (h < 17) buckets.afternoon++;
         else buckets.evening++;
       }
-      const top = (Object.entries(buckets) as [keyof typeof buckets, number][]).sort(
+      const entries = (Object.entries(buckets) as [keyof typeof buckets, number][]).sort(
         (a, b) => b[1] - a[1],
-      )[0];
-      if (!top || top[1] === 0) return null;
+      );
+      const [topLabel, topN] = entries[0]!;
+      const share = topN / rows.length;
+      if (share < 0.5) return null; // no clear lean — don't guess
       return {
         kind: "pattern",
         key: "active_hours",
-        value: buckets,
-        label: `Takes most meetings in the ${top[0]}`,
+        value: { ...buckets, lean: topLabel, share },
+        label: `Prefers meetings in the ${topLabel}`,
+        confidence: Math.min(0.8, 0.4 + share / 2),
+      };
+    },
+  },
+
+  // The weekday the user meets most — helps Otter avoid piling onto a busy day.
+  {
+    key: "busiest_weekday",
+    async extract(userId): Promise<MemoryFact | null> {
+      const rows = await recentBookings(userId);
+      if (rows.length < 6) return null;
+      const byDay = new Array(7).fill(0);
+      for (const b of rows)
+        byDay[DateTime.fromJSDate(b.startsAt).setZone(b.timezone).weekday % 7]++;
+      const max = Math.max(...byDay);
+      const day = byDay.indexOf(max);
+      if (max / rows.length < 0.3) return null; // spread evenly — no standout
+      return {
+        kind: "pattern",
+        key: "busiest_weekday",
+        value: { weekday: day, count: max },
+        label: `${WEEKDAYS[day]}s are usually the busiest`,
         confidence: 0.6,
       };
     },
@@ -126,7 +161,7 @@ export const EXTRACTORS: MemoryExtractor[] = [
         kind: "pattern",
         key: "meeting_load",
         value: { perWeek, sample: rows.length },
-        label: `Books about ${perWeek} meetings a week`,
+        label: `Books about ${plural(perWeek, "meeting")} a week`,
         confidence: 0.6,
       };
     },

--- a/apps/web/lib/ai/proactive.ts
+++ b/apps/web/lib/ai/proactive.ts
@@ -21,11 +21,11 @@ export type ProactiveSuggestion =
   | { id: string; type: "enable_overflow"; title: string; detail: string }
   | { id: string; type: "enable_briefing"; title: string; detail: string };
 
-/** Are there back-to-back meetings in the next week (a running-late risk)? */
-async function hasBackToBack(userId: string): Promise<boolean> {
+/** The user's confirmed meetings over the next week (shared across checks). */
+async function upcomingWeek(userId: string): Promise<{ startsAt: Date; endsAt: Date }[]> {
   const now = new Date();
   const weekOut = new Date(now.getTime() + 7 * 86_400_000);
-  const rows = await getDb().query.bookings.findMany({
+  return getDb().query.bookings.findMany({
     where: and(
       eq(schema.bookings.hostId, userId),
       eq(schema.bookings.status, "confirmed"),
@@ -35,6 +35,10 @@ async function hasBackToBack(userId: string): Promise<boolean> {
     orderBy: asc(schema.bookings.startsAt),
     columns: { startsAt: true, endsAt: true },
   });
+}
+
+/** Does the week contain a tight, back-to-back pair (a running-late risk)? */
+function hasBackToBack(rows: { startsAt: Date; endsAt: Date }[]): boolean {
   for (let i = 0; i < rows.length - 1; i++) {
     const gapMin = (rows[i + 1]!.startsAt.getTime() - rows[i]!.endsAt.getTime()) / 60_000;
     if (gapMin >= 0 && gapMin <= 5) return true;
@@ -50,12 +54,13 @@ const FOCUS_BLOCK_MINUTES = 90;
  */
 export async function getProactiveSuggestions(userId: string): Promise<ProactiveSuggestion[]> {
   const db = getDb();
-  const [user, prefs] = await Promise.all([
+  const [user, prefs, upcoming] = await Promise.all([
     db.query.users.findFirst({ where: eq(schema.users.id, userId), columns: { timezone: true } }),
     db.query.userPreferences.findFirst({
       where: eq(schema.userPreferences.userId, userId),
       columns: { overflowNotifyEnabled: true, briefingEnabled: true },
     }),
+    upcomingWeek(userId),
   ]);
   const tz = user?.timezone ?? "UTC";
   const out: ProactiveSuggestion[] = [];
@@ -69,31 +74,31 @@ export async function getProactiveSuggestions(userId: string): Promise<Proactive
       id: `focus:${s.startISO}`,
       type: "focus",
       title: "Protect deep-work time",
-      detail: `${start.toFormat("ccc, LLL d")} · ${start.toFormat("h:mm")}–${end.toFormat("h:mm a")} is free`,
+      detail: `${start.toFormat("cccc")} ${start.toFormat("h:mm")}–${end.toFormat("h:mm a")} is open`,
       startISO: s.startISO,
       durationMinutes: Math.round(end.diff(start, "minutes").minutes),
     });
   }
 
   // 2. Back-to-back meetings but running-late alerts are off.
-  if (!prefs?.overflowNotifyEnabled && (await hasBackToBack(userId))) {
+  if (!prefs?.overflowNotifyEnabled && hasBackToBack(upcoming)) {
     out.push({
       id: "enable_overflow",
       type: "enable_overflow",
       title: "Turn on running-late alerts",
       detail:
-        "You've got back-to-back meetings coming up. I can warn your next guests if one runs over.",
+        "You've got back-to-back meetings this week. I can warn your next guests if one runs over.",
     });
   }
 
-  // 3. No morning briefing yet.
-  if (!prefs?.briefingEnabled) {
+  // 3. No morning briefing yet — only worth it once there's a day to brief.
+  if (!prefs?.briefingEnabled && upcoming.length > 0) {
     out.push({
       id: "enable_briefing",
       type: "enable_briefing",
       title: "Start the day with a briefing",
       detail:
-        "Each morning I can text you the day ahead — meetings and the focus time you've held.",
+        "Each morning I can text you the day ahead — your meetings and the focus time you've held.",
     });
   }
 

--- a/apps/web/lib/analytics/time-allocation/metrics.ts
+++ b/apps/web/lib/analytics/time-allocation/metrics.ts
@@ -77,12 +77,13 @@ export const METRICS: TimeMetric[] = [
     compute(d: TimeDataset): MetricResult | null {
       if (d.bookings.length === 0) return null;
       const hoursPerWeek = (sum(d.bookings) / 60 / d.windowDays) * 7;
+      const n = d.bookings.length;
       return {
         key: "weekly_load",
         kind: "stat",
         label: "Meeting load",
         value: `${hoursPerWeek.toFixed(1)}h / week`,
-        hint: `${d.bookings.length} meetings in the last ${d.windowDays} days`,
+        hint: `${n} meeting${n === 1 ? "" : "s"} in the last ${d.windowDays} days`,
       };
     },
   },

--- a/apps/web/lib/voice/receptionist.ts
+++ b/apps/web/lib/voice/receptionist.ts
@@ -44,13 +44,22 @@ const inputSchema = {
 } as const;
 
 function systemPrompt(host: VoiceHost): string {
-  return `You are the warm, efficient phone receptionist for ${host.name}. Callers phone in with questions or to book time.
+  return `You are the friendly, natural-sounding phone receptionist for ${host.name}. People call with questions or to book time. Talk the way a warm, competent human receptionist does on the phone.
 
-Rules:
-- Answer ONLY from the KNOWLEDGE provided. If you don't know, say you'll have ${host.name} follow up — never invent hours, prices, or availability.
-- Keep replies SHORT and natural for speech — one or two sentences, no lists, no URLs read aloud.
-- If the caller wants to book / make an appointment, set next = "send_booking_link" and tell them you'll text them a link to pick a time.
-- If the caller is finished, thanks you, or says goodbye, set next = "hangup" with a brief sign-off.
+How to talk:
+- Keep it SHORT — one or two spoken sentences. No lists, and never read out a URL or email address.
+- Sound human: use contractions ("I'll", "you're", "let me see"), and say times and numbers the way people say them out loud ("two thirty", "half an hour", not "2:30 PM").
+- Briefly acknowledge what the caller said before you answer, so it feels like a real back-and-forth.
+- One question at a time. If you didn't quite catch something, ask them to repeat it.
+
+What you actually know:
+- Answer ONLY from the KNOWLEDGE below. If something isn't there — exact hours, prices, live availability — say you'll have ${host.name} follow up, rather than guessing. Never invent details.
+
+Booking:
+- If the caller wants to book or make an appointment, first confirm which service they mean (from the services you know). Then set next = "send_booking_link" and tell them you're texting a link to their phone so they can pick a time that works.
+
+Ending:
+- When the caller is finished, thanks you, or says goodbye, set next = "hangup" with a brief, warm sign-off.
 - Otherwise set next = "listen" and keep helping.`;
 }
 

--- a/apps/web/lib/voice/twiml.ts
+++ b/apps/web/lib/voice/twiml.ts
@@ -9,6 +9,10 @@ function esc(s: string): string {
 
 const VOICE = 'voice="Polly.Joanna-Neural"';
 
+/** Scheduling words we bias the recognizer toward — improves phone accuracy. */
+const SPEECH_HINTS =
+  "book, appointment, reschedule, cancel, availability, hours, meeting, consultation, price, times";
+
 function doc(inner: string): Response {
   return new Response(`<?xml version="1.0" encoding="UTF-8"?><Response>${inner}</Response>`, {
     status: 200,
@@ -16,10 +20,16 @@ function doc(inner: string): Response {
   });
 }
 
-/** Speak `say`, then listen for the caller's next utterance (speech). */
+/**
+ * Speak `say`, then listen for the caller's next utterance. Uses Twilio's
+ * enhanced phone-call speech model + domain hints for better transcription, and
+ * lets the caller barge in over the prompt so it feels like a real conversation.
+ */
 export function sayAndGather(say: string, actionPath: string): Response {
   return doc(
-    `<Gather input="speech" speechTimeout="auto" action="${esc(actionPath)}" method="POST">` +
+    `<Gather input="speech" speechTimeout="auto" speechModel="phone_call" enhanced="true"` +
+      ` language="en-US" bargeIn="true" hints="${esc(SPEECH_HINTS)}"` +
+      ` action="${esc(actionPath)}" method="POST">` +
       `<Say ${VOICE}>${esc(say)}</Say>` +
       `</Gather>` +
       // If they say nothing, re-prompt once by re-hitting the same action.


### PR DESCRIPTION
A quality pass on the AI features — more natural phrasing, more accurate behaviour.

**Otter Memory** — only claims a pattern when it's genuinely clear (share gates on duration & active-hours; busiest-day needs a standout), so it never states something wobbly as fact. Natural phrasing + pluralization ("1 meeting", "Meets often with Dana and Priya"); added a `busiest_weekday` fact. *Verified: natural, accurate labels on real seeded history.*

**Voice receptionist** — enhanced `phone_call` speech model + domain hints + barge-in for better transcription and a real back-and-forth; a warmer, more human system prompt (contractions, say times aloud naturally, confirm the service before texting the link, one question at a time) + an expectation-setting greeting. *Verified: TwiML valid.*

**Proactive Otter** — only nudges the morning briefing once there's an upcoming day to brief (contextual, not noise); natural copy; single upcoming-week query.

**Time analytics** — pluralized the meeting-load hint.

All 11 packages typecheck; biome-formatted.