### PR TITLE
Land Otter voice mode + hero polish on main (was orphaned by stacked PR #27)

### DIFF
--- a/apps/web/components/ai-assistant.tsx
+++ b/apps/web/components/ai-assistant.tsx
@@ -5,8 +5,8 @@ import { FormError } from "@/components/ui/form";
 import { Input, Label } from "@/components/ui/input";
 import type { ChatAction, ChatToolAction } from "@/lib/ai/chat";
 import { track } from "@/lib/analytics";
-import { useSpeechInput } from "@/lib/use-speech";
-import { Mic, Send, Sparkles, Volume2, VolumeX, X } from "lucide-react";
+import { useSpeechInput, useSpeechOutput } from "@/lib/use-speech";
+import { Mic, Send, Sparkles, Volume2, VolumeX, Waves, X } from "lucide-react";
 import { DateTime } from "luxon";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -38,15 +38,6 @@ function fmtWhen(iso: string): string {
   return dt.isValid ? dt.toFormat("ccc, LLL d 'at' h:mm a") : iso;
 }
 
-/** Speak text via the browser's speech synthesis (no-op where unavailable). */
-function speak(text: string) {
-  if (typeof window === "undefined" || !("speechSynthesis" in window) || !text) return;
-  window.speechSynthesis.cancel();
-  const u = new SpeechSynthesisUtterance(text);
-  u.rate = 1.02;
-  window.speechSynthesis.speak(u);
-}
-
 /**
  * Otter - the conversational scheduling assistant. Streams replies from
  * /api/ai/chat, supports voice in (speech-to-text) and spoken replies, and
@@ -56,9 +47,16 @@ function speak(text: string) {
 export function AiAssistant({
   variant = "card",
   onClose,
-}: { variant?: "card" | "panel"; onClose?: () => void } = {}) {
+  onSwitchToVoice,
+}: {
+  variant?: "card" | "panel";
+  onClose?: () => void;
+  onSwitchToVoice?: () => void;
+} = {}) {
   const panel = variant === "panel";
   const router = useRouter();
+  const out = useSpeechOutput();
+  const speak = useCallback((text: string) => out.speak(text), [out]);
   const [messages, setMessages] = useState<Msg[]>([]);
   const [input, setInput] = useState("");
   const [streaming, setStreaming] = useState(false);
@@ -90,9 +88,7 @@ export function AiAssistant({
     setSpeakReplies((v) => {
       const next = !v;
       localStorage.setItem("dayotter_tts", next ? "1" : "0");
-      if (!next && typeof window !== "undefined" && "speechSynthesis" in window) {
-        window.speechSynthesis.cancel();
-      }
+      if (!next) out.cancel();
       return next;
     });
   }
@@ -103,6 +99,7 @@ export function AiAssistant({
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
   }, [messages, action]);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: speak is stable enough; re-creating send per voice change is unnecessary
   const send = useCallback(
     async (raw: string) => {
       const content = raw.trim();
@@ -330,6 +327,16 @@ export function AiAssistant({
             Your scheduling assistant - you confirm before anything changes
           </p>
         </div>
+        {onSwitchToVoice ? (
+          <button
+            type="button"
+            onClick={onSwitchToVoice}
+            title="Switch to hands-free voice"
+            className="rounded-md p-1.5 text-[var(--color-faint)] hover:text-[var(--color-text)]"
+          >
+            <Waves size={16} />
+          </button>
+        ) : null}
         <button
           type="button"
           onClick={toggleSpeak}

--- a/apps/web/components/marketing/hero.tsx
+++ b/apps/web/components/marketing/hero.tsx
@@ -25,15 +25,15 @@ export function Hero() {
           <span className="eyebrow">Meet Otter, your scheduling assistant</span>
         </FadeUp>
         <FadeUp delay={0.08}>
-          <h1 className="font-display mx-auto mt-5 max-w-4xl text-[2.6rem] leading-[1.04] tracking-[-0.02em] sm:text-6xl lg:text-[4.5rem]">
+          <h1 className="font-display mx-auto mt-5 max-w-4xl text-balance text-[2.6rem] leading-[1.04] tracking-[-0.02em] sm:text-6xl lg:text-[4.5rem]">
             Say it once. <em className="text-[var(--color-accent)]">Otter handles the rest.</em>
           </h1>
         </FadeUp>
         <FadeUp delay={0.16}>
-          <p className="mx-auto mt-6 max-w-xl text-lg leading-relaxed text-[var(--color-muted)]">
-            Talk to your calendar like you'd talk to an assistant. Otter books the meeting, holds
-            your focus time, and clears the back-and-forth - and never changes a thing without your
-            OK. Or share one link and let people book you themselves.
+          <p className="mx-auto mt-6 max-w-2xl text-pretty text-lg leading-relaxed text-[var(--color-muted)] sm:text-xl">
+            Talk to your calendar like you'd talk to an assistant. Otter books meetings, protects
+            your focus, and clears the back-and-forth - confirm-first. Or share one link and let
+            people book you themselves.
           </p>
         </FadeUp>
         <FadeUp delay={0.24}>

--- a/apps/web/components/otter-launcher.tsx
+++ b/apps/web/components/otter-launcher.tsx
@@ -1,17 +1,21 @@
 "use client";
 
 import { AiAssistant } from "@/components/ai-assistant";
+import { OtterVoice } from "@/components/otter-voice";
 import { type ReactNode, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
+
+type Mode = "voice" | "chat";
 
 /**
  * The primary way to reach Otter - a floating otter button on every app page
  * that opens the assistant in a slide-over (right drawer on desktop, bottom
- * sheet on mobile). Talk or type; Otter does the scheduling. Rendered globally
- * from the app layout, gated on `aiEnabled`.
+ * sheet on mobile). Opens in hands-free voice mode by default; a tap switches to
+ * text chat. Rendered globally from the app layout, gated on `aiEnabled`.
  */
 export function OtterLauncher() {
   const [open, setOpen] = useState(false);
+  const [mode, setMode] = useState<Mode>("voice");
 
   useEffect(() => {
     if (!open) return;
@@ -49,12 +53,12 @@ export function OtterLauncher() {
         </button>
       )}
 
-      {open ? <Portal>{drawer(() => setOpen(false))}</Portal> : null}
+      {open ? <Portal>{drawer(() => setOpen(false), mode, setMode)}</Portal> : null}
     </>
   );
 }
 
-function drawer(onClose: () => void): ReactNode {
+function drawer(onClose: () => void, mode: Mode, setMode: (m: Mode) => void): ReactNode {
   return (
     <div className="fixed inset-0 z-50">
       <button
@@ -64,7 +68,11 @@ function drawer(onClose: () => void): ReactNode {
         className="absolute inset-0 cursor-default bg-[color-mix(in_srgb,var(--color-text)_38%,transparent)] backdrop-blur-[2px]"
       />
       <div className="animate-dialog-in absolute inset-x-0 bottom-0 flex h-[85vh] flex-col overflow-hidden rounded-t-[var(--radius-xl)] border-t border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-pop)] sm:inset-y-0 sm:right-0 sm:left-auto sm:h-full sm:w-[440px] sm:rounded-none sm:border-l sm:border-t-0">
-        <AiAssistant variant="panel" onClose={onClose} />
+        {mode === "voice" ? (
+          <OtterVoice onSwitchToChat={() => setMode("chat")} onClose={onClose} />
+        ) : (
+          <AiAssistant variant="panel" onClose={onClose} onSwitchToVoice={() => setMode("voice")} />
+        )}
       </div>
     </div>
   );

--- a/apps/web/components/otter-voice.tsx
+++ b/apps/web/components/otter-voice.tsx
@@ -1,0 +1,589 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import type { ChatAction, ChatToolAction, ChatTurn } from "@/lib/ai/chat";
+import {
+  runCancel,
+  runCreateEvent,
+  runReschedule,
+  runToolAction,
+  streamOtterChat,
+} from "@/lib/ai/otter-client";
+import { track } from "@/lib/analytics";
+import { useSpeechInput, useSpeechOutput } from "@/lib/use-speech";
+import { MessageSquare, Mic, Volume2, VolumeX, X } from "lucide-react";
+import { DateTime } from "luxon";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+type Phase = "idle" | "listening" | "thinking" | "speaking";
+
+const CONFIRM_RE =
+  /\b(confirm|yes|yep|yeah|do it|go ahead|book it|sounds good|please do|okay|ok)\b/i;
+const DISCARD_RE = /\b(discard|no thanks|nope|never ?mind|forget it|stop|not now)\b/i;
+
+const HINTS = [
+  "What's next on my calendar?",
+  "Protect 3 hours of focus this week",
+  "Move my next meeting to Friday",
+];
+
+function fmtWhen(iso: string): string {
+  const dt = DateTime.fromISO(iso);
+  return dt.isValid ? dt.toFormat("ccc, LLL d 'at' h:mm a") : iso;
+}
+
+/**
+ * Otter Voice - a hands-free, JARVIS-style conversation with the scheduling
+ * assistant. Tap the orb and talk: Otter listens, thinks, and speaks its reply,
+ * then listens again. It stays confirm-first - any calendar change surfaces a
+ * card you approve by tapping Confirm or simply saying "confirm".
+ */
+export function OtterVoice({
+  onSwitchToChat,
+  onClose,
+}: {
+  onSwitchToChat?: () => void;
+  onClose?: () => void;
+}) {
+  const out = useSpeechOutput();
+
+  const [active, setActive] = useState(false);
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [messages, setMessages] = useState<ChatTurn[]>([]);
+  const [interim, setInterim] = useState("");
+  const [reply, setReply] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [muted, setMuted] = useState(false);
+
+  const [action, setAction] = useState<ChatAction | null>(null);
+  const [toolAction, setToolAction] = useState<ChatToolAction | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // Refs mirror state for use inside speech callbacks (registered once).
+  const activeRef = useRef(active);
+  activeRef.current = active;
+  const phaseRef = useRef(phase);
+  phaseRef.current = phase;
+  const messagesRef = useRef(messages);
+  messagesRef.current = messages;
+  const pendingRef = useRef(false);
+  pendingRef.current = Boolean(action || toolAction);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const say = useCallback(
+    (text: string, onEnd?: () => void) => {
+      if (muted || !out.supported) {
+        onEnd?.();
+        return;
+      }
+      out.speak(text, { onEnd });
+    },
+    [muted, out],
+  );
+
+  const beginListening = useCallback(() => {
+    if (!activeRef.current) return;
+    setInterim("");
+    setPhase("listening");
+    speechStartRef.current?.();
+  }, []);
+
+  // Forward ref to speech.start (defined after the hook below).
+  const speechStartRef = useRef<(() => void) | null>(null);
+
+  const runTurn = useCallback(
+    (turns: ChatTurn[]) => {
+      setReply("");
+      setError(null);
+      setPhase("thinking");
+      let localAction: ChatAction | null = null;
+      let localTool: ChatToolAction | null = null;
+
+      void streamOtterChat(turns, {
+        onToken: (full) => setReply(full),
+        onAction: (a) => {
+          localAction = a;
+          setAction(a);
+        },
+        onToolAction: (t) => {
+          localTool = t;
+          setToolAction(t);
+        },
+        onError: (msg) => {
+          setError(msg);
+          setPhase("idle");
+          say("Sorry, I ran into a problem.");
+        },
+        onDone: (finalText) => {
+          const text = finalText.trim();
+          if (text) setMessages((prev) => [...prev, { role: "assistant", content: text }]);
+          setReply("");
+          const hasPending = Boolean(localAction || localTool);
+          const spoken =
+            text || (hasPending ? "I've drafted that - say confirm to go ahead, or discard." : "");
+          setPhase("speaking");
+          say(spoken, () => {
+            // After speaking: if awaiting a confirm, listen for confirm/discard.
+            // Otherwise loop back to listening for the next request.
+            if (activeRef.current) beginListening();
+            else setPhase("idle");
+          });
+        },
+      });
+    },
+    [say, beginListening],
+  );
+
+  const handleUtterance = useCallback(
+    (finalText: string) => {
+      const text = finalText.trim();
+      if (!text) return;
+      setInterim("");
+
+      // If a confirm-first card is showing, treat speech as confirm / discard.
+      if (pendingRef.current) {
+        if (CONFIRM_RE.test(text)) {
+          void confirmPending();
+          return;
+        }
+        if (DISCARD_RE.test(text)) {
+          discardPending();
+          say("Discarded.", () => {
+            if (activeRef.current) beginListening();
+          });
+          return;
+        }
+        // Unclear - re-prompt and listen again.
+        setPhase("speaking");
+        say("Say confirm to go ahead, or discard.", () => {
+          if (activeRef.current) beginListening();
+        });
+        return;
+      }
+
+      const next: ChatTurn[] = [...messagesRef.current, { role: "user", content: text }];
+      setMessages(next);
+      runTurn(next);
+    },
+    // confirmPending/discardPending are defined below but stable via refs.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [runTurn, say, beginListening],
+  );
+
+  const speech = useSpeechInput(handleUtterance, {
+    interim: true,
+    onInterim: (t) => setInterim(t),
+  });
+  speechStartRef.current = speech.start;
+
+  // If listening ends with no result (silence / denied mic), fall back to idle.
+  useEffect(() => {
+    if (!speech.listening && phaseRef.current === "listening" && activeRef.current) {
+      setPhase("idle");
+    }
+  }, [speech.listening]);
+
+  // Pin the transcript to the latest line.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll on any change
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
+  }, [messages, reply, interim, action, toolAction]);
+
+  function startConversation() {
+    setError(null);
+    setActive(true);
+    activeRef.current = true;
+    setInterim("");
+    setPhase("listening");
+    // Speak a short greeting only on the very first start of an empty thread.
+    if (messagesRef.current.length === 0) {
+      setPhase("speaking");
+      say("Hi, I'm Otter. What can I do with your calendar?", () => {
+        if (activeRef.current) beginListening();
+      });
+    } else {
+      beginListening();
+    }
+    track("Otter Voice Started");
+  }
+
+  const stopConversation = useCallback(() => {
+    setActive(false);
+    activeRef.current = false;
+    speech.abort();
+    out.cancel();
+    setInterim("");
+    setPhase("idle");
+  }, [speech, out]);
+
+  function onOrbTap() {
+    if (!activeRef.current) {
+      startConversation();
+      return;
+    }
+    // Barge-in: tapping while Otter speaks interrupts and listens.
+    if (out.speaking) {
+      out.cancel();
+      beginListening();
+      return;
+    }
+    if (phase === "listening") {
+      stopConversation();
+      return;
+    }
+    // thinking - ignore taps
+  }
+
+  function discardPending() {
+    setAction(null);
+    setToolAction(null);
+  }
+
+  async function confirmPending() {
+    const a = action;
+    const t = toolAction;
+    if (!a && !t) return;
+    setBusy(true);
+    setError(null);
+    out.cancel();
+    setPhase("thinking");
+
+    let summary = "Done.";
+    let ok = false;
+    try {
+      if (a) {
+        const d = a.draft;
+        if (d.intent === "create") {
+          const r = await runCreateEvent({
+            title: d.title,
+            startISO: d.startISO,
+            durationMinutes: a.matchedEventType?.durationMinutes ?? d.durationMinutes,
+            notes: d.notes || undefined,
+            attendees: d.attendees,
+          });
+          ok = r.ok;
+          summary = r.ok ? `Added ${d.title} to your calendar.` : (r.error ?? "That didn't work.");
+          if (r.ok) track("AI Event Added", { kind: d.kind, via: "voice" });
+        } else if (d.intent === "reschedule" && a.target) {
+          const r = await runReschedule(a.target.uid, d.newStartISO);
+          ok = r.ok;
+          summary = r.ok ? "Rescheduled - attendees notified." : (r.error ?? "That didn't work.");
+          if (r.ok) track("AI Reschedule Confirmed", { via: "voice" });
+        } else if (d.intent === "cancel" && a.target) {
+          const r = await runCancel(a.target.uid);
+          ok = r.ok;
+          summary = r.ok ? "Cancelled - attendees notified." : (r.error ?? "That didn't work.");
+          if (r.ok) track("AI Cancel Confirmed", { via: "voice" });
+        }
+      } else if (t) {
+        const r = await runToolAction(t.tool, t.input);
+        ok = r.ok;
+        summary = r.ok ? (r.message ?? "Done.") : (r.error ?? "That didn't work.");
+        if (r.ok) track("AI Tool Action", { tool: t.tool, via: "voice" });
+      }
+    } catch {
+      summary = "Something went wrong.";
+    }
+
+    setBusy(false);
+    setAction(null);
+    setToolAction(null);
+    if (!ok) setError(summary);
+    setMessages((prev) => [...prev, { role: "assistant", content: summary }]);
+    setPhase("speaking");
+    say(summary, () => {
+      if (activeRef.current) beginListening();
+      else setPhase("idle");
+    });
+  }
+
+  const noRecognition = !speech.supported;
+
+  const statusLabel = !active
+    ? messages.length > 0
+      ? "Tap to continue"
+      : "Tap to start talking"
+    : phase === "listening"
+      ? "Listening…"
+      : phase === "thinking"
+        ? "Thinking…"
+        : phase === "speaking"
+          ? "Otter is speaking"
+          : "Tap the orb to talk";
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <VoiceStyles />
+
+      {/* Header */}
+      <div className="flex items-center gap-2 border-b border-[var(--color-border)] px-5 py-3.5">
+        <span className="flex h-7 w-7 items-center justify-center rounded-full bg-[var(--color-accent-soft)] text-[var(--color-accent)]">
+          <Mic size={15} />
+        </span>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-semibold leading-none">Talk to Otter</p>
+          <p className="mt-1 text-xs text-[var(--color-faint)]">
+            Hands-free · you confirm before anything changes
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setMuted((m) => !m)}
+          aria-pressed={muted}
+          title={muted ? "Otter's voice is muted" : "Otter's voice is on"}
+          className={
+            muted
+              ? "rounded-md p-1.5 text-[var(--color-faint)] hover:text-[var(--color-text)]"
+              : "rounded-md p-1.5 text-[var(--color-accent)]"
+          }
+        >
+          {muted ? <VolumeX size={16} /> : <Volume2 size={16} />}
+        </button>
+        {onSwitchToChat ? (
+          <button
+            type="button"
+            onClick={() => {
+              stopConversation();
+              onSwitchToChat();
+            }}
+            title="Switch to text chat"
+            className="rounded-md p-1.5 text-[var(--color-faint)] hover:text-[var(--color-text)]"
+          >
+            <MessageSquare size={16} />
+          </button>
+        ) : null}
+        {onClose ? (
+          <button
+            type="button"
+            onClick={() => {
+              stopConversation();
+              onClose();
+            }}
+            aria-label="Close"
+            className="rounded-md p-1.5 text-[var(--color-faint)] hover:text-[var(--color-text)]"
+          >
+            <X size={16} />
+          </button>
+        ) : null}
+      </div>
+
+      {/* Transcript */}
+      <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+        {messages.length === 0 && !reply && !interim ? (
+          <div className="mt-2 text-center">
+            <p className="text-sm text-[var(--color-muted)]">
+              Tap the orb and just say what you need. Try:
+            </p>
+            <ul className="mt-3 space-y-1.5">
+              {HINTS.map((h) => (
+                <li key={h} className="text-sm italic text-[var(--color-faint)]">
+                  “{h}”
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {messages.map((m, i) => (
+              <Bubble key={i} who={m.role} text={m.content} />
+            ))}
+            {reply ? <Bubble who="assistant" text={reply} /> : null}
+            {interim ? <Bubble who="user" text={interim} muted /> : null}
+          </div>
+        )}
+
+        {/* Confirm-first card */}
+        {action ? (
+          <ConfirmCard
+            title={confirmTitle(action)}
+            body={confirmBody(action)}
+            danger={action.draft.intent === "cancel"}
+            busy={busy}
+            onConfirm={() => void confirmPending()}
+            onDiscard={discardPending}
+          />
+        ) : null}
+        {toolAction ? (
+          <ConfirmCard
+            title={toolAction.title}
+            body={`${toolAction.summary}.`}
+            danger={toolAction.confirmLevel === "danger"}
+            busy={busy}
+            onConfirm={() => void confirmPending()}
+            onDiscard={discardPending}
+          />
+        ) : null}
+      </div>
+
+      {/* Orb + controls */}
+      <div className="border-t border-[var(--color-border)] px-5 py-6">
+        {error ? (
+          <p className="mb-3 text-center text-sm text-[var(--color-danger)]">{error}</p>
+        ) : null}
+
+        {noRecognition ? (
+          <div className="text-center">
+            <p className="text-sm text-[var(--color-muted)]">
+              Voice input isn't supported in this browser. Try Chrome or Safari - or switch to text
+              chat.
+            </p>
+            {onSwitchToChat ? (
+              <Button className="mt-3" variant="outline" size="sm" onClick={onSwitchToChat}>
+                Switch to chat
+              </Button>
+            ) : null}
+          </div>
+        ) : (
+          <div className="flex flex-col items-center gap-4">
+            <button
+              type="button"
+              onClick={onOrbTap}
+              aria-label={active ? "Stop or interrupt Otter" : "Start talking to Otter"}
+              className="otter-orb-btn"
+              data-phase={active ? phase : "off"}
+            >
+              <span className="otter-orb-ring otter-orb-ring-1" />
+              <span className="otter-orb-ring otter-orb-ring-2" />
+              <span className="otter-orb-core">
+                <img
+                  src="/brand/illustrations/otter-focus.png"
+                  alt=""
+                  className="h-full w-full rounded-full object-cover"
+                />
+              </span>
+            </button>
+            <p className="text-sm font-medium text-[var(--color-muted)]">{statusLabel}</p>
+            {active ? (
+              <Button variant="ghost" size="sm" onClick={stopConversation}>
+                End conversation
+              </Button>
+            ) : null}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function confirmTitle(a: ChatAction): string {
+  if (a.draft.intent === "create") return a.matchedEventType?.title ?? "New event";
+  if (a.draft.intent === "reschedule") return "Reschedule";
+  if (a.draft.intent === "cancel") return "Cancel meeting";
+  return "Confirm";
+}
+
+function confirmBody(a: ChatAction): string {
+  const d = a.draft;
+  if (d.intent === "create") {
+    const dur = a.matchedEventType?.durationMinutes ?? d.durationMinutes;
+    return `${d.title} · ${fmtWhen(d.startISO)} · ${dur} min`;
+  }
+  if (d.intent === "reschedule" && a.target) {
+    return `Move “${a.target.title}” to ${fmtWhen(d.newStartISO)}`;
+  }
+  if (d.intent === "cancel" && a.target) {
+    return `Cancel “${a.target.title}” on ${fmtWhen(a.target.startISO)}. Attendees are notified.`;
+  }
+  return "";
+}
+
+function Bubble({
+  who,
+  text,
+  muted,
+}: { who: "user" | "assistant"; text: string; muted?: boolean }) {
+  return (
+    <div className={who === "user" ? "flex justify-end" : "flex justify-start"}>
+      <div
+        className={
+          who === "user"
+            ? `max-w-[85%] rounded-2xl rounded-br-sm px-3.5 py-2 text-sm text-white ${muted ? "bg-[color-mix(in_srgb,var(--color-accent)_55%,transparent)]" : "bg-[var(--color-accent)]"}`
+            : "max-w-[85%] rounded-2xl rounded-bl-sm bg-[var(--color-surface-2)] px-3.5 py-2 text-sm text-[var(--color-text)]"
+        }
+      >
+        {text}
+      </div>
+    </div>
+  );
+}
+
+function ConfirmCard({
+  title,
+  body,
+  danger,
+  busy,
+  onConfirm,
+  onDiscard,
+}: {
+  title: string;
+  body: string;
+  danger?: boolean;
+  busy: boolean;
+  onConfirm: () => void;
+  onDiscard: () => void;
+}) {
+  return (
+    <div
+      className={`mt-3 space-y-3 rounded-lg border p-4 shadow-[var(--shadow-card)] ${
+        danger
+          ? "border-[color-mix(in_srgb,var(--color-danger)_40%,transparent)] bg-[color-mix(in_srgb,var(--color-danger)_5%,transparent)]"
+          : "border-[var(--color-border)] bg-[var(--color-surface)]"
+      }`}
+    >
+      <span
+        className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${
+          danger
+            ? "bg-[color-mix(in_srgb,var(--color-danger)_15%,transparent)] text-[var(--color-danger)]"
+            : "bg-[var(--color-accent-soft)] text-[var(--color-accent)]"
+        }`}
+      >
+        {title}
+      </span>
+      <p className="text-sm text-[var(--color-text)]">{body}</p>
+      <p className="text-xs text-[var(--color-faint)]">Tap Confirm, or just say “confirm”.</p>
+      <div className="flex gap-2">
+        <Button
+          size="sm"
+          variant={danger ? "danger" : "primary"}
+          onClick={onConfirm}
+          disabled={busy}
+        >
+          {busy ? "Working…" : danger ? "Confirm" : "Confirm"}
+        </Button>
+        <Button size="sm" variant="ghost" onClick={onDiscard} disabled={busy}>
+          Discard
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/** Scoped keyframes + orb styling. Injected inline so the component is self-contained. */
+function VoiceStyles() {
+  return (
+    <style>{`
+      .otter-orb-btn{position:relative;display:flex;align-items:center;justify-content:center;width:168px;height:168px;border:0;background:transparent;cursor:pointer;-webkit-tap-highlight-color:transparent;}
+      .otter-orb-core{position:relative;z-index:2;display:flex;align-items:center;justify-content:center;width:104px;height:104px;border-radius:9999px;overflow:hidden;box-shadow:0 0 0 4px color-mix(in srgb,var(--color-accent) 30%,transparent),0 12px 40px color-mix(in srgb,var(--color-accent) 35%,transparent);animation:otterBreathe 4s ease-in-out infinite;}
+      .otter-orb-ring{position:absolute;inset:0;margin:auto;width:120px;height:120px;border-radius:9999px;background:radial-gradient(circle,color-mix(in srgb,var(--color-accent) 22%,transparent) 0%,transparent 70%);opacity:0;}
+      .otter-orb-btn[data-phase="off"] .otter-orb-core{animation-duration:5s;}
+      .otter-orb-btn[data-phase="off"] .otter-orb-ring{opacity:.25;}
+      .otter-orb-btn[data-phase="idle"] .otter-orb-ring{opacity:.3;}
+      /* Listening: outward sonar pulses */
+      .otter-orb-btn[data-phase="listening"] .otter-orb-ring-1{animation:otterPulse 1.6s ease-out infinite;}
+      .otter-orb-btn[data-phase="listening"] .otter-orb-ring-2{animation:otterPulse 1.6s ease-out infinite;animation-delay:.8s;}
+      /* Speaking: faster, brighter pulses + livelier core */
+      .otter-orb-btn[data-phase="speaking"] .otter-orb-ring-1{animation:otterPulse .9s ease-out infinite;}
+      .otter-orb-btn[data-phase="speaking"] .otter-orb-ring-2{animation:otterPulse .9s ease-out infinite;animation-delay:.45s;}
+      .otter-orb-btn[data-phase="speaking"] .otter-orb-core{animation:otterBreathe 1.1s ease-in-out infinite;}
+      /* Thinking: rotating halo */
+      .otter-orb-btn[data-phase="thinking"] .otter-orb-ring-1{opacity:1;background:conic-gradient(from 0deg,transparent 0%,color-mix(in srgb,var(--color-accent) 55%,transparent) 35%,transparent 70%);animation:otterSpin 1s linear infinite;-webkit-mask:radial-gradient(circle,transparent 46px,#000 47px);mask:radial-gradient(circle,transparent 46px,#000 47px);}
+      @keyframes otterBreathe{0%,100%{transform:scale(1)}50%{transform:scale(1.05)}}
+      @keyframes otterPulse{0%{transform:scale(.7);opacity:.55}100%{transform:scale(1.5);opacity:0}}
+      @keyframes otterSpin{to{transform:rotate(360deg)}}
+      @media (prefers-reduced-motion: reduce){
+        .otter-orb-core{animation:none!important}
+        .otter-orb-ring{animation:none!important}
+      }
+    `}</style>
+  );
+}

--- a/apps/web/lib/ai/otter-client.ts
+++ b/apps/web/lib/ai/otter-client.ts
@@ -1,0 +1,157 @@
+import type { ChatAction, ChatToolAction, ChatTurn } from "@/lib/ai/chat";
+
+/**
+ * Client-side streaming helper for talking to Otter over /api/ai/chat. Both the
+ * text panel and the voice ("JARVIS") panel share this so the SSE parsing,
+ * accumulation, and confirm-first action plumbing live in one place.
+ */
+
+export interface OtterStreamHandlers {
+  /** Fires on every token with the full accumulated assistant text so far. */
+  onToken?: (fullText: string) => void;
+  /** A booking create/reschedule/cancel proposal (rich editable card). */
+  onAction?: (action: ChatAction) => void;
+  /** A registry action (booking types, availability, prefs, focus) to confirm. */
+  onToolAction?: (toolAction: ChatToolAction) => void;
+  onError?: (message: string) => void;
+  /** The final trimmed assistant text once the turn is complete. */
+  onDone?: (finalText: string) => void;
+}
+
+/** Stream one assistant turn. Resolves when the stream ends (or errors softly). */
+export async function streamOtterChat(
+  turns: ChatTurn[],
+  handlers: OtterStreamHandlers,
+  signal?: AbortSignal,
+): Promise<void> {
+  let res: Response;
+  try {
+    res = await fetch("/api/ai/chat", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ messages: turns }),
+      signal,
+    });
+  } catch (err) {
+    if ((err as { name?: string })?.name === "AbortError") return;
+    handlers.onError?.("Couldn't reach the assistant.");
+    return;
+  }
+
+  if (!res.ok || !res.body) {
+    const data = await res.json().catch(() => ({}) as Record<string, unknown>);
+    handlers.onError?.(
+      typeof data.error === "string" ? data.error : "The assistant is unavailable.",
+    );
+    return;
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let acc = "";
+  let finalText = "";
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const chunks = buffer.split("\n\n");
+      buffer = chunks.pop() ?? "";
+      for (const chunk of chunks) {
+        const line = chunk.trim();
+        if (!line.startsWith("data:")) continue;
+        let ev: {
+          type: string;
+          text?: string;
+          message?: string;
+          action?: ChatAction;
+          toolAction?: ChatToolAction;
+        };
+        try {
+          ev = JSON.parse(line.slice(5).trim());
+        } catch {
+          continue;
+        }
+        if (ev.type === "token") {
+          acc += ev.text ?? "";
+          handlers.onToken?.(acc);
+        } else if (ev.type === "action" && ev.action) {
+          handlers.onAction?.(ev.action);
+        } else if (ev.type === "tool_action" && ev.toolAction) {
+          handlers.onToolAction?.(ev.toolAction);
+        } else if (ev.type === "error") {
+          handlers.onError?.(ev.message ?? "Something went wrong.");
+        } else if (ev.type === "done") {
+          finalText = (ev.text || acc).trim();
+        }
+      }
+    }
+  } catch (err) {
+    if ((err as { name?: string })?.name === "AbortError") return;
+    handlers.onError?.("The connection dropped.");
+    return;
+  }
+
+  handlers.onDone?.(finalText || acc.trim());
+}
+
+// ---------------------------------------------------------------------------
+// Confirm-first action runners. Each runs ONLY after the human confirms (tap or
+// spoken "confirm"). They mirror the endpoints the text panel calls.
+// ---------------------------------------------------------------------------
+
+export interface ActionResult {
+  ok: boolean;
+  message?: string;
+  error?: string;
+}
+
+async function postJson(url: string, body: unknown): Promise<Response> {
+  return fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body ?? {}),
+  });
+}
+
+export async function runCreateEvent(input: {
+  title: string;
+  startISO: string | null;
+  durationMinutes: number;
+  notes?: string;
+  attendees?: { name?: string; email: string }[];
+}): Promise<ActionResult> {
+  const res = await postJson("/api/ai/schedule/create", input);
+  const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+  if (!res.ok) return { ok: false, error: strOr(data.error, "Couldn't add the event.") };
+  return { ok: true };
+}
+
+export async function runReschedule(uid: string, startISO: string | null): Promise<ActionResult> {
+  const res = await postJson(`/api/bookings/${uid}/reschedule`, { start: startISO });
+  const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+  if (!res.ok) return { ok: false, error: strOr(data.error, "Couldn't reschedule that.") };
+  return { ok: true };
+}
+
+export async function runCancel(uid: string): Promise<ActionResult> {
+  const res = await postJson(`/api/bookings/${uid}/cancel`, {});
+  const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+  if (!res.ok) return { ok: false, error: strOr(data.error, "Couldn't cancel that.") };
+  return { ok: true };
+}
+
+export async function runToolAction(tool: string, input: unknown): Promise<ActionResult> {
+  const res = await postJson("/api/ai/act", { tool, input });
+  const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+  if (!res.ok || !data.ok) {
+    return { ok: false, error: strOr(data.message ?? data.error, "Couldn't complete that.") };
+  }
+  return { ok: true, message: strOr(data.message, "Done.") };
+}
+
+function strOr(v: unknown, fallback: string): string {
+  return typeof v === "string" && v ? v : fallback;
+}

--- a/apps/web/lib/use-speech.ts
+++ b/apps/web/lib/use-speech.ts
@@ -14,7 +14,12 @@ interface SpeechRecognitionLike {
   start: () => void;
   stop: () => void;
   abort: () => void;
-  onresult: ((e: { results: ArrayLike<ArrayLike<{ transcript: string }>> }) => void) | null;
+  onresult:
+    | ((e: {
+        resultIndex: number;
+        results: ArrayLike<ArrayLike<{ transcript: string }> & { isFinal: boolean }>;
+      }) => void)
+    | null;
   onend: (() => void) | null;
   onerror: ((e: { error?: string }) => void) | null;
 }
@@ -29,18 +34,38 @@ function getCtor(): SpeechRecognitionCtor | null {
   return w.SpeechRecognition ?? w.webkitSpeechRecognition ?? null;
 }
 
+export interface SpeechInputOptions {
+  lang?: string;
+  /** Emit partial (interim) transcripts as the user is still speaking. */
+  interim?: boolean;
+  /** Called with the live interim transcript (only when `interim` is true). */
+  onInterim?: (text: string) => void;
+}
+
 /**
  * Speak-to-type via the browser's built-in Web Speech API - no server, no key,
  * transcription happens on the device/browser. `onResult` fires once with the
- * final transcript. `supported` is false where the API is missing (e.g. Firefox);
- * callers should hide the mic in that case.
+ * final transcript. With `interim: true`, `onInterim` streams the partial text
+ * live (for captions). `supported` is false where the API is missing (e.g.
+ * Firefox); callers should hide the mic in that case.
+ *
+ * Back-compat: the second arg may be a bare language string (legacy callers).
  */
-export function useSpeechInput(onResult: (text: string) => void, lang?: string) {
+export function useSpeechInput(
+  onResult: (text: string) => void,
+  options?: SpeechInputOptions | string,
+) {
+  const opts: SpeechInputOptions =
+    typeof options === "string" ? { lang: options } : (options ?? {});
+  const { lang, interim = false } = opts;
+
   const [listening, setListening] = useState(false);
   const [supported, setSupported] = useState(false);
   const recRef = useRef<SpeechRecognitionLike | null>(null);
   const onResultRef = useRef(onResult);
   onResultRef.current = onResult;
+  const onInterimRef = useRef(opts.onInterim);
+  onInterimRef.current = opts.onInterim;
 
   useEffect(() => {
     setSupported(getCtor() !== null);
@@ -52,29 +77,199 @@ export function useSpeechInput(onResult: (text: string) => void, lang?: string) 
     setListening(false);
   }, []);
 
+  const abort = useCallback(() => {
+    recRef.current?.abort();
+    setListening(false);
+  }, []);
+
   const start = useCallback(() => {
     const Ctor = getCtor();
     if (!Ctor) return;
+    // Tear down any prior instance so we never run two recognizers at once.
+    recRef.current?.abort();
     const rec = new Ctor();
     rec.lang = lang ?? navigator.language ?? "en-US";
-    rec.interimResults = false;
+    rec.interimResults = interim;
     rec.maxAlternatives = 1;
     rec.continuous = false;
     rec.onresult = (e) => {
-      const transcript = e.results?.[0]?.[0]?.transcript?.trim() ?? "";
-      if (transcript) onResultRef.current(transcript);
+      let interimText = "";
+      let finalText = "";
+      for (let i = e.resultIndex; i < e.results.length; i++) {
+        const res = e.results[i];
+        if (!res) continue;
+        const transcript = res[0]?.transcript ?? "";
+        if (res.isFinal) finalText += transcript;
+        else interimText += transcript;
+      }
+      if (interimText && onInterimRef.current) onInterimRef.current(interimText.trim());
+      const done = finalText.trim();
+      if (done) onResultRef.current(done);
     };
     rec.onend = () => setListening(false);
     rec.onerror = () => setListening(false);
     recRef.current = rec;
     setListening(true);
     rec.start();
-  }, [lang]);
+  }, [lang, interim]);
 
   const toggle = useCallback(() => {
     if (listening) stop();
     else start();
   }, [listening, start, stop]);
 
-  return { supported, listening, start, stop, toggle };
+  return { supported, listening, start, stop, abort, toggle };
+}
+
+// ---------------------------------------------------------------------------
+// Speech output (text-to-speech) - Otter's voice.
+// ---------------------------------------------------------------------------
+
+/**
+ * Ordered preference of natural-sounding English voices across platforms. We
+ * match by substring (case-insensitive) against the available voices and pick
+ * the first that exists - falling back to any online (neural) en voice, then
+ * any en voice at all. These names are the higher-quality system/cloud voices
+ * on macOS, iOS, Windows, and Chrome.
+ */
+const PREFERRED_VOICES = [
+  "Google UK English Female",
+  "Microsoft Aria Online",
+  "Microsoft Jenny Online",
+  "Microsoft Emma Online",
+  "Samantha",
+  "Serena",
+  "Karen",
+  "Google US English",
+  "Microsoft Zira",
+  "Daniel",
+];
+
+const VOICE_KEY = "dayotter_voice";
+
+function scoreVoice(v: SpeechSynthesisVoice): number {
+  const name = v.name.toLowerCase();
+  const idx = PREFERRED_VOICES.findIndex((p) => name.includes(p.toLowerCase()));
+  if (idx >= 0) return 1000 - idx; // earlier in the list = higher score
+  if (!v.lang.toLowerCase().startsWith("en")) return -1;
+  // Online/cloud voices tend to sound markedly better than local ones.
+  return (v.localService ? 0 : 50) + (name.includes("female") ? 5 : 0);
+}
+
+/** Pick the best available voice, honouring a saved preference by name. */
+function pickBestVoice(
+  voices: SpeechSynthesisVoice[],
+  preferredName?: string | null,
+): SpeechSynthesisVoice | null {
+  if (voices.length === 0) return null;
+  if (preferredName) {
+    const saved = voices.find((v) => v.name === preferredName);
+    if (saved) return saved;
+  }
+  const en = voices.filter((v) => v.lang.toLowerCase().startsWith("en"));
+  const pool = en.length > 0 ? en : voices;
+  return [...pool].sort((a, b) => scoreVoice(b) - scoreVoice(a))[0] ?? null;
+}
+
+export interface SpeakOptions {
+  /** 0.1–2, speaking rate. Default 1.0 (natural). */
+  rate?: number;
+  /** 0–2, pitch. Default 1.02 (a touch bright and friendly). */
+  pitch?: number;
+  onEnd?: () => void;
+}
+
+/** Split into sentence-ish chunks so speech starts fast and phrasing sounds natural. */
+function splitSentences(text: string): string[] {
+  return (
+    text
+      .replace(/\s+/g, " ")
+      .match(/[^.!?]+[.!?]*/g)
+      ?.map((s) => s.trim())
+      .filter(Boolean) ?? [text]
+  );
+}
+
+/**
+ * Otter's voice. Selects a natural-sounding voice, remembers the user's choice,
+ * and speaks with tuned modulation. `speaking` reflects whether audio is playing.
+ * A no-op (but `supported: false`) where speechSynthesis is unavailable.
+ */
+export function useSpeechOutput() {
+  const [supported, setSupported] = useState(false);
+  const [speaking, setSpeaking] = useState(false);
+  const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
+  const [voiceName, setVoiceNameState] = useState<string | null>(null);
+  const voiceRef = useRef<SpeechSynthesisVoice | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !("speechSynthesis" in window)) return;
+    setSupported(true);
+    const saved = localStorage.getItem(VOICE_KEY);
+
+    const load = () => {
+      const list = window.speechSynthesis.getVoices();
+      if (list.length === 0) return;
+      setVoices(list);
+      const best = pickBestVoice(list, saved);
+      voiceRef.current = best;
+      setVoiceNameState(best?.name ?? null);
+    };
+    load();
+    window.speechSynthesis.addEventListener("voiceschanged", load);
+    return () => {
+      window.speechSynthesis.removeEventListener("voiceschanged", load);
+      window.speechSynthesis.cancel();
+    };
+  }, []);
+
+  const setVoiceName = useCallback(
+    (name: string) => {
+      const v = voices.find((x) => x.name === name) ?? null;
+      voiceRef.current = v;
+      setVoiceNameState(v?.name ?? null);
+      if (v) localStorage.setItem(VOICE_KEY, v.name);
+    },
+    [voices],
+  );
+
+  const cancel = useCallback(() => {
+    if (typeof window === "undefined" || !("speechSynthesis" in window)) return;
+    window.speechSynthesis.cancel();
+    setSpeaking(false);
+  }, []);
+
+  const speak = useCallback((text: string, o: SpeakOptions = {}) => {
+    if (typeof window === "undefined" || !("speechSynthesis" in window)) return;
+    const clean = text.trim();
+    if (!clean) {
+      o.onEnd?.();
+      return;
+    }
+    window.speechSynthesis.cancel();
+    const chunks = splitSentences(clean);
+    setSpeaking(true);
+    chunks.forEach((chunk, i) => {
+      const u = new SpeechSynthesisUtterance(chunk);
+      if (voiceRef.current) {
+        u.voice = voiceRef.current;
+        u.lang = voiceRef.current.lang;
+      }
+      u.rate = o.rate ?? 1.0;
+      u.pitch = o.pitch ?? 1.02;
+      if (i === chunks.length - 1) {
+        u.onend = () => {
+          setSpeaking(false);
+          o.onEnd?.();
+        };
+        u.onerror = () => {
+          setSpeaking(false);
+          o.onEnd?.();
+        };
+      }
+      window.speechSynthesis.speak(u);
+    });
+  }, []);
+
+  return { supported, speaking, voices, voiceName, setVoiceName, speak, cancel };
 }


### PR DESCRIPTION
PR #27 (voice mode + hero polish) was merged into its stacked base \`feat/seo-content-batch-2\`, not \`main\`. When #26 was squash-merged into \`main\`, that base branch was orphaned — so the voice changes never reached \`main\`.

This re-lands the exact same commit (cherry-picked cleanly onto current \`main\`). No SEO history, just the 6 voice/hero files:
- \`components/otter-voice.tsx\` (new) — JARVIS-style hands-free voice mode
- \`lib/ai/otter-client.ts\` (new) — shared streaming + confirm-action client
- \`lib/use-speech.ts\` — \`useSpeechOutput\` (natural voice selection + modulation) + interim captions
- \`components/otter-launcher.tsx\` — opens voice by default + Voice/Chat toggle
- \`components/ai-assistant.tsx\` — switch-to-voice control + upgraded spoken replies
- \`components/marketing/hero.tsx\` — widened/enlarged subtitle + balanced headline

Typecheck green. Merge this to actually get voice mode onto \`main\`.