### PR TITLE
Open-source project setup: AGPLv3 + EE license, contributor docs, AI & enterprise sections, Cal.com comparison

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,53 @@
+name: 🐛 Bug report
+description: Something isn't working as expected
+title: "fix: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. **Do not report security issues here** — see our
+        [Security Policy](../../blob/main/SECURITY.md).
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: dropdown
+    id: edition
+    attributes:
+      label: Edition
+      options:
+        - Self-hosted
+        - DayOtter Cloud (dayotter.com)
+        - Local development
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version / commit
+      placeholder: e.g. v0.4.0 or git SHA
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment
+      description: OS, browser, or mobile OS; anything relevant.
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshots
+      description: Relevant server logs (redact secrets) or screenshots.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Questions & discussion
+    url: https://github.com/nometria/dayotter/discussions
+    about: Ask questions, share what you're building, or discuss ideas before filing.
+  - name: 🔒 Report a security vulnerability
+    url: https://github.com/nometria/dayotter/security/advisories/new
+    about: Please report vulnerabilities privately — never as a public issue.
+  - name: 🗺️ Roadmap
+    url: https://github.com/nometria/dayotter/blob/main/docs/ROADMAP.md
+    about: See what's planned before requesting a feature.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,56 @@
+name: ✨ Feature request
+description: Suggest an idea or improvement for DayOtter
+title: "feat: "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea! Please check the [Roadmap](../../blob/main/docs/ROADMAP.md)
+        and existing issues first — someone may already be on it.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: The user pain, not the solution. "As a <role>, I want <goal> so that <benefit>."
+      placeholder: When I run team round-robin, I can't pause a rep who's on holiday…
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What you'd like to see happen. Rough is fine.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches, workarounds you use today, or how other tools do it.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Otter / AI
+        - Scheduling & availability
+        - Teams (round-robin / routing)
+        - Calendar sync
+        - Notifications & reminders
+        - Analytics & insights
+        - Payments / packages
+        - Mobile app
+        - Self-hosting / deploy
+        - Other
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and the roadmap
+          required: true
+        - label: I'd be willing to help build this
+          required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+<!-- Thanks for contributing to DayOtter! Keep PRs focused — one logical change. -->
+
+## What & why
+
+<!-- What does this change, and what problem does it solve? -->
+
+Closes #
+
+## How I verified it
+
+<!-- Not just "it typechecks" — how did you exercise the behaviour end to end? -->
+
+- [ ] `pnpm turbo typecheck` passes
+- [ ] `pnpm biome check` passes (formatted + linted)
+- [ ] Verified the change by driving the actual flow / endpoint
+- [ ] Added/updated a DB migration (`pnpm --filter @dayotter/db generate`) if the schema changed
+- [ ] Updated docs / module README if behaviour or an extension point changed
+
+## Notes for the reviewer
+
+<!-- Anything worth calling out: trade-offs, follow-ups, screenshots. -->
+
+---
+
+By submitting this PR I confirm I wrote this code (or have the right to
+contribute it) and agree to license it under **AGPLv3** (or the EE license for
+changes under `ee/`).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,61 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards and
+will take appropriate and fair corrective action in response to any behavior
+they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**conduct@dayotter.com**. All complaints will be reviewed and investigated
+promptly and fairly. All community leaders are obligated to respect the privacy
+and security of the reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,96 @@
+# Contributing to DayOtter
+
+Thanks for helping build the open scheduling platform. This guide gets you from
+zero to a merged PR.
+
+## Code of conduct
+
+By participating you agree to the [Code of Conduct](./CODE_OF_CONDUCT.md). Be
+kind, be constructive.
+
+## Ways to contribute
+
+- **Report a bug** or **request a feature** → [open an issue](../../issues/new/choose).
+- **Improve docs** — the fastest way to make a first contribution.
+- **Fix a bug** or **build a feature** — grab an issue labelled `good first issue`
+  or `help wanted`, or propose your own (see *Proposing a change* below).
+- **Add to an extensible module** — the AI extractors, time-allocation metrics,
+  voice knowledge sources, and reminder kinds are all registry-based; adding one
+  is a great first PR. See each module's `README.md`.
+
+## Before you start
+
+For anything larger than a small fix, **open an issue first** so we can agree on
+the approach before you invest time. Check the [Roadmap](./docs/ROADMAP.md) to
+see if it's already planned.
+
+## Development setup
+
+Requirements: **Node 20+**, **pnpm 10+**, **Docker** (for Postgres + Redis).
+
+```bash
+git clone https://github.com/nometria/dayotter && cd dayotter
+docker compose up -d            # Postgres + Redis
+cp .env.example .env            # fill in what you need (most features degrade gracefully without creds)
+pnpm install
+pnpm db:push                    # create the schema
+pnpm dev                        # web on :3000, worker in the background
+```
+
+You don't need every credential to start — Otter needs `ANTHROPIC_API_KEY`,
+calendar sync needs OAuth creds, messaging needs Twilio, etc. Features that
+aren't configured stay inert rather than crashing.
+
+## Project layout
+
+See [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md) for the full map. In short:
+`apps/web` (Next.js + API + Otter), `apps/worker` (BullMQ jobs), `apps/mobile`
+(Expo), `packages/*` (shared libs), `docs/*`.
+
+## Making a change
+
+1. **Branch** off `main`: `git checkout -b feat/short-name` (or `fix/`, `docs/`,
+   `chore/`).
+2. **Write it to match the surrounding code** — same patterns, naming, and
+   comment density. We favour small, well-commented, self-explaining code.
+3. **Keep it green:**
+   ```bash
+   pnpm turbo typecheck          # all packages must typecheck
+   pnpm biome check --write .    # format + lint (or `pnpm lint`)
+   ```
+4. **Verify behaviour**, not just types — exercise the change end to end
+   (drive the flow, hit the endpoint). Add tests where the repo has them
+   (`packages/core` is unit-tested; add cases there for pure logic).
+5. **Migrations:** if you touch `packages/db/src/schema/*`, run
+   `pnpm --filter @dayotter/db generate` to create the SQL migration and commit
+   it. Never hand-edit a generated migration.
+
+## Commits & PRs
+
+- **Conventional Commits:** `feat(scope): …`, `fix(scope): …`, `docs: …`,
+  `refactor: …`, `chore: …`. The scope is the module (`ai`, `booking`, `voice`,
+  `db`, …).
+- **One logical change per PR.** Smaller PRs get reviewed faster.
+- Fill in the PR template: what changed, why, and how you verified it. Link the
+  issue (`Closes #123`).
+- CI must be green (typecheck + lint). A maintainer will review; expect a couple
+  of rounds of feedback.
+
+## Licensing of contributions
+
+- Contributions to the **open-source core** (everything outside `ee/`) are
+  accepted under **AGPLv3** — the repo's license. By opening a PR you certify you
+  wrote the code (or have the right to contribute it) and agree to license it
+  under AGPLv3.
+- The **`ee/`** directory is commercial (see [`apps/web/lib/ee/LICENSE.md`](./apps/web/lib/ee/LICENSE.md));
+  most contributors never touch it, and PRs to it need explicit maintainer
+  sign-off.
+
+## Security
+
+Please **don't** file security issues publicly. See [`SECURITY.md`](./SECURITY.md)
+for private disclosure.
+
+## Questions
+
+Open a [discussion](../../discussions) or email hello@dayotter.com. Thank you 🦦

--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,661 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-   1. Definitions.
+                            Preamble
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
 
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
 
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
 
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
 
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
 
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
 
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
+  The precise terms and conditions for copying, distribution and
+modification follow.
 
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
+                       TERMS AND CONDITIONS
 
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
+  0. Definitions.
 
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
+  "This License" refers to version 3 of the GNU Affero General Public License.
 
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
 
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
 
-      (a) You must give any other recipients of the Work or Derivative
-          Works a copy of this License; and
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
 
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
 
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
 
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and do
-          not modify the License. You may add Your own attribution notices
-          within Derivative Works that You distribute, alongside or as an
-          addendum to the NOTICE text from the Work, provided that such
-          additional attribution notices cannot be construed as modifying
-          the License.
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
 
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
 
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
+  1. Source Code.
 
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
 
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
 
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
 
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
 
-   END OF TERMS AND CONDITIONS
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
 
-   APPENDIX: How to apply the Apache License to your work.
+  The Corresponding Source for a work in source code form is that
+same work.
 
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
+  2. Basic Permissions.
 
-   Copyright 2026 dayotter
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
 
-       http://www.apache.org/licenses/LICENSE-2.0
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -1,116 +1,107 @@
-# dayotter
+<div align="center">
 
-Open-source team scheduling & calendar platform. Sync every calendar (Google,
-Microsoft 365, Apple), share availability across your team, let people book you,
-and get automatic reminders before every call.
+# DayOtter
 
-Apache-2.0 licensed — self-host it, or use the hosted cloud.
+**The AI-native, open-source scheduling platform.**
+Say it once — Otter books the meeting, protects your focus, and clears the back-and-forth. Confirm-first, always.
 
-## Why
+[Website](https://dayotter.com) · [Docs](./docs) · [Roadmap](./docs/ROADMAP.md) · [AI architecture](./docs/AI.md) · [Contributing](./CONTRIBUTING.md)
 
-Founders and teams overpay for scheduling tools that still can't handle multiple
-calendars or shared team availability well. dayotter treats **shared team
-availability as a first-class primitive** (collective + round-robin, no paywall)
-and unifies all your calendars into one source of truth.
+![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)
+![Self-hostable](https://img.shields.io/badge/self--hostable-yes-brightgreen)
+![Made with TypeScript](https://img.shields.io/badge/TypeScript-strict-3178c6)
+
+</div>
+
+---
+
+## Why DayOtter
+
+Calendly is closed and cloud-only. **[Cal.com moved its core to a closed repo in April 2026](https://cal.com/blog/cal-diy-open-source-to-closed-source)** — citing AI — leaving only a stripped-down MIT fork with the commercial features removed. Motion and Reclaim were never open at all.
+
+DayOtter is the alternative that stays genuinely open: **AGPLv3, self-host the _whole_ product** — including every AI feature — for free, forever. Not a demo, not a stripped fork.
+
+And it's built around **Otter**, a confirm-first AI executive assistant that actually does the scheduling work, not just shares a link:
+
+- Talk to it — in the app, by voice, or over **WhatsApp / SMS**.
+- It **protects your focus time**, warns your next meeting when you're **running late**, and proactively **notices things worth doing**.
+- It **learns your patterns** over time.
+- It **never touches your calendar without your OK.**
+
+## Features
+
+**Scheduling** · unlimited event types & booking pages · Google / Microsoft 365 / Apple (CalDAV) / ICS calendar sync · availability engine with buffers, notice, timezones · recurring meetings · group polls · accept payments (Stripe) · prepaid session packages
+
+**Teams** · weighted round-robin & collective booking · routing forms · shared availability · per-seat billing
+
+**Otter (AI)** · natural-language command bar · voice input (mobile) · **inbound WhatsApp/SMS** · **AI voice receptionist** (24/7 phone line) · focus auto-scheduling · running-late overflow alerts · **proactive suggestions** · **long-term memory** · post-meeting recap. See [`docs/AI.md`](./docs/AI.md).
+
+**Insight** · booking analytics + "where your time goes" time-allocation · CSV export
+
+**Platform** · multi-channel reminders (email, Slack, WhatsApp, SMS, push) · automations & workflows · API keys & webhooks · mobile app (Expo, iOS + Android)
+
+## Open-core
+
+DayOtter is **open-core**, the way Cal.com _used to be_:
+
+- **Everything outside `ee/` is AGPLv3** — the whole product, including all of Otter's AI. Self-host it and pay nothing.
+- **`ee/` is a small, separately-licensed commercial layer** for *cloud-only infrastructure* — Managed AI (no key to configure), SSO, white-label, hosted messaging. It's inert unless `DAYOTTER_CLOUD=1`. See [`apps/web/lib/ee/LICENSE.md`](./apps/web/lib/ee/LICENSE.md) and [`docs/ENTERPRISE.md`](./docs/ENTERPRISE.md).
+
+You do **not** need `ee/` to run the full product.
 
 ## Monorepo layout
 
 ```
 apps/
-  web       Next.js — dashboard, public booking pages, REST API
-  worker    Node — BullMQ workers: reminders + calendar sync
+  web       Next.js 15 — dashboard, public booking pages, REST API, Otter
+  worker    Node + BullMQ — reminders, calendar sync, briefings, scribe
+  mobile    Expo (React Native) — iOS + Android
 packages/
-  core          availability engine, round-robin, token crypto (pure, unit-tested)
-  calendar      provider adapters: Google, Microsoft, Apple (CalDAV) behind one interface
+  core          availability engine, round-robin, crypto (pure, unit-tested)
   db            Drizzle schema + Postgres client
-  notifications multi-channel delivery: Slack, WhatsApp/SMS (Twilio), mobile push (Expo)
+  jobs          BullMQ queue contracts (shared producer/consumer)
+  calendar      Google / Microsoft / Apple adapters behind one interface
+  integrations  provider OAuth + sync
+  notifications multi-channel delivery (Slack, Twilio, Expo/web push)
+  emails        transactional email (Resend / SMTP)
+  auth          Better Auth config (email, Google, phone/OTP)
 ```
 
-## Stack
-
-TypeScript everywhere · Next.js 15 · Postgres + Drizzle · Redis + BullMQ ·
-Luxon (timezones) · googleapis / Microsoft Graph / tsdav (CalDAV).
+Full breakdown: [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md).
 
 ## Quick start (development)
 
 ```bash
-# 1. Datastores
-docker compose up -d          # Postgres + Redis
+# 1. Datastores (Postgres + Redis)
+docker compose up -d
 
-# 2. Config
-cp .env.example .env          # fill in OAuth creds + generate secrets
-
-# 3. Install & migrate
-pnpm install
-pnpm db:push                  # create schema
-
-# 4. Run
-pnpm dev                      # web (:3000) + worker
-```
-
-Generate secrets:
-
-```bash
-openssl rand -base64 32       # AUTH_SECRET
-openssl rand -hex 32          # ENCRYPTION_KEY (32-byte token-encryption key)
-```
-
-## Deploy to production (one-click)
-
-Want it live on your own server with HTTPS, not just localhost? The [`deploy/`](deploy/)
-directory has a production stack (web + worker + Postgres + Redis + Caddy for
-automatic TLS, with DB migrations applied on boot):
-
-- **AWS, one click** — a CloudFormation *Launch Stack* button spins up an EC2
-  instance that boots the whole thing. See [deploy/README.md](deploy/README.md).
-- **Any Ubuntu box, one command:**
-  ```bash
-  curl -fsSL https://raw.githubusercontent.com/OWNER/dayotter/main/deploy/install.sh \
-    | sudo DAYOTTER_DOMAIN=cal.example.com bash
-  ```
-
-The installer creates strong secrets on first run and brings everything up.
-Full guide, day-two ops, and backups: **[deploy/README.md](deploy/README.md)**.
-
-## Self-hosting (Docker, from a checkout)
-
-The full stack — web, worker, Postgres, and Redis — runs from one compose file.
-The `app` profile builds the web + worker images; without it you get just the
-datastores (the dev workflow above).
-
-```bash
-# 1. Configure — fill in secrets, OAuth creds, and any optional providers
+# 2. Config — fill in OAuth creds + generate secrets
 cp .env.example .env
 
-# 2. Create the schema on first run (fresh database)
-docker compose up -d postgres redis
-docker compose --profile app run --rm worker pnpm --filter @dayotter/db migrate
+# 3. Install & create the schema
+pnpm install
+pnpm db:push
 
-# 3. Build + start everything
-docker compose --profile app up -d --build
+# 4. Run web (:3000) + worker
+pnpm dev
 ```
 
-The web app is served on `http://localhost:3000`. Optional integrations are
-env-gated and no-op until configured:
+**Stack:** TypeScript · Next.js 15 · Postgres + Drizzle · Redis + BullMQ · Luxon · Anthropic (Otter) · Better Auth · Stripe · Twilio.
 
-| Feature | Env vars |
-| --- | --- |
-| AI scheduling / drafts | `ANTHROPIC_API_KEY` |
-| WhatsApp + SMS reminders | `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_WHATSAPP_FROM`, `TWILIO_SMS_FROM` |
-| Slack + mobile push reminders | none — the destination travels with each channel's config |
-| Analytics | `NEXT_PUBLIC_MIXPANEL_TOKEN`, `NEXT_PUBLIC_GA_ID` |
-| Bot/abuse protection | `TURNSTILE_SECRET`, `NEXT_PUBLIC_TURNSTILE_SITE_KEY` |
+## Self-hosting (production)
 
-## Testing
+Docker Compose brings up Postgres, Redis, migrations, web, worker, and a reverse proxy. See [`deploy/README.md`](./deploy/README.md) and [`docs/SELF_HOSTING.md`](./docs/SELF_HOSTING.md). Redeploys always run migrations via [`deploy/deploy.sh`](./deploy/deploy.sh).
 
-```bash
-pnpm test                     # runs the core availability + crypto test suites
-```
+## Contributing
 
-## Status
+We'd love your help — see [`CONTRIBUTING.md`](./CONTRIBUTING.md) for setup, conventions, and the PR flow, and [`docs/ROADMAP.md`](./docs/ROADMAP.md) for where we're headed. Good first issues are labelled on the tracker. By contributing, you agree your changes are licensed under AGPLv3 (or the EE license for `ee/`).
 
-Early foundation. Working today: monorepo, full data model, the availability
-engine (unit-tested), provider adapters, background workers (reminders + sync),
-and the availability REST endpoint. See [docs/FEATURES.md](docs/FEATURES.md) for
-the full roadmap and [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for how it fits
-together.
+- [Report a bug or request a feature](../../issues/new/choose)
+- [Security policy](./SECURITY.md) · [Code of conduct](./CODE_OF_CONDUCT.md)
+
+## License
+
+- **Core:** [GNU AGPLv3](./LICENSE) — free to use, self-host, modify, and share.
+- **`ee/`:** [DayOtter Enterprise Edition License](./apps/web/lib/ee/LICENSE.md) — commercial, cloud-only.
+
+© DayOtter. "Otter" and "DayOtter" are trademarks; the AGPL covers the code, not the brand.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,45 @@
+# Security Policy
+
+DayOtter handles calendars, tokens, and personal data — we take security
+seriously, and we believe being open makes the product *more* secure, not less.
+Every line is auditable, and fixes ship in the open.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security problems.**
+
+Report privately via one of:
+
+- **GitHub** → *Security* tab → *Report a vulnerability* (private advisory), or
+- **Email** `security@dayotter.com` (PGP available on request).
+
+Please include: a description, steps to reproduce (or a PoC), affected
+version/commit, and impact. We'll acknowledge within **3 business days**, keep
+you updated, and credit you in the advisory unless you prefer to stay anonymous.
+
+Please give us a reasonable window to fix and release before public disclosure
+(we aim for 90 days or sooner for critical issues).
+
+## Scope
+
+In scope: the code in this repository (web, worker, mobile, packages) and the
+hosted product at dayotter.com. Out of scope: third-party services we integrate
+with (Google, Microsoft, Stripe, Twilio, Anthropic) — report those to the
+respective vendor.
+
+## Handling secrets safely (self-hosters)
+
+- OAuth tokens, notification secrets, and webhook signing keys are **encrypted at
+  rest** (AES-256-GCM); API keys are stored **hashed**.
+- Set a strong `ENCRYPTION_KEY` / `BETTER_AUTH_SECRET` and never commit `.env`.
+- Inbound webhooks (Twilio SMS/voice, Stripe, calendar providers) are
+  **signature-verified and fail closed**.
+- Keep your deployment updated — security fixes land on `main` and are noted in
+  the changelog.
+
+## Our stance on "AI and security"
+
+Some vendors have used AI-assisted vulnerability discovery as a reason to *close*
+their source. We take the opposite view: transparency plus responsible
+disclosure is the stronger model. Automated auditing helps defenders too — we'd
+rather fix issues in the open than hide the code.

--- a/apps/web/app/(auth)/layout.tsx
+++ b/apps/web/app/(auth)/layout.tsx
@@ -88,7 +88,7 @@ export default function AuthLayout({ children }: { children: ReactNode }) {
             rel="noreferrer"
             className="hover:text-[var(--color-muted)]"
           >
-            Open source · Apache-2.0
+            Open source · AGPLv3
           </a>
         </div>
       </div>

--- a/apps/web/app/(marketing)/pricing/page.tsx
+++ b/apps/web/app/(marketing)/pricing/page.tsx
@@ -64,7 +64,7 @@ const TIERS: Tier[] = [
     features: [
       "Every Pro feature, free forever",
       "Your data on your servers",
-      "Apache-2.0 licensed core",
+      "AGPLv3 licensed core",
       "Docker & docker-compose",
       "Community support",
     ],

--- a/apps/web/app/(marketing)/self-hosting/page.tsx
+++ b/apps/web/app/(marketing)/self-hosting/page.tsx
@@ -13,7 +13,7 @@ export default function SelfHostingPage() {
       <MarketingHeader
         eyebrow="Open source"
         title="Self-host DayOtter"
-        subtitle="Your data, your servers, every feature unlocked — free forever under Apache-2.0."
+        subtitle="Your data, your servers, every feature unlocked — free forever under AGPLv3."
       />
       <Prose>
         <p>

--- a/apps/web/components/marketing/sections.tsx
+++ b/apps/web/components/marketing/sections.tsx
@@ -148,7 +148,7 @@ const HOME_FAQ = [
   },
   {
     q: "Can I self-host it?",
-    a: "The core is open-source, Apache-2.0 licensed, and ships with Docker. Run it on your own servers with every Pro feature unlocked, or let us host it for you.",
+    a: "The core is open-source, AGPLv3-licensed, and ships with Docker. Run it on your own servers with every Pro feature unlocked, or let us host it for you.",
   },
 ];
 
@@ -165,10 +165,7 @@ export function FAQ() {
       <Reveal className="mt-12">
         <div className="divide-y divide-[var(--color-border)] border-y border-[var(--color-border)]">
           {HOME_FAQ.map((item) => (
-            <details
-              key={item.q}
-              className="group py-5 [&_summary::-webkit-details-marker]:hidden"
-            >
+            <details key={item.q} className="group py-5 [&_summary::-webkit-details-marker]:hidden">
               <summary className="flex cursor-pointer list-none items-center justify-between gap-4 font-semibold">
                 {item.q}
                 <Plus
@@ -280,7 +277,7 @@ export function Footer() {
       <div className="border-t border-[var(--color-border)]">
         <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-2 px-6 py-6 text-xs text-[var(--color-faint)] sm:flex-row">
           <span>
-            © {BRAND.copyrightYear} {BRAND.name} · Apache-2.0
+            © {BRAND.copyrightYear} {BRAND.name} · AGPLv3
           </span>
           <span>Made for people who value their time.</span>
         </div>

--- a/apps/web/lib/comparisons.ts
+++ b/apps/web/lib/comparisons.ts
@@ -118,23 +118,35 @@ export const COMPARISONS: Comparison[] = [
   {
     slug: "cal-com",
     name: "Cal.com",
-    blurb: "Open-source and developer-grade — but its AI is a usage-priced voice add-on.",
+    blurb:
+      "Went closed-source in 2026, leaving a stripped MIT fork. DayOtter is the open alternative.",
     title: "DayOtter vs Cal.com",
     subtitle:
-      "Both are open-source with generous free plans. The difference is the assistant: DayOtter is built around a proactive AI EA that protects your time — Cal.com's AI is a separate, metered voice product.",
+      "Cal.com was the open-source scheduler for years — then moved its core to a closed repo in 2026, keeping only a stripped-down fork with the commercial features removed. DayOtter is the genuinely open alternative: AGPLv3, the whole product, AI included.",
     intro: [
-      "Cal.com is the open-source scheduler developers love — API-first, self-hostable, with a genuinely generous free tier and strong routing. On the fundamentals, DayOtter and Cal.com are close cousins.",
-      "Where they diverge is the assistant. Cal.com's AI (Cal.ai) is a usage-priced voice-agent add-on. DayOtter is designed from the ground up around Otter — a conversational assistant that books, protects focus, and handles overflow, confirm-first, at no per-minute cost.",
+      'For years Cal.com was the open-source scheduler developers loved — API-first, self-hostable, strong routing. In April 2026 it moved its production codebase to a closed repository (citing AI), keeping a separate MIT fork, "Cal.diy", with the commercial features — Organizations, Teams, Routing, Workflows, Instant Booking — removed. So the open version is now a demo, and the real product is closed.',
+      "DayOtter took the opposite path. The whole product — teams, routing, workflows, and all of Otter's AI — is AGPLv3 and self-hostable, free forever. And it's built around Otter, a confirm-first assistant that books, protects focus, and handles overflow at no per-minute cost (Cal.com's AI was a usage-priced voice add-on).",
     ],
     theirStrength:
-      "Cal.com's API and webhook surface is excellent, its app ecosystem is large, and its enterprise/org tier (attribute routing, SAML, SCIM, HIPAA) is further along. If you're building a scheduling product on top of an API, it's a strong platform.",
+      "Cal.com's API and app ecosystem are mature, and their hosted product is polished. If you want a managed scheduling API and don't mind that the core is now closed, it's an established choice.",
     rows: [
-      { label: "Open source / self-host", dayotter: "Yes", them: "Yes", edge: "tie" },
+      {
+        label: "License",
+        dayotter: "AGPLv3 — genuinely open",
+        them: "Core closed (2026); stripped MIT fork",
+        edge: "us",
+      },
+      {
+        label: "Self-host the whole product",
+        dayotter: "Yes — teams, routing, AI, all of it",
+        them: "Fork has commercial features removed",
+        edge: "us",
+      },
       { label: "Generous free plan", dayotter: "Yes", them: "Yes", edge: "tie" },
       {
         label: "AI assistant",
         dayotter: "Otter, included — chat + confirm-first",
-        them: "Cal.ai, usage-priced voice (~$0.29/min)",
+        them: "Cal.ai was usage-priced voice (~$0.29/min)",
         edge: "us",
       },
       {
@@ -166,30 +178,34 @@ export const COMPARISONS: Comparison[] = [
     ],
     whyUs: [
       {
+        title: "Still genuinely open source",
+        body: "Cal.com moved its core to a closed repo and stripped the commercial features out of its open fork. DayOtter is AGPLv3 — teams, routing, workflows, and all of Otter's AI are in the open core, self-hostable and free forever. Not a demo.",
+      },
+      {
         title: "The assistant is the product, not an add-on",
-        body: "With DayOtter, talking to Otter is the main way to get things done — book, reschedule, protect focus, all confirm-first, at no metered cost. Cal.com's AI is a separate voice product billed by the minute.",
+        body: "Talking to Otter is the main way to get things done — book, reschedule, protect focus, confirm-first, at no metered cost. Cal.com's AI was a separate voice product billed by the minute.",
       },
       {
         title: "Time protection built in",
-        body: "Otter finds open time and holds it for deep work, and warns your next meeting when you're running behind — Reclaim/Motion territory that Cal.com doesn't touch.",
-      },
-      {
-        title: "Calmer out of the box",
-        body: "Cal.com is powerful and endlessly configurable. DayOtter is opinionated and quiet by default — you're booked in minutes without wiring up apps.",
+        body: "Otter finds open time and holds it for deep work, and warns your next meeting when you're running behind — Reclaim/Motion territory Cal.com never touched.",
       },
     ],
     chooseThem:
-      "You're building on top of a scheduling API, want the deepest developer platform, or need mature enterprise org features (SAML/SCIM) right now.",
+      "You want a mature, managed scheduling API and app ecosystem, and you're comfortable that the core is now closed.",
     chooseUs:
-      "You want the open-source, self-hostable base plus a proactive AI assistant and time protection included — not a metered voice add-on.",
+      "You want a genuinely open, self-hostable platform — the whole product, AI included — with a proactive assistant and time protection built in.",
     faq: [
       {
-        q: "Both are open-source — what's the real difference?",
-        a: "The assistant and time protection. DayOtter is built around Otter (conversational, confirm-first, included) and defends your focus time. Cal.com's AI is a usage-priced voice add-on and it doesn't do focus scheduling.",
+        q: "Didn't Cal.com go closed source?",
+        a: "Yes — in April 2026 Cal.com moved its production code to a closed repository and kept only a stripped MIT fork with the commercial features (Orgs, Teams, Routing, Workflows) removed. DayOtter stayed open: AGPLv3, the whole product self-hostable.",
       },
       {
-        q: "Can I self-host DayOtter like Cal.com?",
-        a: "Yes — the core is Apache-2.0 and ships with Docker/compose. Self-hosting unlocks every feature for free.",
+        q: "Is DayOtter really fully open source?",
+        a: "The core — everything except a small cloud-only infrastructure layer (managed keys, SSO, white-label) — is AGPLv3 and self-hostable for free, including every AI feature. See our docs on editions and the enterprise boundary.",
+      },
+      {
+        q: "Can I self-host DayOtter?",
+        a: "Yes — it ships with Docker/compose and unlocks every Pro feature for free when self-hosted. No license key, no billing.",
       },
     ],
   },
@@ -325,7 +341,7 @@ export const COMPARISONS: Comparison[] = [
     subtitle:
       "Google Calendar is the calendar. DayOtter is the scheduling layer on top — booking pages, team routing, focus protection and an assistant — working with your Google Calendar, not replacing it.",
     intro: [
-      "Google Calendar is where most of us actually keep our time, and its built-in \"appointment schedules\" let people grab a slot. For one person with simple needs, that can be enough.",
+      'Google Calendar is where most of us actually keep our time, and its built-in "appointment schedules" let people grab a slot. For one person with simple needs, that can be enough.',
       "But the moment you need team round-robin, routing, reminders across channels, payments, or an assistant that protects your focus, you've outgrown it. DayOtter adds all of that — and syncs straight into the Google Calendar you already live in.",
     ],
     theirStrength:

--- a/apps/web/lib/ee/LICENSE.md
+++ b/apps/web/lib/ee/LICENSE.md
@@ -1,20 +1,45 @@
-# dayotter Commercial / Enterprise Edition (`ee/`)
+# DayOtter Enterprise Edition (EE) License
 
-**This directory is NOT covered by the open-source license of the rest of this
-repository.**
+**The code in any `ee/` directory is NOT open source and is NOT covered by the
+repository's AGPL-3.0 license (see the root `LICENSE`).**
 
-The code under `apps/web/lib/ee/` (and any other `ee/` directory) implements
-features exclusive to **dayotter Cloud** (the hosted product at dayotter.com). It
-is provided source-available for transparency but is licensed **only** for use
-in Anthropic/​dayotter's own hosted deployment.
+Copyright © DayOtter. All rights reserved.
 
-You may read this code. You may **not** use, run, copy, modify, or redistribute
-it as part of a self-hosted or third-party deployment without a commercial
-license from dayotter.
+## What this covers
 
-The open-source edition of dayotter (everything outside `ee/`) is fully
-functional on its own — these features simply do not activate when
-`DAYOTTER_CLOUD` is unset. See `docs/EDITIONS.md`.
+Every file under an `ee/` directory (currently `apps/web/lib/ee/`) implements
+**cloud-only** capabilities of DayOtter Cloud (the hosted product at
+dayotter.com):
 
-Everything else in this repository remains under the repository's open-source
-license (see the root `LICENSE`).
+- **Managed AI** — Otter running on DayOtter's own model provider, so you don't
+  configure an API key.
+- **SSO** — SAML / Google Workspace sign-in.
+- **White-label** — remove the "Powered by DayOtter" mark and serve booking pages
+  on a custom domain.
+- **Hosted messaging** — SMS / WhatsApp on DayOtter's Twilio with included credits.
+
+These are inert unless `DAYOTTER_CLOUD=1` is set. **The open-source edition of
+DayOtter — everything outside `ee/` — is the whole product and is fully
+functional on its own, including all of Otter's AI features.**
+
+## Grant
+
+You may **read** this source for transparency and reference.
+
+You may **not**, without a separate written commercial agreement with DayOtter:
+use, run, deploy, copy, modify, create derivative works of, sublicense, sell, or
+redistribute any `ee/` code, in whole or in part, as part of any self-hosted,
+internal, or third-party product or service.
+
+This restriction exists so the open-source community cannot resell DayOtter's
+commercial features. It does not restrict anything outside `ee/`.
+
+## Contributions
+
+Contributions to `ee/` are accepted only under this license and assign the
+necessary rights to DayOtter. Most contributors will never need to touch `ee/` —
+the open-source core is where the product lives.
+
+## Commercial licensing
+
+Want to run these features in your own deployment? Email **hello@dayotter.com**.

--- a/docs/AI.md
+++ b/docs/AI.md
@@ -1,0 +1,160 @@
+# Otter — the AI inside DayOtter
+
+Otter is DayOtter's AI executive assistant. This document covers the philosophy,
+the architecture, how the AI stays open, and — most importantly — **where it's
+going**: the advancements and improvements we want the community to help build.
+
+> The whole AI subsystem is **AGPLv3 and self-hostable**. Bring your own
+> `ANTHROPIC_API_KEY` (or point the model layer at any provider) and run every
+> feature below on your own infrastructure, for free. Cal.com closed its source
+> "because of AI"; we went the other way.
+
+---
+
+## Philosophy
+
+1. **Confirm-first, always.** Otter *proposes*; a human confirms before anything
+   is created, moved, cancelled, or sent — on every surface (web, chat, mobile,
+   SMS/WhatsApp, voice, proactive nudges). This is the invariant. No silent
+   auto-scheduling (the thing people fear about Motion).
+2. **Grounded, not hallucinated.** Otter answers from the user's real
+   availability, bookings, and knowledge base. It's told to defer ("I'll have the
+   host follow up") rather than invent hours, prices, or slots.
+3. **The assistant is the product, not an add-on.** Talking to Otter is a primary
+   way to use DayOtter — at no per-minute metered cost (unlike Cal.ai's voice).
+4. **One brain, every surface.** The command bar, mobile, and SMS share a single
+   interpret core, so behaviour is identical everywhere.
+
+## Architecture
+
+```
+                       ┌───────────────────────────────────────────┐
+  surfaces             │  web command bar · chat · mobile · SMS ·   │
+                       │  WhatsApp · voice · proactive suggestions   │
+                       └───────────────┬───────────────────────────┘
+                                       │
+        interpret.ts  ◀── memory recall ── retrieval (RAG-lite) ──▶ context
+        (the shared brain)             │
+                                       ▼
+        parse (single-shot)  ·  agent (availability loop)  ·  chat (streaming)
+                                       │
+                            ┌──────────┴──────────┐
+                            ▼                     ▼
+                     propose a draft        tool registry
+                     (confirm card)         (read inline / write→confirm)
+                                       │
+                              user taps Confirm
+                                       ▼
+                          execute (reuses the app's own write paths)
+```
+
+### The LLM layer — `lib/ai/llm.ts`
+The single Anthropic choke point. `aiEnabled` is just "is a key present." Model
+tiers live in one place — `deep: claude-opus-4-8`, `fast: claude-haiku-4-5` —
+swap models without touching features. `extract()` is the shared structured-output
+primitive (forced tool-use → Zod-validated object, with a chain-of-thought
+field), plus prompt caching and streaming. **No feature instantiates its own
+client**, which is what makes the model layer swappable (including to a
+self-hosted or alternative provider).
+
+### The interpret core — `lib/ai/interpret.ts`
+`interpretOtterCommand(userId, text)` is the shared brain for every non-chat
+surface. It recalls memory + retrieves relevant bookings in parallel, then routes:
+availability-dependent requests go through the agentic loop; everything else
+through the fast single-shot parser. Returns a confirm-first draft. Never writes.
+
+### The tool registry — `lib/ai/tools/`
+A declarative catalog where each tool is tagged `read` / `write` / `destructive`
+with a confirm level. **Reads run inline; writes surface a confirm card;
+destructive actions get a danger confirm.** Execution reuses the app's own
+validated DB writes — the assistant can never do anything the app itself
+couldn't. To give Otter a new capability, add a tool.
+
+### Memory — `lib/ai/memory/`  ([module README](../apps/web/lib/ai/memory/README.md))
+Long-term, per-user patterns (typical duration, frequent contacts, active hours,
+busiest weekday, meeting load) derived from real history and injected into the
+prompt so proposals get personal. Self-refreshing, honest (only claims clear
+patterns). **Extension point:** add a `MemoryExtractor`.
+
+### Proactive — `lib/ai/proactive.ts`
+Otter noticing things unprompted — protect an open focus window, turn on
+running-late alerts when you have back-to-backs, start a morning briefing — each
+confirm-first on the dashboard.
+
+### Voice receptionist — `lib/voice/`  ([module README](../apps/web/lib/voice/README.md))
+A 24/7 phone line: greets, answers from the host's knowledge, and texts a booking
+link (never books blind). Pluggable knowledge sources; enhanced phone speech
+recognition.
+
+### Where your time goes — `lib/analytics/time-allocation/`  ([README](../apps/web/lib/analytics/time-allocation/README.md))
+A pluggable metric registry over your bookings + focus time. Add a `TimeMetric`.
+
+## How the AI stays open
+
+- **Bring your own key / model.** Set `ANTHROPIC_API_KEY` and everything works.
+  Because all AI flows through `llm.ts`, pointing at a different provider (or a
+  self-hosted model) is a one-file change.
+- **No data leaves without use.** If you never use Otter, nothing is sent to a
+  model. When you do, only the relevant scheduling context goes.
+- **The commercial part is convenience, not capability.** DayOtter Cloud's
+  "Managed AI" (in `ee/`) just means *we* supply the key so you don't have to —
+  the AI *code* is fully open. See [`ENTERPRISE.md`](./ENTERPRISE.md).
+
+---
+
+## Roadmap — advancements we want to build
+
+Otter is early. These are the improvements that would most deepen it — great
+places to contribute. Grouped by ambition.
+
+### Near-term (sharpen what's here)
+- **Memory depth** — more extractors (preferred buffers, no-meeting days,
+  reschedule habits, video-vs-in-person preference); LLM-summarised freeform
+  notes from conversations as low-confidence `inferred` facts.
+- **Proactive breadth** — buffer suggestions for back-to-backs, "your Thursday is
+  overloaded — move something?", stale-holds cleanup, follow-up nudges.
+- **Voice quality** — capture the caller's name/intent, confirm-back before
+  texting, multi-tenant number→host mapping, call transcripts + summaries.
+- **Grounding** — a real knowledge-base store (custom FAQ, hours, pricing) the
+  voice + chat assistants answer from, with citations.
+- **Time analytics** — external-vs-internal split (by email domain), longest focus
+  streak, recurring load, "reclaimed time" Otter protected.
+
+### Mid-term (new capability)
+- **Real Scribe** — live Zoom/Meet transcription → summary + extracted action
+  items, wired into post-meeting workflows (today it's a recap nudge).
+- **Negotiation over SMS/voice** — actually book a specific slot conversationally
+  (propose times, confirm), not just hand over a link.
+- **Team-aware Otter** — "find 30 min with the design pod next week" resolving
+  across members' real availability and round-robin weights.
+- **Smart routing by intent** — the routing form powered by Otter understanding
+  the enquiry, not just field rules.
+
+### Longer-term (the vision)
+- **A genuinely proactive EA** — Otter plans the week with you: proposes a draft
+  calendar each Monday (focus blocks, batched meetings, protected mornings),
+  confirm-first, learning from what you accept.
+- **Multi-model + local** — first-class support for self-hosted/open models so a
+  fully offline, private Otter is possible.
+- **Evaluation harness** — a test suite of scheduling scenarios to measure
+  accuracy and prevent regressions as prompts and models change. (High-value,
+  low-glamour — a great contribution.)
+- **Agentic tool growth** — as the tool registry expands, Otter can handle more of
+  the calendar end-to-end, always confirm-first.
+
+## Contributing to Otter
+
+The AI subsystem is deliberately modular so improvements are small, well-scoped
+PRs:
+
+| Want to… | Do this |
+|---|---|
+| Teach Otter a new fact | add a `MemoryExtractor` to `EXTRACTORS` |
+| Add a proactive nudge | add a `ProactiveSuggestion` type + action |
+| Add a "where your time goes" insight | add a `TimeMetric` to `METRICS` |
+| Give the voice bot new knowledge | add a `KnowledgeSource` |
+| Give Otter a new capability | add a tool to the registry (`kind` + confirm level) |
+| Support another model/provider | it's one place — `llm.ts` |
+
+See [`CONTRIBUTING.md`](../CONTRIBUTING.md) and each module's README. Ideas and
+prototypes welcome in [Discussions](../../discussions).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,61 +1,124 @@
-# dayotter — Architecture
+# Architecture
 
-## The three core systems
+DayOtter is a TypeScript monorepo (pnpm + Turborepo). This is the map of what
+lives where and why. For the AI subsystem see [`AI.md`](./AI.md); for the
+open-core boundary see [`ENTERPRISE.md`](./ENTERPRISE.md).
 
-Everything else is product work on top of these:
+## The engines (single sources of truth)
 
-1. **Calendar sync engine** (`packages/calendar` + `apps/worker`) — bidirectional
-   sync across Google / Microsoft / Apple behind one `CalendarAdapter` interface.
-   Real-time via provider webhooks (Google `watch`, MS Graph subscriptions);
-   Apple/CalDAV is poll-based. Busy times land in a Postgres cache (`busy_blocks`).
-2. **Availability engine** (`packages/core`) — a pure function: given a schedule,
-   busy blocks, and event constraints, return bookable slots. Timezone/DST-correct
-   via Luxon. Fully unit-tested. `intersectAvailability` powers collective team
-   scheduling; `roundRobinPick` powers weighted round-robin.
-3. **Durable jobs** (`apps/worker`) — BullMQ on Redis for reminders (1d / 1h) and
-   sync. Reminders are idempotent (a `scheduled_reminders` row + a `jobId`), so a
-   reschedule cleanly replaces the pending job and nothing double-sends.
+Every feature builds on these; nothing duplicates their logic.
 
-## Data model (packages/db)
+1. **Timezone** — Luxon everywhere; all times stored UTC, rendered per-viewer.
+2. **Sync** (`packages/calendar` + `apps/worker/sync`) — bidirectional sync across
+   Google / Microsoft / Apple (CalDAV) / ICS behind one `CalendarAdapter`.
+   Real-time via provider webhooks; Apple/ICS is poll-based. Busy times land in a
+   Postgres cache (`busy_blocks`) — the availability engine reads only the cache.
+3. **Availability** (`packages/core/availability`) — a pure function: schedule +
+   busy blocks + constraints → bookable slots. DST-correct, unit-tested.
+4. **Notification** (`packages/jobs` + `apps/worker/reminders` + `packages/notifications`) —
+   durable BullMQ delayed jobs; multi-channel delivery.
+5. **LLM** (`apps/web/lib/ai/llm.ts`) — the single Anthropic choke point; model
+   tiering, prompt caching, structured output. Every AI feature goes through it.
 
-Tenanted on `organizations`. Key tables:
+## Monorepo layout
 
-- **orgs**: `organizations`, `users`, `memberships` (RBAC)
-- **calendar**: `calendar_connections` (encrypted OAuth tokens), `calendars`,
-  `webhook_subscriptions`, `busy_blocks` (free/busy cache)
-- **scheduling**: `schedules`, `availability_rules`, `date_overrides`, `event_types`
-- **booking**: `bookings`, `booking_attendees`, `booking_references` (per-provider
-  event id for two-way sync)
-- **team**: `teams`, `team_members`, `event_type_hosts` (round-robin pools)
-- **workflow**: `workflows`, `workflow_event_types`, `scheduled_reminders`
+```
+apps/
+  web       Next.js 15 — dashboard, public booking pages, REST API, Otter
+  worker    Node + BullMQ — reminders, sync, maintenance, briefings, scribe, webhooks
+  mobile    Expo / React Native (expo-router) — iOS + Android
+packages/
+  core          availability engine, weighted round-robin, crypto, SSRF guards (pure)
+  db            Drizzle schema (split by domain) + Postgres client
+  jobs          BullMQ queues + producers (shared web↔worker contracts)
+  calendar      Google / Microsoft / Apple / ICS adapters behind one interface
+  integrations  binds stored connections to the calendar adapters (token refresh)
+  notifications Slack / Twilio (SMS·WhatsApp) / Expo push / web push
+  emails        Nodemailer + transactional templates
+  auth          Better Auth server instance (identity + organizations)
+```
 
-## Request flows
+## `apps/web/lib` — by domain
 
-### Booking-page availability (read)
-`GET /api/availability/:eventTypeId` → load event type + schedule + cached busy
-blocks from Postgres → `computeAvailability()` → JSON slots. No provider API calls
-on the hot path; the cache is kept warm by the sync worker.
+### booking/
+The scheduling core. `create-booking.ts` (validate slot → write booking +
+attendees → calendar → reminders → webhooks), `availability.ts` (adapts the core
+engine to event types: `hostSlots`), `host-booking.ts` (host-initiated/Otter
+bookings, hung off the hidden `__personal` event type — see
+`personal-event-type.ts`), `cancel-booking.ts` / `reschedule-booking.ts`,
+`reminders.ts` (schedules reminders, workflow messages, overflow checks, scribe),
+`insights.ts` + `analytics.ts` + `focus-insights.ts` (metrics), `focus-suggestions.ts`
+(deep-work windows), `travel.ts`, `running-late.ts`, `overlay.ts` (booker-side
+calendar overlay), `rank-slots.ts`, `team-schedule.ts`.
 
-### A booking is made (write)
-Create `bookings` row → `CalendarAdapter.createEvent()` on the host's target
-calendar (+ Meet/Teams link) → store `booking_references` → send confirmation →
-enqueue reminder jobs at (start − 1d) and (start − 1h).
+### ai/  → see [`AI.md`](./AI.md)
+`llm.ts`, `interpret.ts` (the shared brain), `command-parse.ts`, `agent.ts`,
+`chat.ts`, `retrieval.ts` (RAG-lite), `tools/` (registry + exec), `memory/`,
+`proactive.ts`, `invite-triage.ts`, `meeting-actions.ts`.
 
-### An external calendar changes (sync)
-Provider webhook → `sync` queue → adapter `getBusy()` over the rolling window →
-replace `busy_blocks` for those calendars. (Next step: incremental `syncToken`
-deltas instead of full-window refresh.)
+### analytics/time-allocation/
+"Where your time goes" — a pluggable metric registry (`METRICS[]`) over one
+dataset. Extensible; see its README.
 
-## Security
+### voice/  → see [`AI.md`](./AI.md)
+The AI phone receptionist: `receptionist.ts`, `knowledge.ts` (pluggable sources),
+`resolver.ts`, `twiml.ts`.
 
-OAuth tokens are encrypted at rest with AES-256-GCM (`packages/core/crypto`,
-`ENCRYPTION_KEY`). Tokens never leave the worker/server boundary.
+### messaging/
+`otter-sms.ts` (inbound SMS/WhatsApp → confirm-first Otter),
+`twilio-signature.ts` (shared, fail-closed HMAC validation).
 
-## Known scaffolding / next steps
+### packages/ (in-app)
+Prepaid session bundles: `credits.ts` (atomic spend), `fulfill.ts` (Stripe grant).
 
-- OAuth connect routes + Better Auth wiring (sign-in, orgs) — not yet built.
-- Webhook receiver endpoints + subscription renewal jobs.
-- Sync currently does a full-window free/busy refresh and attributes busy blocks
-  to the primary conflict calendar; switch to per-calendar incremental deltas.
-- Apple/CalDAV adapter needs live testing against iCloud.
-- Booking write flow (create/reschedule/cancel) + public booking UI.
+### billing/  → see [`ENTERPRISE.md`](./ENTERPRISE.md)
+`edition.ts` (`isCloud`), `features.ts` (free/pro/cloud tiers + `hasFeature`),
+`entitlements.ts`, `require-feature.ts` (402 gate on cloud+free only),
+`subscription.ts` (Stripe sync).
+
+### payments/
+`stripe.ts` (the one Stripe layer, env-gated), `pending.ts` (Redis stash during
+Checkout), `fulfill.ts` (idempotent paid→booking).
+
+### calendar/
+`host-calendar.ts` (write to the host's target calendar), `calendar-connect.ts`,
+`providers.ts` (OAuth app config), `oauth-state.ts` (signed anti-CSRF state),
+`invites.ts` / `invite-actions.ts` / `inbox.ts` (calendar inbox).
+
+### server/
+`http.ts` (`withUser`, `jsonError`), `rate-limit.ts` (Redis token bucket),
+`env.ts` (Zod-validated typed env), `api-key.ts` (public API key auth).
+
+### routing/ · polls/ · intelligence/ · automation/ · webhooks/ · integrations/
+Routing forms; meeting polls; the recommendations engine; automation rules
+(`apply-rules.ts`); outbound webhook fan-out (`emit.ts`, SSRF-hardened); Zoom.
+
+## `packages/db/schema` (Drizzle, split by domain)
+
+`orgs` (organizations, users, memberships) · `auth` (sessions, accounts) ·
+`team` (teams, members, rules) · `scheduling` (schedules, availabilityRules,
+timeBlocks, automationRules, eventTypes) · `booking` (bookings, attendees,
+references) · `calendar` (connections, calendars, busyBlocks) · `conferencing` ·
+`poll` · `routing` · `workflow` (workflows, scheduledReminders) · `packages`
+(sessionPackages, packageCredits) · `memory` (otterMemory) · `analytics`
+(bookingPageViews) · `preferences` (userPreferences, notificationChannels) ·
+`developer` (apiKeys, webhookEndpoints, webhookDeliveries).
+
+Migrations live in `packages/db/drizzle/*.sql` (drizzle-kit generate; never
+hand-edit).
+
+## `apps/worker`
+
+`reminders` (due reminders / follow-ups / no-show / running-late / recap /
+workflow emails) · `sync` (incremental calendar sync over a 90-day window) ·
+`maintenance` (~15-min tick: auto-complete past bookings, drives
+`materializeWeeklyBlocks` + `sendDueBriefings`) · `webhooks` (signed,
+SSRF-hardened outbound delivery).
+
+## Conventions
+
+- **Types are the contract.** `pnpm turbo typecheck` gates everything.
+- **Confirm-first for AI.** Otter proposes; a human confirms. See `AI.md`.
+- **Feature-gate at the edition, not per user.** `isCloud` is deploy-time.
+- **Best-effort side effects never break the booking.** Calendar writes,
+  reminders, webhooks are wrapped and logged, not fatal.

--- a/docs/ENTERPRISE.md
+++ b/docs/ENTERPRISE.md
@@ -1,0 +1,74 @@
+# Enterprise & the open-core boundary
+
+DayOtter is **open-core**. This document is the honest, precise line between what
+you get free forever and what's commercial — and why we drew it there.
+
+**TL;DR:** the *whole product*, including every AI feature, is AGPLv3 and free to
+self-host. A small `ee/` layer of *cloud-only infrastructure* is separately
+licensed so the community can't resell our hosted service. That's the entire
+difference.
+
+## The two licenses
+
+| | License | What it covers | Self-host? |
+|---|---|---|---|
+| **Core** | [AGPLv3](../LICENSE) | Everything outside `ee/` — scheduling, teams, **all of Otter's AI**, analytics, payments, packages, mobile | ✅ Free, forever |
+| **Enterprise (`ee/`)** | [DayOtter EE License](../apps/web/lib/ee/LICENSE.md) | Cloud-only infrastructure (below) | ❌ Commercial only |
+
+The `ee/` code is **source-available** (you can read it) but **not open source**:
+you may not run, copy, modify, or resell it without a commercial agreement. It is
+inert unless `DAYOTTER_CLOUD=1`.
+
+## What's in `ee/` (and why it's not in the core)
+
+These are **cloud-only infrastructure** — they're about *us operating a hosted
+service*, not about product capability. A self-hoster doesn't need them because
+they bring their own equivalents.
+
+| `ee/` feature | What it is | Self-host equivalent |
+|---|---|---|
+| **Managed AI** | Otter running on *our* model key so you don't configure one | Set your own `ANTHROPIC_API_KEY` — same AI |
+| **Hosted messaging** | SMS/WhatsApp on *our* Twilio with included credits | Set your own `TWILIO_*` |
+| **SSO** | SAML / Google Workspace via our hosted control plane | (roadmap for self-host) |
+| **White-label** | Remove branding + custom domain via our edge | `brandingHidden` gate exists; CNAME/TLS is hosted |
+
+The pattern: **the code is open; the managed keys and credits are the commercial
+part.** You can run Otter, messaging, and branding yourself — you just supply
+your own provider accounts.
+
+## Why this line (and not Cal.com's)
+
+When [Cal.com went closed source](https://cal.com/blog/cal-diy-open-source-to-closed-source),
+they *removed* the commercial features (Organizations, Teams, Routing, Workflows,
+Instant Booking) from the open fork — so the open version is a stripped
+demo. **We didn't.** Teams, routing, workflows, and all of Otter's AI are in the
+open core. The only things behind a commercial license are the bits that only
+make sense when *DayOtter* runs the servers.
+
+This keeps the promise: **self-host the whole product, free.**
+
+## How feature-gating works in code
+
+- `lib/billing/edition.ts` — `isCloud = DAYOTTER_CLOUD === "1"` (deploy-time, so a
+  self-hoster can't accidentally paywall themselves).
+- `lib/billing/features.ts` — the tier catalog: `free` (never gated), `pro`
+  (differentiators — **free on self-host**, $9/seat on cloud), `cloud`
+  (`ee/`-only). Single policy: `hasFeature(feature, {isCloud, isPro})`.
+- `lib/billing/require-feature.ts` — returns a 402 only on **cloud + not-Pro**; on
+  self-host it never blocks.
+
+So on self-host, `isPro` is effectively always true and `cloud` features are
+simply absent. See [`EDITIONS.md`](./EDITIONS.md) for the full pricing/edition
+breakdown.
+
+## Commercial licensing
+
+Want to run the `ee/` features in your own deployment, or need an enterprise
+agreement (support, SLA, invoicing, a self-host SSO connector)? Email
+**hello@dayotter.com**.
+
+## Contributing to `ee/`
+
+Most contributors never touch `ee/` — the product lives in the open core.
+Contributions to `ee/` are accepted only under the EE license and need explicit
+maintainer sign-off. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,153 +1,69 @@
-# dayotter Roadmap & Build Tracker
+# Roadmap
 
-> The single source of truth for **what's built, what's partial, and what's next**.
-> Organized by the layered **Time-OS engine model**: every feature builds on an
-> engine below it; no feature duplicates scheduling / timezone / notification /
-> sync logic. Update this doc as things land.
+Where DayOtter is and where it's going. This is a living document — open an
+[issue](../../issues/new/choose) to propose something, and check
+[Discussions](../../discussions) for what's being debated.
 
-**Legend:** ✅ done · 🟡 partial · ⬜ not started · ⭐ differentiator
-
-**Architectural rule (non-negotiable):** a new feature must build on an existing
-engine, never introduce parallel business logic. Engines are the single source of
-truth: **Timezone**, **Sync**, **Availability**, **Notification**, **LLM**,
-**Payments**. Everything else composes them.
+**Legend:** ✅ shipped · 🟡 partial · ⬜ planned · ⭐ differentiator
 
 ---
 
-## Phase 0 — Core Platform
-| Capability | Status | Notes |
-|---|---|---|
-| Email/password, Google, Microsoft sign-in | ✅ | Better Auth; **Google social sign-in now enabled** (env-gated `NEXT_PUBLIC_GOOGLE_AUTH`). MS social ⬜. |
-| Sessions, multi-device, bearer (mobile) | ✅ | |
-| Account recovery (password reset) | ✅ | Better Auth `sendResetPassword` → emailed link; /forgot-password + /reset-password; change-password in Settings |
-| Profile: name, photo, timezone, locale | 🟡 | photo = `image` URL only (no upload); working-location + language ⬜ |
-| Preferences (encrypted): hours, days, reminders, channels, time format | ✅ | AES-256-GCM `encryptedData` |
-| Lunch hours / calendar defaults | ✅ | daily lunch-break preference blocks availability (DST-correct); other calendar defaults ⬜ |
-| Postgres, Redis, job queue, background workers | ✅ | BullMQ |
-| **Object storage** (avatars/attachments) | ⬜ | **NEW** — needed for photo upload + attachments |
-| **Audit logs** | ⬜ | **NEW** |
-| **Metrics** | 🟡 | structured `logger` + `/health` only; no metrics pipeline |
-| **Feature flags** | ⬜ | **NEW** |
+## Shipped
 
-## Phase 1 — Calendar Engine ⭐ (highest priority: "nothing else matters if calendars can't be trusted")
-| Capability | Status | Notes |
-|---|---|---|
-| Google / Microsoft / Apple(CalDAV) providers | ✅ | adapters behind one interface |
-| Generic CalDAV (Fastmail/Nextcloud) | 🟡 | adapter takes `serverUrl`, no UI (ICS-feed import now covers many of these) |
-| **ICS feed import** | ✅ | subscribe an external ICS/webcal URL as a read-only busy source (SSRF-guarded, recurrence-aware, poll-synced). Raw `.ics` file upload ⬜ |
-| Initial / incremental / webhook sync + reconciliation | ✅ | syncToken/delta + maintenance job |
-| Duplicate detection | ✅ | busy_blocks upsert on `(calendarId, externalEventId)` |
-| Deleted-event handling | ✅ | `deletedExternalIds` |
-| Sync retries | ✅ | BullMQ |
-| **Conflict resolution (bidirectional edits)** | 🟡 | last-writer-wins on our writes; no merge policy |
-| Connect / disconnect calendars | ✅ | disconnect now has UI (cascade-removes calendars/events/busy/subs) |
-| Pick conflict-check calendars / write-target | ✅ | `checkForConflicts` |
-| **Rename calendars, visibility, read-only/writable controls** | ✅ | per-calendar manager: rename, hide, toggle availability, pick booking write-target (read-only guarded) |
-| **Unified full event model** (title, guests, recurrence, location, privacy, metadata) | ✅ | `calendar_events` table (migration 0008); adapters ingest full events; `busy_blocks` is now its lean availability projection. Attachments field TBD. |
-| Calendar health: last sync, OAuth expiry, errors | ✅ | reconnect alerts + **duplicate-event detection** (same meeting on 2+ calendars) + **timezone-mismatch** (write-target tz ≠ schedule) in the Inbox; missing-event ⬜ |
-| Timezone Engine (DST, organizer/viewer/device) | ✅ | Luxon, DST-tested |
-| **Floating events / traveling-user timezone** | ⬜ | **NEW** |
+**Scheduling core** — ✅ unlimited event types & booking pages · ✅ Google /
+Microsoft 365 / Apple (CalDAV) / ICS sync · ✅ availability engine (buffers,
+notice, timezones, DST) · ✅ recurring meetings · ✅ group polls · ✅ accept
+payments (Stripe) · ✅ prepaid session packages
 
-## Phase 2 — Scheduling Engine
-| Capability | Status | Notes |
-|---|---|---|
-| Availability engine (working hours, buffers, focus, holidays, limits, tz) | ✅ | pure + unit-tested |
-| **Ranked availability / suggested slots** | ✅ | **recommended times** — `rank-slots.ts` scores by consolidation (back-to-back), preferred hour, recency; top-3 surfaced on the booking page + starred in the grid. Conflict-reason strings ⬜ |
-| Booking links: 1:1, collective, round-robin | ✅ | |
-| **Group events** (many bookers, one slot) | ✅ | capacity per slot (`max_attendees`); slot stays open until full, concurrency-safe (is_group exempt from the single-slot + GiST guards, seat limit enforced in-txn with a per-slot advisory lock). Not written to host calendar. |
-| Unlimited event types (duration/buffer/questions/platform/notifications) | ✅ | |
-| Multiple durations · slot interval · min-gap · daily limit | ✅ | |
-| **Expiring / password-protected / one-off links** | ✅ | one-off ✅, expiring ✅, **password ✅** (SHA-256 access code gates the public page + book-time verify) |
-| Private/secret event types · redirect · color · duplicate | ✅ | |
-| Booking pages: public profile, team, mobile-friendly | ✅ | |
-| **Branded booking pages · embedded widget** | ✅ | embed `/embed.js` (inline+popup) + **per-host branding** (accent colour + welcome message + avatar, re-themes the whole page) + **i18n** (en/es/fr/de/pt) + **SavvyCal overlay** (booker pastes ICS → clashing slots grey out) |
-| Scheduling policies: min notice, daily/weekly limits, window | ✅ | **weekly limit ✅** (per host-local ISO week, enforced in the booking txn) |
-| **No-meeting windows · preferred weekdays** | 🟡 | date-overrides support it in engine; no dedicated UI |
-| **Date-specific overrides UI · multiple named schedules** | ✅ | date-overrides editor + **multiple named schedules** (CRUD + switcher + per-event-type picker; engine honours the pinned `scheduleId`) |
-| Payments: require payment, deposits, refunds, multi-currency | ✅ | Stripe |
+**Teams** — ✅ ⭐ weighted round-robin & collective · ✅ routing forms · ✅ shared
+availability · ✅ per-seat billing
 
-## Phase 3 — Planning Engine
-| Capability | Status | Notes |
-|---|---|---|
-| Manual time blocks / focus blocks | ✅ | first-class `time_blocks` (focus/personal/travel/other); block the availability engine; manager on the Availability page |
-| **Recurring / protected blocks** | ✅ | manual blocks repeat weekly (4/8/12/26w), DST-correct, series-aware delete |
-| Deep work: focus sessions, **targets, auto-protection, weekly goals** | 🟡 | suggestions only; targets/goals ⬜ |
-| Planning views: daily / weekly / monthly / agenda | ✅ | calendar views shipped this session |
-| **Timeline view** | ⬜ | **NEW** |
-| **Schedule balancing** (overloaded/empty days, redistribution, density viz) | ⬜ | **NEW** |
-| **Personal events** (travel, exercise, family, birthdays) | ⬜ | **NEW** — needs the unified event model |
+**Otter (AI)** — ✅ ⭐ confirm-first command bar · ✅ voice input (mobile) ·
+✅ ⭐ inbound WhatsApp/SMS · ✅ ⭐ AI voice receptionist · ✅ ⭐ focus
+auto-scheduling · ✅ running-late overflow alerts · ✅ ⭐ proactive suggestions ·
+✅ ⭐ long-term memory · 🟡 post-meeting recap (recap nudge; transcription pending)
 
-## Phase 4 — Communication Engine
-| Capability | Status | Notes |
-|---|---|---|
-| Channels: email, push, Slack, WhatsApp, SMS | ✅ | desktop ⬜ |
-| Reminder engine: 1d, 1h, custom | ✅ | recurring reminders 🟡 |
-| Delay management (overflow → notify next meeting) | ✅ | ⭐ shipped; auto-detection of overrun ⬜ |
-| Invitation inbox: accept / decline / tentative | ✅ | **suggest-another-time ✅** (emails organizer + tentative RSVP) · **delegate ✅** (forwards to a teammate) |
+**Insight** — ✅ booking analytics + funnel · ✅ ⭐ "where your time goes"
 
-## Phase 5 — Automation Engine
-| Capability | Status | Notes |
-|---|---|---|
-| Natural-language scheduling (create / reschedule / cancel) | ✅ | confirm-first, singular LLM layer |
-| **Automation rules** (trigger → action) | ✅ | `automation_rules`: booking-created triggers (prep block before / buffer after / **follow-up email**) fire in `createBooking`; **weekly time-based triggers** ("every Friday, block 13:00–17:00") materialize focus `time_blocks` across a 14-day horizon on the maintenance tick (tz-correct, idempotent). Settings → Automations. |
-| **Event templates** (duration, buffers, reminders, links, follow-up) | ⬜ | **NEW** (email templates exist for workflows, not event templates) |
-| **Smart rescheduling** (cancelled → focus) | 🟡 | cancelled future 1:1 → freed time held as a focus block (pref-gated). Delayed→shift-downstream ⬜ |
+**Platform** — ✅ multi-channel reminders (email/Slack/WhatsApp/SMS/push) ·
+✅ automations & workflows (unified) · ✅ daily morning briefing · ✅ API keys &
+webhooks · ✅ mobile app (Expo, iOS + Android)
 
-## Phase 6 — Intelligence Engine
-| Capability | Status | Notes |
-|---|---|---|
-| Calendar analytics (meeting hours, focus, busiest day, by-type) | ✅ | Insights page + `/api/insights` |
-| **Booking analytics** (funnel, conversion, revenue, CSV export) | ✅ | `booking_page_views` beacon + `computeAnalytics()`; `/analytics` page (views→visitors→bookings→confirmed funnel, per-event-type table, revenue) + `/api/analytics` + CSV export |
-| **Focus analytics** (context switching, fragmentation, deep-work) | ✅ | Insights page: meetings/busy-day, %fragmented (3+/day), %back-to-back (<15min), avg longest focus gap — pure `computeFocusMetrics`, tz-aware |
-| **Calendar-health detection** (unused recurring mtgs, repeated cancellations, late meetings, inefficiencies) | ⬜ | **NEW** — needs unified event model |
-| **Recommendations** ("move customer calls to mornings", "protect Friday") | ⬜ | **NEW** |
-| ⭐ **Calendar Memory** (learn habits → soft recommendations, never hard rules) | ⬜ | **NEW differentiator** |
+## Now (in progress / next up)
 
-## Phase 7 — Collaboration
-| Capability | Status | Notes |
-|---|---|---|
-| Shared team calendar view · collective · round-robin · team event types | ✅ | the wedge |
-| **Shared booking links** | ⬜ | **NEW** |
-| **Team scheduling rules** (company holidays, meeting-free windows) | ✅ | team_rules block every member's availability (individual + team pages), applied per-member in their tz; admin-managed on the team page. Shared team focus blocks ⬜ |
+- ⬜ **Native CRM** — Salesforce / HubSpot sync (the top parity gap with Calendly)
+- 🟡 **Real Scribe** — Zoom/Meet transcription → summary + action items
+- ⬜ **Team briefings** — a shared daily digest, not just personal
+- ⬜ **Deeper time analytics** — external-vs-internal, focus streaks, reclaimed time
 
-## Phase 8 — Mobile (companion, not reduced web)
-| Capability | Status | Notes |
-|---|---|---|
-| Expo app: host mgmt, event types, availability, bookings, settings, calendar, insights, AI, channels, overflow, **workflows, booking-page branding** | ✅ | typecheck + Metro-export verified; workflows CRUD + branding (accent + welcome) at parity with web |
-| **Voice commands** ✅ (web: Web Speech API; mobile: on-device expo-speech-recognition, needs a dev build). Native push · widgets · live activities · offline ⬜ | 🟡 | |
-| Quick actions (running late, accept/decline, book, delay) | 🟡 | running-late + overflow shipped; rest ⬜ |
+## Next
 
-## Phase 9 — Public Platform
-| Capability | Status | Notes |
-|---|---|---|
-| REST API (internal, bearer-authed for mobile) | ✅ | not a public contract |
-| **API keys · outbound webhooks · SDK · Zapier · n8n · MCP server · browser extension · CLI** | 🟡 | **v1 shipped** — hashed API keys + public REST API (`/api/v1/*`); outbound webhooks (encrypted signing secret, HMAC-SHA-256 signed delivery via BullMQ queue+worker, booking.created/cancelled/rescheduled); `/embed.js` SDK. MCP server · extension · CLI ⬜ |
+- ⬜ **Zapier app + integration directory** — beyond raw webhooks
+- ⬜ **Otter memory depth** — more learned patterns; preference capture in-chat
+- ⬜ **Voice receptionist v2** — conversational booking, transcripts, multi-tenant
+- ⬜ **Self-host SSO** — a SAML/OIDC connector for self-hosters
+- ⬜ **CRM-grade routing** — Otter-understood enquiry routing
 
-## Phase 10 — Enterprise (deferred by owner)
-Organizations ✅ · RBAC ✅ · audit logs ⬜ · SSO/SAML/SCIM ⬜ · admin dashboard ⬜ · billing ⬜ · self-hosting ✅ (Docker) · compliance ⬜. **Explicitly parked until earlier phases are excellent.**
+## Later (vision)
+
+- ⬜ ⭐ **Proactive weekly planning** — Otter drafts your week (focus blocks,
+  batched meetings), confirm-first, learning from what you accept
+- ⬜ **Multi-model / local AI** — first-class self-hosted model support for a
+  fully private Otter
+- ⬜ **AI evaluation harness** — scenario tests to keep Otter accurate across
+  model/prompt changes
+
+See [`AI.md`](./AI.md) for the detailed AI roadmap and how to contribute to it.
 
 ---
 
-## ⭐ Long-term differentiators (should shape architecture now)
-| Differentiator | Status | Depends on |
-|---|---|---|
-| AI Meeting Overflow | 🟡 | manual today; auto-detect needs provider presence signals |
-| **Calendar Memory** (habit learning) | ⬜ | unified event model + Intelligence engine |
-| **Travel-Aware Scheduling** (travel time, airport buffers, hybrid locations) | 🟡 | **v1 shipped** — in-person bookings reserve a configurable travel buffer as `travel` time_blocks before + after (Preferences → travel time); airport buffers / maps-based estimates ⬜ |
-| **Adaptive Availability** (fewer slots on heavy days) | 🟡 | **shipped** — pref-driven daily meeting cap hides slots on heavy days (via the event model). Auto-reserve-focus-when-target-missed still ⬜. |
-| **Calendar Inbox** (unified: pending invites, conflicts, expired links, broken sync, suggestions) | 🟡 | **v1 shipped** — `/inbox` composes sync-health (reconnect) + double-booking detection (via event model) + pending invites + focus suggestions. Add expired-links + optimization nudges next. |
-| **Meeting Lifecycle** (scheduled→confirmed→reminded→joined→delayed→completed→follow-up→archived) with automation hooks | 🟡 | **v1 shipped** — `no_show`/`completed` booking statuses; host no-show toggle on past bookings; post-meeting **follow-up emails** via the reminder infra (`kind=followup`) + follow-up automation action; no-shows feed Intelligence. Full state machine (joined/delayed detection) ⬜ |
+## How we prioritize
 
----
+1. **Depth over breadth** — make Otter genuinely useful before adding surface.
+2. **Confirm-first, always** — no feature breaks the "Otter proposes, you confirm"
+   invariant.
+3. **Open first** — capability lands in the open core; only cloud-only
+   *infrastructure* goes in `ee/`.
 
-## Highest-leverage NEW work this PRD surfaces (beyond the §-cluster list)
-1. **Unified full event model** — ingest full events (not just busy times). Foundational; unlocks Planning, Intelligence, Calendar Inbox, personal events, travel-aware.
-2. **Calendar Inbox** — one actionable surface for every pending scheduling action. Highest UX leverage.
-3. **Automation Engine** — rules + templates + smart rescheduling. The Zapier-for-your-calendar wedge.
-4. **Planning Engine** — schedule balancing + recurring/protected blocks + timeline + personal events.
-5. **Intelligence Engine** — focus analytics + calendar-health recommendations + Calendar Memory.
-6. **Calendar Engine hardening surfacing** — health dashboard, ICS import, calendar rename/visibility/read-only.
-7. **Developer platform** — outbound webhooks, API keys, SDK, MCP server, extension, CLI.
-
-## Reprioritization signal
-The PRD says **Calendar Engine is the highest priority** — its robustness (unified event model, health, conflict resolution) should come before piling on more scheduling/AI features, since those sit on top of it. Recommend interleaving **engine-hardening** with the remaining feature clusters rather than a pure feature march.
+Want something moved up? 👍 the issue, or better yet, send a PR — see
+[`CONTRIBUTING.md`](../CONTRIBUTING.md).

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -1,0 +1,134 @@
+# Self-hosting DayOtter
+
+Run the whole product — including all of Otter's AI — on your own infrastructure,
+free, under AGPLv3. This is the setup guide.
+
+## Requirements
+
+- **Node 20+** and **pnpm 10+** (for local/dev) — or just **Docker** (for prod)
+- **Postgres 15+** and **Redis 7+**
+- Provider credentials for the features you want (all optional — unconfigured
+  features stay inert, they don't crash)
+
+## Quick start (local / evaluation)
+
+```bash
+git clone https://github.com/nometria/dayotter && cd dayotter
+docker compose up -d            # Postgres + Redis
+cp .env.example .env            # see Configuration below
+pnpm install
+pnpm db:push                    # create the schema
+pnpm dev                        # web on http://localhost:3000 + worker
+```
+
+## Production
+
+Use the Docker Compose stack in [`deploy/`](../deploy). It runs Postgres, Redis,
+a one-shot migration, web, worker, and a reverse proxy.
+
+```bash
+cd deploy
+cp .env.example .env            # fill in production values
+./deploy.sh                     # build → run migrations → start
+```
+
+`deploy.sh` **always runs migrations before starting the app** — a plain
+`docker compose up -d` reuses the completed migrate container and can boot new
+code against an un-migrated DB. Full walkthrough (nginx + TLS options) in
+[`deploy/README.md`](../deploy/README.md). To update: `git pull` then re-run
+`./deploy.sh`.
+
+## Configuration
+
+Set these in `.env`. **Everything is optional** — DayOtter runs with just a
+database, and each capability lights up when you add its credentials.
+
+### Core (required)
+
+```ini
+DATABASE_URL=postgresql://user:pass@localhost:5432/dayotter
+REDIS_URL=redis://localhost:6379
+APP_URL=https://your-domain.com
+BETTER_AUTH_SECRET=<32+ random bytes>     # openssl rand -base64 32
+ENCRYPTION_KEY=<32 bytes>                  # encrypts OAuth tokens at rest
+```
+
+### Otter (AI) — bring your own key
+
+```ini
+ANTHROPIC_API_KEY=sk-ant-...              # that's it — every AI feature works
+```
+
+Because all AI flows through one layer (`lib/ai/llm.ts`), you can point it at a
+different provider or a self-hosted model with a small change. See [`AI.md`](./AI.md).
+
+### Calendars (OAuth)
+
+```ini
+GOOGLE_CLIENT_ID=...        GOOGLE_CLIENT_SECRET=...
+MICROSOFT_CLIENT_ID=...     MICROSOFT_CLIENT_SECRET=...
+# Apple/CalDAV needs no app — users add an app-specific password
+```
+
+Google sign-in also needs `NEXT_PUBLIC_*` build args baked at build time — the
+Docker build handles this.
+
+### Messaging & notifications
+
+```ini
+RESEND_API_KEY=...          # or SMTP_URL=smtp://...   (transactional email)
+TWILIO_ACCOUNT_SID=...  TWILIO_AUTH_TOKEN=...
+TWILIO_SMS_FROM=+1...    TWILIO_WHATSAPP_FROM=whatsapp:+1...
+```
+
+**Inbound Otter (SMS/WhatsApp)** — point your Twilio number's inbound webhook at
+`https://<APP_URL>/api/webhooks/twilio`. **Voice receptionist** — point the
+number's *A Call Comes In* webhook at `.../api/webhooks/twilio/voice` and set
+`VOICE_RECEPTIONIST_HANDLE=<the host handle>`. Both are signature-verified.
+
+### Payments
+
+```ini
+STRIPE_SECRET_KEY=sk_...    STRIPE_WEBHOOK_SECRET=whsec_...
+STRIPE_PRICE_PRO=price_...  # only if you run the paid cloud edition
+```
+
+Point Stripe's webhook at `.../api/webhooks/stripe`.
+
+### Conferencing
+
+```ini
+ZOOM_CLIENT_ID=...  ZOOM_CLIENT_SECRET=...     # Google Meet / Teams need no extra config
+```
+
+## Editions
+
+Leave `DAYOTTER_CLOUD` **unset** for the open-source edition: every Pro feature is
+unlocked and there's no billing. Only set `DAYOTTER_CLOUD=1` if you're running the
+hosted/commercial edition (which also needs the `ee/` commercial license — see
+[`ENTERPRISE.md`](./ENTERPRISE.md)).
+
+## Upgrading & migrations
+
+Schema changes ship as SQL migrations in `packages/db/drizzle/`. `deploy.sh` (and
+the compose `migrate` service) apply them. For local dev, `pnpm db:push` syncs the
+schema directly.
+
+## Backups & operations
+
+- Back up Postgres (all app data) regularly. Redis holds jobs + ephemeral state
+  and can be rebuilt.
+- Rotate `BETTER_AUTH_SECRET` / `ENCRYPTION_KEY` carefully — changing
+  `ENCRYPTION_KEY` invalidates stored OAuth tokens (users reconnect calendars).
+- The worker writes a Redis heartbeat; monitor it for liveness.
+
+## Troubleshooting
+
+- **Google button missing** → `NEXT_PUBLIC_*` weren't baked at build; rebuild.
+- **500s after deploy** → migrations didn't run; use `./deploy.sh`, never a bare
+  `up -d`.
+- **AI features absent** → `ANTHROPIC_API_KEY` unset (`aiEnabled` is false).
+- **Webhooks rejected (403)** → wrong `TWILIO_AUTH_TOKEN` or `APP_URL` mismatch
+  (signatures are validated against the public URL).
+
+Questions? [Discussions](../../discussions) or hello@dayotter.com.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "description": "Open-source team scheduling & calendar platform",
-  "license": "Apache-2.0",
+  "license": "AGPL-3.0-only",
   "packageManager": "pnpm@10.24.0",
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
Sets DayOtter up as a proper open-source project, following industry guidelines, and leverages Cal.com's move to closed source.

## Licensing (open-core: AGPLv3 core + cloud-infra-only EE)
- **`LICENSE`**: GNU AGPLv3 — the license Cal.com just abandoned. Self-host the *whole* product (all AI included) free.
- **`apps/web/lib/ee/LICENSE.md`**: DayOtter Enterprise Edition license — cloud-only infrastructure (managed AI, SSO, white-label, hosted messaging) that can't be resold. Everything else is open.
- `package.json` + all marketing: Apache-2.0 → AGPLv3.

## Contributor & community docs
- Rewritten **README** (AI-native + "more open than Cal.com" positioning)
- **CONTRIBUTING**, **CODE_OF_CONDUCT**, **SECURITY** (addresses the "AI security" argument head-on)
- **.github/**: feature-request + bug issue forms, PR template, config

## Project docs
- **`docs/AI.md`** — the AI section you emphasized: architecture, confirm-first philosophy, how the AI stays open (bring-your-own-key/model), and a detailed **roadmap of AI advancements** to build (near / mid / long term) + a contribution table.
- **`docs/ENTERPRISE.md`** — the open-core boundary + EE license, with an honest feature table (why the line is drawn at cloud-infra, not features).
- **`docs/ARCHITECTURE.md`** — detailed, current module map across every domain.
- **`docs/ROADMAP.md`** — public Now/Next/Later product roadmap.
- **`docs/SELF_HOSTING.md`** — full setup + configuration guide.
- Each AI/analytics/voice module already ships its own README (extension points).

## Positioning
Cal.com moved its core to a closed repo in April 2026 (keeping a stripped MIT fork). Rewrote the **`/vs/cal-com`** comparison around DayOtter as the genuinely-open, whole-product alternative. Verified rendering.

Typecheck passes; biome-formatted.