### PR TITLE
SEO architecture + programmatic content pages (16 → 61 indexed pages)

### DIFF
--- a/apps/web/app/(marketing)/features/[slug]/page.tsx
+++ b/apps/web/app/(marketing)/features/[slug]/page.tsx
@@ -1,0 +1,121 @@
+import { MarketingHeader } from "@/components/marketing/page-shell";
+import { BreadcrumbJsonLd, FaqJsonLd } from "@/components/seo/json-ld";
+import { buttonVariants } from "@/components/ui/button";
+import { FEATURES, getFeature } from "@/lib/features";
+import { ArrowRight, Check } from "lucide-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+export function generateStaticParams() {
+  return FEATURES.map((f) => ({ slug: f.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const f = getFeature((await params).slug);
+  if (!f) return { title: "Features" };
+  const path = `/features/${f.slug}`;
+  return {
+    title: f.title,
+    description: f.subtitle,
+    alternates: { canonical: path },
+    openGraph: { title: `${f.title} — DayOtter`, description: f.subtitle, url: path },
+  };
+}
+
+export default async function FeaturePage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const f = getFeature(slug);
+  if (!f) notFound();
+  const related = f.related.map(getFeature).filter((x): x is NonNullable<typeof x> => Boolean(x));
+
+  return (
+    <>
+      <FaqJsonLd items={f.faq} />
+      <BreadcrumbJsonLd
+        items={[
+          { name: "Features", path: "/features" },
+          { name: f.label, path: `/features/${f.slug}` },
+        ]}
+      />
+      <MarketingHeader eyebrow="Feature" title={f.title} subtitle={f.subtitle} />
+
+      <div className="mx-auto max-w-4xl px-6 py-16">
+        <div className="mb-14 flex flex-wrap justify-center gap-3">
+          <Link href="/sign-up" className={buttonVariants({ variant: "primary" })}>
+            Get started free
+          </Link>
+          <Link href="/#how" className={buttonVariants({ variant: "outline" })}>
+            See how it works
+          </Link>
+        </div>
+
+        <section className="mx-auto max-w-2xl space-y-4">
+          {f.intro.map((p) => (
+            <p
+              key={p.slice(0, 24)}
+              className="text-[15px] leading-relaxed text-[var(--color-muted)]"
+            >
+              {p}
+            </p>
+          ))}
+        </section>
+
+        <section className="mt-16 grid gap-4 sm:grid-cols-2">
+          {f.points.map((pt) => (
+            <div
+              key={pt.title}
+              className="flex gap-3 rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)] p-5 shadow-[var(--shadow-card)]"
+            >
+              <Check size={18} className="mt-0.5 shrink-0 text-[var(--color-accent)]" />
+              <div>
+                <p className="font-semibold text-[var(--color-text)]">{pt.title}</p>
+                <p className="mt-1 text-sm leading-relaxed text-[var(--color-muted)]">{pt.body}</p>
+              </div>
+            </div>
+          ))}
+        </section>
+
+        {f.faq.length > 0 ? (
+          <section className="mx-auto mt-20 max-w-2xl">
+            <div className="divide-y divide-[var(--color-border)] border-y border-[var(--color-border)]">
+              {f.faq.map((q) => (
+                <div key={q.q} className="py-5">
+                  <p className="font-semibold text-[var(--color-text)]">{q.q}</p>
+                  <p className="mt-2 text-sm leading-relaxed text-[var(--color-muted)]">{q.a}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        <section className="mt-16 text-center">
+          <Link href="/sign-up" className={buttonVariants({ variant: "primary", size: "lg" })}>
+            Start free — no credit card
+          </Link>
+        </section>
+
+        {related.length > 0 ? (
+          <section className="mt-20 border-t border-[var(--color-border)] pt-10">
+            <p className="eyebrow text-center">Related features</p>
+            <div className="mt-5 flex flex-wrap justify-center gap-2.5">
+              {related.map((r) => (
+                <Link
+                  key={r.slug}
+                  href={`/features/${r.slug}`}
+                  className="inline-flex items-center gap-1.5 rounded-full border border-[var(--color-border)] px-3.5 py-1.5 text-sm text-[var(--color-muted)] transition-colors hover:text-[var(--color-text)]"
+                >
+                  {r.label} <ArrowRight size={13} />
+                </Link>
+              ))}
+            </div>
+          </section>
+        ) : null}
+      </div>
+    </>
+  );
+}

--- a/apps/web/app/(marketing)/features/page.tsx
+++ b/apps/web/app/(marketing)/features/page.tsx
@@ -1,0 +1,48 @@
+import { MarketingHeader } from "@/components/marketing/page-shell";
+import { FEATURES } from "@/lib/features";
+import { ArrowRight } from "lucide-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Features",
+  description:
+    "Everything DayOtter does — AI scheduling with Otter, weighted round-robin, routing forms, focus-time protection, calendar sync, reminders, payments, and more. Open source.",
+  alternates: { canonical: "/features" },
+};
+
+export default function FeaturesPage() {
+  return (
+    <>
+      <MarketingHeader
+        eyebrow="Features"
+        title="Everything you need to run your calendar"
+        subtitle="From an AI assistant that does the scheduling to team round-robin, routing, and payments — all in one calm, open-source platform."
+      />
+
+      <section className="mx-auto max-w-5xl px-6 py-16">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {FEATURES.map((f) => (
+            <Link
+              key={f.slug}
+              href={`/features/${f.slug}`}
+              className="group flex flex-col rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)] p-5 shadow-[var(--shadow-card)] transition-colors hover:border-[var(--color-accent)]"
+            >
+              <p className="font-semibold text-[var(--color-text)]">{f.label}</p>
+              <p className="mt-1.5 flex-1 text-sm leading-relaxed text-[var(--color-muted)]">
+                {f.blurb}
+              </p>
+              <span className="mt-3 inline-flex items-center gap-1 text-sm font-medium text-[var(--color-accent)]">
+                Learn more{" "}
+                <ArrowRight
+                  size={14}
+                  className="transition-transform group-hover:translate-x-0.5"
+                />
+              </span>
+            </Link>
+          ))}
+        </div>
+      </section>
+    </>
+  );
+}

--- a/apps/web/app/(marketing)/for/[slug]/page.tsx
+++ b/apps/web/app/(marketing)/for/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { MarketingHeader } from "@/components/marketing/page-shell";
+import { BreadcrumbJsonLd, FaqJsonLd } from "@/components/seo/json-ld";
 import { buttonVariants } from "@/components/ui/button";
 import { PERSONAS, getPersona } from "@/lib/personas";
 import { ArrowRight, Check } from "lucide-react";
@@ -17,7 +18,13 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const p = getPersona((await params).slug);
   if (!p) return { title: "DayOtter" };
-  return { title: `${p.title} — DayOtter`, description: p.subtitle };
+  const path = `/for/${p.slug}`;
+  return {
+    title: p.title,
+    description: p.subtitle,
+    alternates: { canonical: path },
+    openGraph: { title: `${p.title} — DayOtter`, description: p.subtitle, url: path },
+  };
 }
 
 export default async function PersonaPage({ params }: { params: Promise<{ slug: string }> }) {
@@ -28,6 +35,13 @@ export default async function PersonaPage({ params }: { params: Promise<{ slug: 
 
   return (
     <>
+      <FaqJsonLd items={p.faq} />
+      <BreadcrumbJsonLd
+        items={[
+          { name: "For", path: "/for" },
+          { name: p.label, path: `/for/${p.slug}` },
+        ]}
+      />
       <MarketingHeader
         eyebrow={`For ${p.label.toLowerCase()}`}
         title={p.title}

--- a/apps/web/app/(marketing)/integrations/[slug]/page.tsx
+++ b/apps/web/app/(marketing)/integrations/[slug]/page.tsx
@@ -1,0 +1,124 @@
+import { MarketingHeader } from "@/components/marketing/page-shell";
+import { BreadcrumbJsonLd, FaqJsonLd } from "@/components/seo/json-ld";
+import { buttonVariants } from "@/components/ui/button";
+import { INTEGRATIONS, getIntegration } from "@/lib/integrations-content";
+import { ArrowRight, Check } from "lucide-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+export function generateStaticParams() {
+  return INTEGRATIONS.map((i) => ({ slug: i.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const it = getIntegration((await params).slug);
+  if (!it) return { title: "Integrations" };
+  const path = `/integrations/${it.slug}`;
+  const title = `${it.name} scheduling — DayOtter integration`;
+  return {
+    title,
+    description: it.subtitle,
+    alternates: { canonical: path },
+    openGraph: { title, description: it.subtitle, url: path },
+  };
+}
+
+export default async function IntegrationPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const it = getIntegration(slug);
+  if (!it) notFound();
+  const others = INTEGRATIONS.filter((x) => x.slug !== slug).slice(0, 6);
+
+  return (
+    <>
+      <FaqJsonLd items={it.faq} />
+      <BreadcrumbJsonLd
+        items={[
+          { name: "Integrations", path: "/integrations" },
+          { name: it.name, path: `/integrations/${it.slug}` },
+        ]}
+      />
+      <MarketingHeader
+        eyebrow={`${it.category} integration`}
+        title={`DayOtter + ${it.name}`}
+        subtitle={it.subtitle}
+      />
+
+      <div className="mx-auto max-w-4xl px-6 py-16">
+        <div className="mb-14 flex flex-wrap justify-center gap-3">
+          <Link href="/sign-up" className={buttonVariants({ variant: "primary" })}>
+            Connect {it.name}
+          </Link>
+          <Link href="/integrations" className={buttonVariants({ variant: "outline" })}>
+            All integrations
+          </Link>
+        </div>
+
+        <section className="mx-auto max-w-2xl space-y-4">
+          {it.intro.map((p) => (
+            <p
+              key={p.slice(0, 24)}
+              className="text-[15px] leading-relaxed text-[var(--color-muted)]"
+            >
+              {p}
+            </p>
+          ))}
+        </section>
+
+        <section className="mt-16 grid gap-4 sm:grid-cols-2">
+          {it.points.map((pt) => (
+            <div
+              key={pt.title}
+              className="flex gap-3 rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)] p-5 shadow-[var(--shadow-card)]"
+            >
+              <Check size={18} className="mt-0.5 shrink-0 text-[var(--color-accent)]" />
+              <div>
+                <p className="font-semibold text-[var(--color-text)]">{pt.title}</p>
+                <p className="mt-1 text-sm leading-relaxed text-[var(--color-muted)]">{pt.body}</p>
+              </div>
+            </div>
+          ))}
+        </section>
+
+        {it.faq.length > 0 ? (
+          <section className="mx-auto mt-20 max-w-2xl">
+            <div className="divide-y divide-[var(--color-border)] border-y border-[var(--color-border)]">
+              {it.faq.map((q) => (
+                <div key={q.q} className="py-5">
+                  <p className="font-semibold text-[var(--color-text)]">{q.q}</p>
+                  <p className="mt-2 text-sm leading-relaxed text-[var(--color-muted)]">{q.a}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        <section className="mt-16 text-center">
+          <Link href="/sign-up" className={buttonVariants({ variant: "primary", size: "lg" })}>
+            Start free — no credit card
+          </Link>
+        </section>
+
+        <section className="mt-20 border-t border-[var(--color-border)] pt-10">
+          <p className="eyebrow text-center">More integrations</p>
+          <div className="mt-5 flex flex-wrap justify-center gap-2.5">
+            {others.map((o) => (
+              <Link
+                key={o.slug}
+                href={`/integrations/${o.slug}`}
+                className="inline-flex items-center gap-1.5 rounded-full border border-[var(--color-border)] px-3.5 py-1.5 text-sm text-[var(--color-muted)] transition-colors hover:text-[var(--color-text)]"
+              >
+                {o.name} <ArrowRight size={13} />
+              </Link>
+            ))}
+          </div>
+        </section>
+      </div>
+    </>
+  );
+}

--- a/apps/web/app/(marketing)/integrations/page.tsx
+++ b/apps/web/app/(marketing)/integrations/page.tsx
@@ -1,0 +1,59 @@
+import { MarketingHeader } from "@/components/marketing/page-shell";
+import { INTEGRATIONS } from "@/lib/integrations-content";
+import { ArrowRight } from "lucide-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Integrations",
+  description:
+    "DayOtter connects with Google Calendar, Outlook, Apple iCloud, Zoom, Google Meet, Teams, Slack, WhatsApp, and Stripe — one calm scheduling layer over the tools you already use.",
+  alternates: { canonical: "/integrations" },
+};
+
+const CATEGORIES = ["Calendar", "Video", "Messaging", "Payments"] as const;
+
+export default function IntegrationsPage() {
+  return (
+    <>
+      <MarketingHeader
+        eyebrow="Integrations"
+        title="Works with the tools you already use"
+        subtitle="DayOtter is a scheduling layer on top of your calendar, video, and messaging tools — not a replacement. Connect and go."
+      />
+
+      <section className="mx-auto max-w-5xl px-6 py-16">
+        {CATEGORIES.map((cat) => {
+          const items = INTEGRATIONS.filter((i) => i.category === cat);
+          if (items.length === 0) return null;
+          return (
+            <div key={cat} className="mb-12">
+              <h2 className="eyebrow mb-4">{cat}</h2>
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {items.map((i) => (
+                  <Link
+                    key={i.slug}
+                    href={`/integrations/${i.slug}`}
+                    className="group flex flex-col rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)] p-5 shadow-[var(--shadow-card)] transition-colors hover:border-[var(--color-accent)]"
+                  >
+                    <p className="font-semibold text-[var(--color-text)]">{i.name}</p>
+                    <p className="mt-1.5 flex-1 text-sm leading-relaxed text-[var(--color-muted)]">
+                      {i.blurb}
+                    </p>
+                    <span className="mt-3 inline-flex items-center gap-1 text-sm font-medium text-[var(--color-accent)]">
+                      Learn more{" "}
+                      <ArrowRight
+                        size={14}
+                        className="transition-transform group-hover:translate-x-0.5"
+                      />
+                    </span>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </section>
+    </>
+  );
+}

--- a/apps/web/app/(marketing)/pricing/page.tsx
+++ b/apps/web/app/(marketing)/pricing/page.tsx
@@ -1,4 +1,5 @@
 import { MarketingHeader } from "@/components/marketing/page-shell";
+import { FaqJsonLd } from "@/components/seo/json-ld";
 import { buttonVariants } from "@/components/ui/button";
 import { PRO_PRICE_USD } from "@/lib/billing/edition";
 import { BRAND } from "@/lib/marketing";
@@ -7,9 +8,10 @@ import type { Metadata } from "next";
 import Link from "next/link";
 
 export const metadata: Metadata = {
-  title: "Pricing — DayOtter",
+  title: "Pricing",
   description:
-    "Free forever for individuals. Pro is $9/seat/mo for the whole team. Or self-host every feature for free.",
+    "Free forever for individuals. Pro is $9/seat/mo for the whole team. Or self-host every feature for free under AGPLv3.",
+  alternates: { canonical: "/pricing" },
 };
 
 interface Tier {
@@ -98,6 +100,7 @@ const FAQ = [
 export default function PricingPage() {
   return (
     <>
+      <FaqJsonLd items={FAQ} />
       <MarketingHeader
         eyebrow="Pricing"
         title="Simple pricing for time well spent"

--- a/apps/web/app/(marketing)/vs/[slug]/page.tsx
+++ b/apps/web/app/(marketing)/vs/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { MarketingHeader } from "@/components/marketing/page-shell";
+import { BreadcrumbJsonLd, FaqJsonLd } from "@/components/seo/json-ld";
 import { buttonVariants } from "@/components/ui/button";
 import { COMPARISONS, getComparison } from "@/lib/comparisons";
 import { Check, Minus } from "lucide-react";
@@ -17,9 +18,13 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const c = getComparison((await params).slug);
   if (!c) return { title: "Compare — DayOtter" };
+  const path = `/vs/${c.slug}`;
+  const title = `${c.title} (2026) — how they compare`;
   return {
-    title: `${c.title} (2026) — how they compare`,
+    title,
     description: c.subtitle,
+    alternates: { canonical: path },
+    openGraph: { title, description: c.subtitle, url: path },
   };
 }
 
@@ -35,6 +40,13 @@ export default async function ComparisonPage({ params }: { params: Promise<{ slu
 
   return (
     <>
+      <FaqJsonLd items={c.faq} />
+      <BreadcrumbJsonLd
+        items={[
+          { name: "Compare", path: "/vs" },
+          { name: c.name, path: `/vs/${c.slug}` },
+        ]}
+      />
       <MarketingHeader eyebrow="Compare" title={c.title} subtitle={c.subtitle} />
 
       <div className="mx-auto max-w-3xl px-6 py-16">

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -54,8 +54,8 @@
 
   /* Spacing rhythm — the canonical gaps/paddings the components compose from.
    * Field gap: space-y-4 · Card padding: p-6 · Section gap: gap-3 · inline: gap-2 */
-  --font-sans: var(--font-geist-sans), ui-sans-serif, system-ui, -apple-system, "Segoe UI",
-    Roboto, Helvetica, Arial, sans-serif;
+  --font-sans: var(--font-geist-sans), ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+    Helvetica, Arial, sans-serif;
   /* Headings use the same family a weight heavier — the modern software look
      (one grotesque doing display + body) rather than a separate serif. */
   --font-display: var(--font-geist-sans), ui-sans-serif, system-ui, -apple-system, sans-serif;

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,4 +1,6 @@
 import { Analytics } from "@/components/analytics";
+import { OrganizationJsonLd } from "@/components/seo/json-ld";
+import { BRAND } from "@/lib/marketing";
 import { GeistMono } from "geist/font/mono";
 import { GeistSans } from "geist/font/sans";
 import type { Metadata } from "next";
@@ -10,11 +12,53 @@ import "./globals.css";
 // small uppercase eyebrow labels. Self-hosted via the `geist` package (no runtime
 // network request).
 
+const DESCRIPTION =
+  "DayOtter is the AI-native, open-source scheduling platform. Otter books meetings, protects your focus, and clears the back-and-forth — confirm-first. Sync every calendar, run your team, self-host it all under AGPLv3.";
+
 export const metadata: Metadata = {
-  title: "DayOtter — scheduling that respects every calendar you own",
-  description:
-    "The open-source home for your time. Sync every calendar, share availability across your team, and let people book you — beautifully.",
+  metadataBase: new URL(BRAND.url),
+  title: {
+    default: "DayOtter — the AI-native, open-source scheduling platform",
+    template: "%s — DayOtter",
+  },
+  description: DESCRIPTION,
+  applicationName: BRAND.name,
+  keywords: [
+    "AI scheduling",
+    "open source scheduling",
+    "Calendly alternative",
+    "Cal.com alternative",
+    "team scheduling",
+    "round robin scheduling",
+    "booking page",
+    "self-hosted scheduling",
+    "AI calendar assistant",
+    "focus time",
+  ],
+  authors: [{ name: BRAND.name, url: BRAND.url }],
+  creator: BRAND.name,
+  publisher: BRAND.name,
+  alternates: { canonical: "/" },
   icons: { icon: "/brand/dayotter-icon.svg", apple: "/brand/dayotter-icon.svg" },
+  openGraph: {
+    type: "website",
+    siteName: BRAND.name,
+    title: "DayOtter — the AI-native, open-source scheduling platform",
+    description: DESCRIPTION,
+    url: BRAND.url,
+    locale: "en_US",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "DayOtter — the AI-native, open-source scheduling platform",
+    description: DESCRIPTION,
+    creator: "@dayotter",
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: { index: true, follow: true, "max-image-preview": "large", "max-snippet": -1 },
+  },
 };
 
 // Set the theme class before first paint to avoid a flash of the wrong theme.
@@ -31,6 +75,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
       </head>
       <body>
+        <OrganizationJsonLd />
         {children}
         <Analytics />
       </body>

--- a/apps/web/app/manifest.ts
+++ b/apps/web/app/manifest.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from "next";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "DayOtter",
+    short_name: "DayOtter",
+    description: "The AI-native, open-source scheduling platform.",
+    start_url: "/dashboard",
+    display: "standalone",
+    background_color: "#FAF9F6",
+    theme_color: "#6743e6",
+    icons: [
+      { src: "/brand/dayotter-icon.svg", sizes: "any", type: "image/svg+xml" },
+      { src: "/brand/dayotter-icon.svg", sizes: "any", type: "image/svg+xml", purpose: "maskable" },
+    ],
+  };
+}

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -1,0 +1,17 @@
+import { BRAND } from "@/lib/marketing";
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        // Keep private/app + auth surfaces out of the index.
+        disallow: ["/api/", "/dashboard", "/settings", "/sign-in", "/sign-up", "/onboarding"],
+      },
+    ],
+    sitemap: `${BRAND.url}/sitemap.xml`,
+    host: BRAND.url,
+  };
+}

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,0 +1,44 @@
+import { POSTS } from "@/lib/blog";
+import { COMPARISONS } from "@/lib/comparisons";
+import { GUIDES } from "@/lib/docs";
+import { FEATURES } from "@/lib/features";
+import { INTEGRATIONS } from "@/lib/integrations-content";
+import { BRAND } from "@/lib/marketing";
+import { PERSONAS } from "@/lib/personas";
+import type { MetadataRoute } from "next";
+
+/** Dynamic sitemap — every public page, so search engines can crawl the lot. */
+export default function sitemap(): MetadataRoute.Sitemap {
+  const base = BRAND.url;
+  const now = new Date();
+
+  const entry = (
+    path: string,
+    priority: number,
+    changeFrequency: MetadataRoute.Sitemap[number]["changeFrequency"] = "weekly",
+  ) => ({ url: `${base}${path}`, lastModified: now, changeFrequency, priority });
+
+  return [
+    entry("", 1, "daily"),
+    entry("/pricing", 0.9),
+    entry("/features", 0.9),
+    entry("/integrations", 0.9),
+    entry("/vs", 0.8),
+    entry("/self-hosting", 0.8),
+    entry("/blog", 0.7),
+    entry("/docs", 0.7),
+    entry("/about", 0.5),
+    entry("/security", 0.5),
+    entry("/contact", 0.5),
+    entry("/changelog", 0.4),
+    entry("/status", 0.3),
+    entry("/privacy", 0.3),
+    entry("/terms", 0.3),
+    ...FEATURES.map((f) => entry(`/features/${f.slug}`, 0.7)),
+    ...INTEGRATIONS.map((i) => entry(`/integrations/${i.slug}`, 0.7)),
+    ...COMPARISONS.map((c) => entry(`/vs/${c.slug}`, 0.8)),
+    ...PERSONAS.map((p) => entry(`/for/${p.slug}`, 0.7)),
+    ...POSTS.map((p) => entry(`/blog/${p.slug}`, 0.6)),
+    ...GUIDES.map((g) => entry(`/docs/${g.slug}`, 0.5)),
+  ];
+}

--- a/apps/web/components/seo/json-ld.tsx
+++ b/apps/web/components/seo/json-ld.tsx
@@ -1,0 +1,113 @@
+import { BRAND } from "@/lib/marketing";
+
+/**
+ * Structured data (schema.org JSON-LD) helpers. Rendered as inline scripts so
+ * search engines get rich context: org identity, the app as a product, FAQ
+ * rich-results, breadcrumbs, and blog articles. Keep the emitted objects small
+ * and truthful — Google penalizes markup that doesn't match visible content.
+ */
+
+function JsonLd({ data }: { data: Record<string, unknown> }) {
+  return (
+    // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON.stringify output is safe structured data
+    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }} />
+  );
+}
+
+/** Site-wide: who we are + the software product. Rendered once in the root layout. */
+export function OrganizationJsonLd() {
+  return (
+    <>
+      <JsonLd
+        data={{
+          "@context": "https://schema.org",
+          "@type": "Organization",
+          name: BRAND.name,
+          url: BRAND.url,
+          logo: `${BRAND.url}/brand/dayotter-icon.svg`,
+          email: BRAND.email,
+          sameAs: [BRAND.x, BRAND.github],
+        }}
+      />
+      <JsonLd
+        data={{
+          "@context": "https://schema.org",
+          "@type": "SoftwareApplication",
+          name: BRAND.name,
+          applicationCategory: "BusinessApplication",
+          operatingSystem: "Web, iOS, Android",
+          description:
+            "AI-native, open-source scheduling platform. Otter books meetings, protects focus, and clears the back-and-forth — confirm-first.",
+          offers: [
+            { "@type": "Offer", price: "0", priceCurrency: "USD", name: "Free" },
+            { "@type": "Offer", price: "9", priceCurrency: "USD", name: "Pro (per seat / month)" },
+          ],
+          url: BRAND.url,
+        }}
+      />
+    </>
+  );
+}
+
+/** FAQ rich results — pass the same Q&As shown on the page. */
+export function FaqJsonLd({ items }: { items: { q: string; a: string }[] }) {
+  if (items.length === 0) return null;
+  return (
+    <JsonLd
+      data={{
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        mainEntity: items.map((i) => ({
+          "@type": "Question",
+          name: i.q,
+          acceptedAnswer: { "@type": "Answer", text: i.a },
+        })),
+      }}
+    />
+  );
+}
+
+/** Breadcrumb trail for a deep page. `items` are ordered root → current. */
+export function BreadcrumbJsonLd({ items }: { items: { name: string; path: string }[] }) {
+  return (
+    <JsonLd
+      data={{
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        itemListElement: items.map((it, i) => ({
+          "@type": "ListItem",
+          position: i + 1,
+          name: it.name,
+          item: `${BRAND.url}${it.path}`,
+        })),
+      }}
+    />
+  );
+}
+
+/** A blog post / article. */
+export function ArticleJsonLd(props: {
+  title: string;
+  description: string;
+  path: string;
+  datePublished?: string;
+}) {
+  return (
+    <JsonLd
+      data={{
+        "@context": "https://schema.org",
+        "@type": "Article",
+        headline: props.title,
+        description: props.description,
+        url: `${BRAND.url}${props.path}`,
+        ...(props.datePublished ? { datePublished: props.datePublished } : {}),
+        author: { "@type": "Organization", name: BRAND.name },
+        publisher: {
+          "@type": "Organization",
+          name: BRAND.name,
+          logo: { "@type": "ImageObject", url: `${BRAND.url}/brand/dayotter-icon.svg` },
+        },
+      }}
+    />
+  );
+}

--- a/apps/web/lib/features.ts
+++ b/apps/web/lib/features.ts
@@ -1,0 +1,362 @@
+/**
+ * Feature landing pages, rendered at /features and /features/[slug]. One page per
+ * capability — the programmatic-SEO play (like Calendly's per-feature pages).
+ * Each targets the search intent for that feature and links back into the product.
+ */
+
+export interface Feature {
+  slug: string;
+  /** Short label for nav/cards. */
+  label: string;
+  /** One-line descriptor for the hub grid. */
+  blurb: string;
+  title: string;
+  subtitle: string;
+  intro: string[];
+  /** The key capabilities, 3–4. */
+  points: { title: string; body: string }[];
+  faq: { q: string; a: string }[];
+  /** Related feature slugs for internal linking. */
+  related: string[];
+}
+
+export const FEATURES: Feature[] = [
+  {
+    slug: "ai-scheduling",
+    label: "AI scheduling",
+    blurb: "Talk to Otter — it books, reschedules, and protects your time, confirm-first.",
+    title: "AI scheduling with Otter",
+    subtitle:
+      "Otter is your AI executive assistant for the calendar. Say what you want in plain words — it drafts the change and waits for your OK. Never books anything on its own.",
+    intro: [
+      'Most "AI scheduling" is a chatbot bolted onto a booking link. Otter is built into DayOtter from the ground up: it reads your real availability, understands "book 30 minutes with Priya Thursday" or "hold two hours for deep work," and turns it into a calendar change you confirm.',
+      "It works in the app, by voice on mobile, and over WhatsApp and SMS — and it learns your patterns so its suggestions get sharper over time.",
+    ],
+    points: [
+      {
+        title: "Confirm-first, always",
+        body: "Otter proposes; you approve. Nothing lands on your calendar and nothing moves without your explicit OK — no silent auto-scheduling.",
+      },
+      {
+        title: "Grounded in your real calendar",
+        body: "It reads your actual availability and bookings, so the times it suggests are ones you're truly free for — across every timezone.",
+      },
+      {
+        title: "Everywhere you are",
+        body: "Chat in the app, tap the mic on mobile, or just text Otter over WhatsApp/SMS. One assistant, every surface.",
+      },
+    ],
+    faq: [
+      {
+        q: "Will the AI change my calendar without asking?",
+        a: "No. Otter is confirm-first — it only ever drafts a change and waits for your confirmation.",
+      },
+      {
+        q: "Does AI scheduling cost extra per use?",
+        a: "No metered per-minute cost. It's included in Pro, and free when you self-host with your own API key.",
+      },
+    ],
+    related: ["focus-time", "voice-receptionist", "running-late"],
+  },
+  {
+    slug: "round-robin",
+    label: "Round-robin",
+    blurb: "Distribute meetings across your team, weighted and load-balanced.",
+    title: "Weighted round-robin scheduling",
+    subtitle:
+      "Spread inbound meetings fairly across your team — weight your best closers, pause anyone who's out, and keep it load-balanced automatically.",
+    intro: [
+      "Round-robin routing sends each new booking to the next available team member. DayOtter's is weighted: give senior reps a higher share, set someone to zero to pause them, and it stays balanced over time — not just a naive rotation.",
+      "Combine it with routing forms and collective availability to build a real team booking flow, all free to self-host.",
+    ],
+    points: [
+      {
+        title: "Weighted distribution",
+        body: "Assign each member a weight to book some people more than others — by seniority, territory, or performance.",
+      },
+      {
+        title: "Pause without breaking the rotation",
+        body: "Set a weight to zero when someone's on holiday; they drop out cleanly and rejoin when you're ready.",
+      },
+      {
+        title: "Load-balanced, not just rotated",
+        body: "The engine accounts for who's already been booked, so meetings stay evenly spread instead of clustering.",
+      },
+    ],
+    faq: [
+      {
+        q: "Can I weight some reps higher than others?",
+        a: "Yes — every member has a weight you can tune any time; set it to zero to pause them.",
+      },
+      {
+        q: "Is round-robin behind a paywall?",
+        a: "It's included in Pro, and completely free when you self-host — unlike tools that gate team scheduling on expensive tiers.",
+      },
+    ],
+    related: ["routing-forms", "team-scheduling", "collective"],
+  },
+  {
+    slug: "routing-forms",
+    label: "Routing forms",
+    blurb: "Qualify inbound and send each visitor to the right person or event type.",
+    title: "Routing forms",
+    subtitle:
+      "Ask a couple of questions up front, then route each visitor to the right person, team, or event type — so leads never land on the wrong desk.",
+    intro: [
+      "A routing form is a short set of questions on your booking page. Based on the answers, DayOtter sends the visitor to the right destination — a specific rep, a round-robin pool, or a particular event type.",
+      "It's how sales teams qualify inbound instantly and route enterprise leads to closers, and how support teams get people to the right specialist — no reply-and-wait.",
+    ],
+    points: [
+      {
+        title: "Qualify before they book",
+        body: "Capture the essentials (company size, topic, urgency) so the meeting starts with context.",
+      },
+      {
+        title: "Rules, checked top to bottom",
+        body: 'Write simple rules — "if Enterprise, send to sales" — with a fallback. No code, no wrong-desk bookings.',
+      },
+      {
+        title: "Route to a person or a pool",
+        body: "Send matched visitors to one host, a weighted round-robin team, or a specific event type.",
+      },
+    ],
+    faq: [
+      {
+        q: "Do I need to write code for routing?",
+        a: "No — routing is no-code: add questions, then rules that map answers to destinations.",
+      },
+    ],
+    related: ["round-robin", "team-scheduling", "ai-scheduling"],
+  },
+  {
+    slug: "focus-time",
+    label: "Focus time",
+    blurb: "Otter finds and protects blocks for deep work — held as real events.",
+    title: "Focus-time protection",
+    subtitle:
+      "Ask Otter to hold time for deep work and it defends it as a real calendar event — so meetings route around your focus instead of eating into it.",
+    intro: [
+      'Say "hold two hours for deep work tomorrow morning" and Otter finds an open block that fits your schedule and protects it. Because it becomes a real busy block, your booking page and team availability route around it automatically.',
+      "This is Reclaim/Motion territory — but confirm-first, and part of a full scheduling platform rather than a separate app.",
+    ],
+    points: [
+      {
+        title: "Held as real events",
+        body: "Protected focus time shows as busy everywhere, so nobody can book over your deep work.",
+      },
+      {
+        title: "Proactively suggested",
+        body: "Otter notices open windows worth protecting and offers to hold them — you just confirm.",
+      },
+      {
+        title: "Across every calendar",
+        body: "It works whether you're on Google, Outlook, or Apple — one honest view of your real free time.",
+      },
+    ],
+    faq: [
+      {
+        q: "Does it move my meetings around to make room?",
+        a: "No — it protects open time, confirm-first. It never silently rearranges your calendar.",
+      },
+    ],
+    related: ["ai-scheduling", "running-late", "analytics"],
+  },
+  {
+    slug: "reminders",
+    label: "Reminders",
+    blurb: "Automatic reminders over email, SMS, WhatsApp, Slack, and push.",
+    title: "Meeting reminders & notifications",
+    subtitle:
+      "Cut no-shows with automatic reminders on the channels people actually check — email, SMS, WhatsApp, Slack, and mobile push.",
+    intro: [
+      "Set your lead times once and DayOtter reminds you and your attendees before every meeting. Reminders are durable (backed by a real job queue), multi-channel, and reschedule cleanly when a meeting moves.",
+      "Add before/after-event workflow messages on your own templates for confirmations, prep, and follow-ups.",
+    ],
+    points: [
+      {
+        title: "Every channel",
+        body: "Email and — on Pro/self-host — SMS, WhatsApp, Slack, and push, so reminders land where people look.",
+      },
+      {
+        title: "Reschedule-aware",
+        body: "Move a meeting and the reminders re-schedule themselves; cancel it and they're cleared.",
+      },
+      {
+        title: "Custom workflows",
+        body: "Send templated before/after-event messages — prep notes, follow-ups — automatically.",
+      },
+    ],
+    faq: [
+      {
+        q: "Which channels can attendees get reminders on?",
+        a: "Email always; SMS, WhatsApp, Slack, and push are available on Pro and free when self-hosted.",
+      },
+    ],
+    related: ["running-late", "ai-scheduling", "payments"],
+  },
+  {
+    slug: "calendar-sync",
+    label: "Calendar sync",
+    blurb: "Google, Outlook, Apple, and ICS — one honest view of your time.",
+    title: "Calendar sync",
+    subtitle:
+      "Connect Google, Microsoft 365, Apple iCloud, and any ICS feed. DayOtter unifies them into one source of truth for your availability — two-way, real-time.",
+    intro: [
+      "DayOtter reads your busy times from every calendar you connect and writes new bookings back — so you're never double-booked and everything lives in the calendar you already check.",
+      "Google and Microsoft sync in real time via provider webhooks; Apple/CalDAV and ICS feeds are kept fresh by polling. Tokens are encrypted at rest.",
+    ],
+    points: [
+      {
+        title: "Every provider",
+        body: "Google Calendar, Microsoft 365 / Outlook, Apple iCloud (CalDAV), and read-only ICS feeds — behind one interface.",
+      },
+      {
+        title: "Two-way and real-time",
+        body: "Busy times flow in; confirmed bookings flow out to your target calendar with the video link attached.",
+      },
+      {
+        title: "Never double-booked",
+        body: "Availability is computed against all your connected calendars at once, across timezones.",
+      },
+    ],
+    faq: [
+      {
+        q: "Does it work with Apple/iCloud?",
+        a: "Yes — via CalDAV with an app-specific password. Unlike some tools that dropped iCloud support, DayOtter keeps it.",
+      },
+    ],
+    related: ["booking-pages", "ai-scheduling", "focus-time"],
+  },
+  {
+    slug: "payments",
+    label: "Payments",
+    blurb: "Charge or take a deposit to book — powered by Stripe.",
+    title: "Accept payments for bookings",
+    subtitle:
+      "Require payment or a deposit before a slot is held. Fewer no-shows, paid up front — with prepaid session packages for recurring clients.",
+    intro: [
+      "Connect Stripe and charge the full price or a deposit as part of booking. The slot is only confirmed once payment succeeds, so flaky free bookings stop costing you income.",
+      'Sell prepaid session packages too — a bundle of sessions a client buys once, tracked as they book ("3 of 5 used").',
+    ],
+    points: [
+      {
+        title: "Full price or deposit",
+        body: "Take the whole fee or just a deposit to secure the slot — your call per event type.",
+      },
+      {
+        title: "Session packages",
+        body: "Sell bundles of sessions; each booking spends a credit, tracked automatically.",
+      },
+      {
+        title: "Stripe, secure",
+        body: "Payments run on Stripe Checkout — DayOtter never stores card numbers.",
+      },
+    ],
+    faq: [
+      {
+        q: "Do I need a Stripe account?",
+        a: "Yes — connect Stripe and you can charge for bookings and sell packages. It's included in Pro and free to self-host.",
+      },
+    ],
+    related: ["session-packages", "reminders", "booking-pages"],
+  },
+  {
+    slug: "voice-receptionist",
+    label: "Voice receptionist",
+    blurb: "A 24/7 AI phone line that answers questions and books appointments.",
+    title: "AI voice receptionist",
+    subtitle:
+      "Give your booking line an AI receptionist. It answers common questions, and texts callers a link to book — 24/7, grounded in your real services.",
+    intro: [
+      "Callers reach a warm, natural AI receptionist that answers from your knowledge base and, when they want to book, texts them a link to pick a time. It never books blind — confirm-first, over the phone.",
+      "Perfect for solo service businesses, coaches, and clinics that miss calls after hours.",
+    ],
+    points: [
+      {
+        title: "Answers, grounded",
+        body: "It responds only from your services and info — and defers to you rather than inventing details.",
+      },
+      {
+        title: "Texts a booking link",
+        body: "When a caller wants an appointment, it sends them a link to choose a time — no blind bookings.",
+      },
+      {
+        title: "24/7, natural speech",
+        body: "Enhanced phone-call transcription and a human-sounding voice, so callers get help any hour.",
+      },
+    ],
+    faq: [
+      {
+        q: "Can it actually book on the call?",
+        a: "It hands the caller a booking link to confirm a time themselves — confirm-first. Conversational booking is on the roadmap.",
+      },
+    ],
+    related: ["ai-scheduling", "reminders", "booking-pages"],
+  },
+  {
+    slug: "booking-pages",
+    label: "Booking pages",
+    blurb: "Calm, branded pages with intake, buffers, and instant video links.",
+    title: "Booking pages",
+    subtitle:
+      "Share one link and let people book you — on a page as calm as it is capable, with intake questions, buffers, and automatic video links.",
+    intro: [
+      "Your booking page is a branded, fast, mobile-friendly place for anyone to grab a time that works. Add intake questions, buffers, notice periods, and multiple durations; DayOtter attaches a Google Meet, Zoom, or Teams link automatically.",
+      "Unlimited event types on every plan — including free — instead of the one-event-only trap.",
+    ],
+    points: [
+      {
+        title: "Unlimited event types",
+        body: "Create as many booking types as you need, free forever — intro calls, demos, office hours, whatever.",
+      },
+      {
+        title: "Yours, branded",
+        body: "Your name, accent color, welcome message, and intake questions — calm and professional, not a generic form.",
+      },
+      {
+        title: "Video links, automatic",
+        body: "Google Meet, Zoom, and Teams links are generated and attached to every booking.",
+      },
+    ],
+    faq: [
+      {
+        q: "How many event types can I create?",
+        a: "Unlimited, on every plan including Free — unlike Calendly's one-event free tier.",
+      },
+    ],
+    related: ["calendar-sync", "payments", "group-polls"],
+  },
+  {
+    slug: "group-polls",
+    label: "Group polls",
+    blurb: "Find a time across a group — propose slots, collect votes, lock it in.",
+    title: "Group polls",
+    subtitle:
+      "Find one time that works across a group. Propose a few slots, let everyone vote, and finalize the winner into a real booking — no email thread.",
+    intro: [
+      "Group polls (Doodle-style) solve the many-people problem: propose candidate times, share the link, collect yes/no/maybe votes, and turn the most-supported slot into a booking on everyone's calendar.",
+      "Great for panel interviews, team calls, and any meeting where a single link won't do.",
+    ],
+    points: [
+      {
+        title: "Propose, vote, finalize",
+        body: "Offer a handful of times, let people vote, and lock in the winner — it becomes a real booking.",
+      },
+      {
+        title: "No back-and-forth",
+        body: "One link replaces the reply-all thread that usually finds a group time.",
+      },
+    ],
+    faq: [
+      {
+        q: "Is this like Doodle?",
+        a: "Same idea, but it finalizes straight into a booking on your calendar with reminders — not just a poll.",
+      },
+    ],
+    related: ["booking-pages", "team-scheduling", "routing-forms"],
+  },
+];
+
+export function getFeature(slug: string): Feature | undefined {
+  return FEATURES.find((f) => f.slug === slug);
+}

--- a/apps/web/lib/integrations-content.ts
+++ b/apps/web/lib/integrations-content.ts
@@ -1,0 +1,268 @@
+/**
+ * Integration landing pages, rendered at /integrations and /integrations/[slug].
+ * One page per integration — Calendly's highest-volume programmatic-SEO play
+ * ("DayOtter + Outlook", etc.). Each targets "<tool> scheduling / integration"
+ * search intent and links into the product.
+ */
+
+export interface Integration {
+  slug: string;
+  name: string;
+  category: "Calendar" | "Video" | "Messaging" | "Payments";
+  blurb: string;
+  subtitle: string;
+  intro: string[];
+  points: { title: string; body: string }[];
+  faq: { q: string; a: string }[];
+}
+
+export const INTEGRATIONS: Integration[] = [
+  {
+    slug: "google-calendar",
+    name: "Google Calendar",
+    category: "Calendar",
+    blurb: "Two-way, real-time sync with your Google Calendar.",
+    subtitle:
+      "Connect Google Calendar and DayOtter keeps your availability honest and writes every booking back — in real time.",
+    intro: [
+      "DayOtter reads your Google Calendar busy times so you're never double-booked, and writes new bookings straight to your calendar with a Google Meet link attached. Sync is real-time via Google's push notifications.",
+      "It's a scheduling layer on top of Google Calendar, not a replacement — everything stays in the calendar you already live in.",
+    ],
+    points: [
+      {
+        title: "Real-time sync",
+        body: "Changes flow both ways instantly via Google push channels.",
+      },
+      {
+        title: "Auto Google Meet links",
+        body: "Every booking gets a Meet link generated and attached.",
+      },
+      {
+        title: "Never double-booked",
+        body: "Availability is computed against your real Google busy times.",
+      },
+    ],
+    faq: [
+      {
+        q: "Does DayOtter replace Google Calendar?",
+        a: "No — it works with it. Your bookings show up in the Google Calendar you already use.",
+      },
+    ],
+  },
+  {
+    slug: "outlook",
+    name: "Microsoft Outlook",
+    category: "Calendar",
+    blurb: "Sync availability and bookings with Microsoft 365 / Outlook.",
+    subtitle:
+      "Connect Microsoft 365 and DayOtter syncs your Outlook calendar both ways, with Teams links on every booking.",
+    intro: [
+      "DayOtter reads your Outlook / Microsoft 365 busy times and writes bookings back via Microsoft Graph, kept fresh in real time with Graph subscriptions.",
+      "Great for teams standardized on Microsoft who want modern scheduling without leaving Outlook.",
+    ],
+    points: [
+      { title: "Microsoft 365 sync", body: "Two-way sync via Microsoft Graph, real-time." },
+      { title: "Teams links", body: "Microsoft Teams meeting links attached automatically." },
+      {
+        title: "Works alongside Google/Apple",
+        body: "Combine Outlook with your other calendars into one view.",
+      },
+    ],
+    faq: [
+      {
+        q: "Does it work with Microsoft 365 and Outlook.com?",
+        a: "Yes — connect your Microsoft account and DayOtter syncs your calendar via Microsoft Graph.",
+      },
+    ],
+  },
+  {
+    slug: "apple-calendar",
+    name: "Apple iCloud Calendar",
+    category: "Calendar",
+    blurb: "Sync your Apple iCloud calendar — which some tools dropped.",
+    subtitle:
+      "Connect Apple iCloud via CalDAV and keep your availability accurate — a calendar some competitors stopped supporting.",
+    intro: [
+      "DayOtter syncs your Apple iCloud calendar over CalDAV using an app-specific password. Your iCloud busy times count toward your availability, and bookings land where you want them.",
+      "Unlike some scheduling tools that dropped iCloud support, DayOtter keeps it — one honest view across Google, Outlook, and Apple.",
+    ],
+    points: [
+      { title: "CalDAV sync", body: "Connect with an app-specific password; no extra app needed." },
+      { title: "Still supported", body: "iCloud remains first-class here, not deprecated." },
+      {
+        title: "Unified availability",
+        body: "iCloud busy times combine with your other calendars.",
+      },
+    ],
+    faq: [
+      {
+        q: "How do I connect Apple/iCloud?",
+        a: "Generate an app-specific password in your Apple ID settings and add it in DayOtter — that's it.",
+      },
+    ],
+  },
+  {
+    slug: "zoom",
+    name: "Zoom",
+    category: "Video",
+    blurb: "Auto-create a Zoom meeting for every booking.",
+    subtitle:
+      "Connect Zoom and DayOtter generates a Zoom meeting link for each booking, added to the calendar invite automatically.",
+    intro: [
+      "Set an event type's location to Zoom and every booking gets a fresh Zoom meeting created and attached to the invite — no manual link-copying.",
+      "Works alongside Google Meet and Teams; pick per event type.",
+    ],
+    points: [
+      {
+        title: "Auto-generated links",
+        body: "A unique Zoom meeting per booking, attached to the invite.",
+      },
+      {
+        title: "Per event type",
+        body: "Choose Zoom for some booking types and Meet/Teams for others.",
+      },
+    ],
+    faq: [
+      {
+        q: "Does each booking get its own Zoom link?",
+        a: "Yes — a fresh Zoom meeting is created per booking and added to the calendar invite.",
+      },
+    ],
+  },
+  {
+    slug: "google-meet",
+    name: "Google Meet",
+    category: "Video",
+    blurb: "Google Meet links on every Google-calendar booking, automatically.",
+    subtitle:
+      "With Google Calendar connected, DayOtter attaches a Google Meet link to every booking — no configuration needed.",
+    intro: [
+      "Google Meet works out of the box with a connected Google Calendar: set the location to Meet and DayOtter attaches a video link to each booking automatically.",
+      "The simplest video option if your team is on Google Workspace.",
+    ],
+    points: [
+      { title: "Zero setup", body: "No separate connection — it rides on your Google Calendar." },
+      { title: "Automatic links", body: "Every Meet booking gets a link in the invite." },
+    ],
+    faq: [
+      {
+        q: "Do I need to connect Google Meet separately?",
+        a: "No — connecting Google Calendar is enough; Meet links are attached automatically.",
+      },
+    ],
+  },
+  {
+    slug: "slack",
+    name: "Slack",
+    category: "Messaging",
+    blurb: "Get booking reminders and nudges in Slack.",
+    subtitle:
+      "Add a Slack channel and DayOtter can send you reminders and running-late nudges where your team already works.",
+    intro: [
+      "Connect Slack via an incoming webhook and receive meeting reminders and Otter's nudges in Slack — alongside email, SMS, WhatsApp, and push.",
+      "Handy for staying on top of your day without another inbox.",
+    ],
+    points: [
+      {
+        title: "Reminders in Slack",
+        body: "Upcoming-meeting and running-late notices delivered to Slack.",
+      },
+      {
+        title: "One of many channels",
+        body: "Mix Slack with email, SMS, WhatsApp, and push as you like.",
+      },
+    ],
+    faq: [
+      {
+        q: "How does the Slack connection work?",
+        a: "You add a Slack incoming webhook URL in settings; DayOtter posts your notifications there.",
+      },
+    ],
+  },
+  {
+    slug: "stripe",
+    name: "Stripe",
+    category: "Payments",
+    blurb: "Charge or take a deposit to book — powered by Stripe.",
+    subtitle:
+      "Connect Stripe to require payment or a deposit before a slot is held, and to sell prepaid session packages.",
+    intro: [
+      "With Stripe connected, DayOtter can charge the full price or a deposit as part of booking via Stripe Checkout — the slot confirms only once payment succeeds.",
+      "You can also sell prepaid session bundles that clients buy once and spend as they book.",
+    ],
+    points: [
+      { title: "Paid bookings", body: "Full price or deposit, taken through Stripe Checkout." },
+      {
+        title: "Session packages",
+        body: "Sell bundles; each booking spends a credit, tracked automatically.",
+      },
+      { title: "No card data stored", body: "Payments run entirely on Stripe." },
+    ],
+    faq: [
+      {
+        q: "Is Stripe required to take payments?",
+        a: "Yes — connect a Stripe account and you can charge for bookings and sell packages.",
+      },
+    ],
+  },
+  {
+    slug: "whatsapp",
+    name: "WhatsApp",
+    category: "Messaging",
+    blurb: "Reminders on WhatsApp — and talk to Otter there too.",
+    subtitle:
+      "Send booking reminders over WhatsApp, and let people chat with Otter to book and reschedule right from WhatsApp.",
+    intro: [
+      "With Twilio configured, DayOtter delivers reminders over WhatsApp — where response rates beat email. And Otter is available inbound: text it to book, reschedule, or check your day, confirm-first.",
+      "A differentiator neither Calendly nor Cal.com offers.",
+    ],
+    points: [
+      {
+        title: "WhatsApp reminders",
+        body: "Deliver reminders and nudges where people actually reply.",
+      },
+      {
+        title: "Talk to Otter",
+        body: "Text Otter to book or reschedule — it drafts and waits for your OK.",
+      },
+    ],
+    faq: [
+      {
+        q: "Can I message the assistant on WhatsApp?",
+        a: "Yes — inbound WhatsApp lets you ask Otter to book, move, or check meetings, confirm-first.",
+      },
+    ],
+  },
+  {
+    slug: "microsoft-teams",
+    name: "Microsoft Teams",
+    category: "Video",
+    blurb: "Teams meeting links on every Microsoft-calendar booking.",
+    subtitle:
+      "With Microsoft 365 connected, DayOtter attaches a Microsoft Teams meeting link to each booking automatically.",
+    intro: [
+      "Set an event type's location to Teams and every booking gets a Teams meeting link created via Microsoft Graph and added to the invite.",
+      "The natural video option for teams on Microsoft 365.",
+    ],
+    points: [
+      {
+        title: "Automatic Teams links",
+        body: "A Teams meeting per booking, in the calendar invite.",
+      },
+      {
+        title: "Rides on Microsoft 365",
+        body: "No separate setup beyond your Microsoft connection.",
+      },
+    ],
+    faq: [
+      {
+        q: "Do I need extra setup for Teams links?",
+        a: "No — connect Microsoft 365 and choose Teams as the location; links are attached automatically.",
+      },
+    ],
+  },
+];
+
+export function getIntegration(slug: string): Integration | undefined {
+  return INTEGRATIONS.find((i) => i.slug === slug);
+}

--- a/apps/web/lib/marketing.ts
+++ b/apps/web/lib/marketing.ts
@@ -3,6 +3,8 @@
 export const BRAND = {
   name: "DayOtter",
   tagline: "The calm home for your time.",
+  /** Canonical site origin — drives metadataBase, sitemap, canonical URLs, JSON-LD. */
+  url: process.env.NEXT_PUBLIC_APP_URL ?? "https://dayotter.com",
   email: "hello@dayotter.com",
   github: "https://github.com/nometria/dayotter",
   githubLicense: "https://github.com/nometria/dayotter/blob/main/LICENSE",
@@ -22,7 +24,8 @@ export const FOOTER_COLUMNS: { title: string; links: FooterLink[] }[] = [
   {
     title: "Product",
     links: [
-      { label: "Features", href: "/#features" },
+      { label: "Features", href: "/features" },
+      { label: "Integrations", href: "/integrations" },
       { label: "Pricing", href: "/pricing" },
       { label: "How it works", href: "/#how" },
       { label: "Changelog", href: "/changelog" },
@@ -74,9 +77,9 @@ export const FOOTER_COLUMNS: { title: string; links: FooterLink[] }[] = [
 
 /** Top-nav links shown on marketing pages. */
 export const MARKETING_NAV: FooterLink[] = [
-  { label: "Features", href: "/#features" },
+  { label: "Features", href: "/features" },
+  { label: "Integrations", href: "/integrations" },
   { label: "Pricing", href: "/pricing" },
   { label: "Compare", href: "/vs" },
-  { label: "Blog", href: "/blog" },
   { label: "Docs", href: "/docs" },
 ];


### PR DESCRIPTION
Addresses "too few content pages + no SEO architecture," following the programmatic-SEO playbook Calendly uses for [1.1M+ monthly organic visits](https://upgrowth.in/how-calendlys-programmatic-seo-drives-1-1m-monthly-organic-traffic/).

## SEO foundation (was entirely missing)
- **`sitemap.ts`** (dynamic — all 61 pages), **`robots.ts`**, **`manifest.ts`**
- Root **metadata**: `metadataBase`, title template, **OpenGraph + Twitter cards**, keywords, canonical, robots directives
- **`components/seo/json-ld`**: Organization + SoftwareApplication (site-wide), FAQPage, BreadcrumbList, Article helpers
- Retrofitted **FAQ + Breadcrumb JSON-LD + per-page canonical** onto `/vs`, `/for`, and pricing

## New content categories (programmatic pages)
- **`/features` + `/features/[slug]`** — 10 feature landing pages (AI scheduling, round-robin, routing, focus time, reminders, calendar sync, payments, voice, booking pages, group polls)
- **`/integrations` + `/integrations/[slug]`** — 9 integration pages ("DayOtter + Google Calendar/Outlook/Zoom/Slack/Stripe/…") — Calendly's highest-volume play
- Both wired into the top nav + footer, with internal cross-linking

## Verified
All pages return 200, **sitemap has 61 `<loc>` URLs** (up from ~16), robots + manifest serve correctly, JSON-LD present (Organization/SoftwareApplication on home; FAQPage/BreadcrumbList on comparisons), canonical + templated OG confirmed on feature pages. Typecheck passes; biome-formatted.

Both are data-driven templates — adding a feature or integration is a one-object edit, so this keeps scaling.