### PR TITLE
Native CRM sync (Salesforce/HubSpot) + deeper time analytics

### DIFF
--- a/apps/web/app/(app)/settings/crm/page.tsx
+++ b/apps/web/app/(app)/settings/crm/page.tsx
@@ -1,0 +1,158 @@
+import { CrmDisconnectButton } from "@/components/crm-manager";
+import { buttonVariants } from "@/components/ui/button";
+import { Card, CardBody, CardHeader } from "@/components/ui/card";
+import { getSession } from "@/lib/auth/session";
+import { cn } from "@/lib/cn";
+import { eq, getDb, schema } from "@dayotter/db";
+import { crmEnabledProviders } from "@dayotter/integrations";
+import { AlertTriangle, CheckCircle2, Plus } from "lucide-react";
+import Link from "next/link";
+
+export const dynamic = "force-dynamic";
+
+const PROVIDERS = [
+  {
+    id: "salesforce",
+    name: "Salesforce",
+    color: "#00A1E0",
+    blurb: "Log every booking as an Event on the matched Contact.",
+  },
+  {
+    id: "hubspot",
+    name: "HubSpot",
+    color: "#FF7A59",
+    blurb: "Create the contact and log the meeting, kept in sync on reschedule.",
+  },
+] as const;
+
+export default async function CrmSettingsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ crm?: string }>;
+}) {
+  const session = await getSession();
+  if (!session?.user) return null; // the (app) layout redirects; this guards the render race
+  const params = await searchParams;
+
+  const connections = await getDb().query.crmConnections.findMany({
+    where: eq(schema.crmConnections.userId, session.user.id),
+  });
+  const enabled = crmEnabledProviders();
+
+  return (
+    <>
+      {params.crm === "connected" ? (
+        <div className="mb-5 flex items-center gap-2 rounded-md border border-[var(--color-success)]/30 bg-[var(--color-success)]/10 px-4 py-3 text-sm text-[var(--color-success)]">
+          <CheckCircle2 size={16} /> CRM connected. New bookings sync automatically.
+        </div>
+      ) : params.crm === "error" ? (
+        <div className="mb-5 rounded-md border border-[var(--color-danger)]/30 bg-[var(--color-danger)]/10 px-4 py-3 text-sm text-[var(--color-danger)]">
+          Couldn't connect that CRM. Please try again.
+        </div>
+      ) : params.crm === "upgrade" ? (
+        <div className="mb-5 rounded-md border border-[var(--color-accent)]/30 bg-[var(--color-accent)]/10 px-4 py-3 text-sm text-[var(--color-text)]">
+          CRM sync is a Pro feature.{" "}
+          <Link href="/settings/billing" className="font-medium text-[var(--color-accent)]">
+            Upgrade
+          </Link>{" "}
+          to connect Salesforce or HubSpot.
+        </div>
+      ) : params.crm === "unavailable" ? (
+        <div className="mb-5 rounded-md border border-[var(--color-danger)]/30 bg-[var(--color-danger)]/10 px-4 py-3 text-sm text-[var(--color-danger)]">
+          That CRM isn't configured on this server yet.
+        </div>
+      ) : null}
+
+      <div className="mb-6">
+        <h2 className="text-lg font-semibold">CRM sync</h2>
+        <p className="mt-1 text-sm text-[var(--color-muted)]">
+          Push every booking to your CRM: DayOtter finds or creates the guest as a contact and logs
+          the meeting as an activity - updated on reschedule, closed on cancel.
+        </p>
+      </div>
+
+      {/* Connected CRMs */}
+      {connections.length > 0 ? (
+        <div className="mb-6 space-y-3">
+          {connections.map((conn) => {
+            const meta = PROVIDERS.find((p) => p.id === conn.provider);
+            return (
+              <Card key={conn.id}>
+                <CardHeader
+                  title={
+                    <span className="flex items-center gap-2">
+                      <span
+                        className="inline-block h-2.5 w-2.5 rounded-full"
+                        style={{ background: meta?.color }}
+                      />
+                      {meta?.name ?? conn.provider}
+                    </span>
+                  }
+                  description={conn.accountLabel ?? conn.externalAccountId}
+                  action={<CrmDisconnectButton provider={conn.provider} />}
+                />
+                {conn.lastError ? (
+                  <CardBody>
+                    <p className="flex items-center gap-1.5 text-sm text-[var(--color-danger)]">
+                      <AlertTriangle size={14} /> Last sync error: {conn.lastError}
+                    </p>
+                  </CardBody>
+                ) : null}
+              </Card>
+            );
+          })}
+        </div>
+      ) : null}
+
+      {/* Connect a CRM */}
+      <Card>
+        <CardHeader title="Connect a CRM" description="One click - OAuth, no API keys to paste." />
+        <CardBody>
+          <div className="space-y-3">
+            {PROVIDERS.map((p) => {
+              const isConnected = connections.some((c) => c.provider === p.id);
+              const isAvailable = enabled.includes(p.id);
+              return (
+                <div
+                  key={p.id}
+                  className="flex items-center justify-between gap-3 rounded-lg border border-[var(--color-border)] p-3"
+                >
+                  <div className="flex items-center gap-3">
+                    <span
+                      className="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
+                      style={{ background: p.color }}
+                    />
+                    <div>
+                      <p className="text-sm font-medium">{p.name}</p>
+                      <p className="text-xs text-[var(--color-muted)]">{p.blurb}</p>
+                    </div>
+                  </div>
+                  {isConnected ? (
+                    <span className="flex items-center gap-1 text-sm text-[var(--color-success)]">
+                      <CheckCircle2 size={15} /> Connected
+                    </span>
+                  ) : isAvailable ? (
+                    <Link
+                      href={`/api/integrations/crm/${p.id}`}
+                      className={cn(buttonVariants({ variant: "outline", size: "sm" }), "gap-1.5")}
+                    >
+                      <Plus size={14} /> Connect
+                    </Link>
+                  ) : (
+                    <span className="text-xs text-[var(--color-faint)]">Not configured</span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+          {enabled.length === 0 ? (
+            <p className="mt-4 text-xs text-[var(--color-faint)]">
+              No CRM is configured on this server. Set the provider's client id + secret in the
+              environment to enable it.
+            </p>
+          ) : null}
+        </CardBody>
+      </Card>
+    </>
+  );
+}

--- a/apps/web/app/(marketing)/integrations/page.tsx
+++ b/apps/web/app/(marketing)/integrations/page.tsx
@@ -7,11 +7,11 @@ import Link from "next/link";
 export const metadata: Metadata = {
   title: "Integrations",
   description:
-    "DayOtter connects with Google Calendar, Outlook, Apple iCloud, Zoom, Google Meet, Teams, Slack, WhatsApp, and Stripe - one calm scheduling layer over the tools you already use.",
+    "DayOtter connects with Google Calendar, Outlook, Apple iCloud, Zoom, Google Meet, Teams, Slack, WhatsApp, Stripe, Salesforce, and HubSpot - one calm scheduling layer over the tools you already use.",
   alternates: { canonical: "/integrations" },
 };
 
-const CATEGORIES = ["Calendar", "Video", "Messaging", "Payments"] as const;
+const CATEGORIES = ["Calendar", "Video", "Messaging", "Payments", "CRM"] as const;
 
 export default function IntegrationsPage() {
   return (

--- a/apps/web/app/api/integrations/crm/[provider]/callback/route.ts
+++ b/apps/web/app/api/integrations/crm/[provider]/callback/route.ts
@@ -1,0 +1,34 @@
+import { verifyState } from "@/lib/calendar/oauth-state";
+import { env } from "@/lib/server/env";
+import { logger } from "@dayotter/core";
+import { connectCrm, exchangeCrmCode, isCrmProvider } from "@dayotter/integrations";
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+/** CRM OAuth callback: verify state, exchange the code, store the connection. */
+export async function GET(request: Request, { params }: { params: Promise<{ provider: string }> }) {
+  const { provider } = await params;
+  const settings = `${env.APP_URL}/settings/crm`;
+
+  if (!isCrmProvider(provider)) return NextResponse.redirect(`${settings}?crm=error`);
+
+  const url = new URL(request.url);
+  const code = url.searchParams.get("code");
+  const state = url.searchParams.get("state");
+  if (!code || !state) return NextResponse.redirect(`${settings}?crm=error`);
+
+  const payload = verifyState(state);
+  if (!payload || payload.provider !== provider) {
+    return NextResponse.redirect(`${settings}?crm=error`);
+  }
+
+  try {
+    const { credentials, account } = await exchangeCrmCode(provider, code);
+    await connectCrm(payload.userId, provider, credentials, account);
+    return NextResponse.redirect(`${settings}?crm=connected`);
+  } catch (err) {
+    logger.error("crm connect failed", { event: "crm_connect_failed", provider, err });
+    return NextResponse.redirect(`${settings}?crm=error`);
+  }
+}

--- a/apps/web/app/api/integrations/crm/[provider]/route.ts
+++ b/apps/web/app/api/integrations/crm/[provider]/route.ts
@@ -1,0 +1,59 @@
+import { randomUUID } from "node:crypto";
+import { getSession } from "@/lib/auth/session";
+import { requireFeature } from "@/lib/billing/require-feature";
+import { createState } from "@/lib/calendar/oauth-state";
+import { and, eq, getDb, schema } from "@dayotter/db";
+import { crmAuthUrl, crmEnabledProviders, isCrmProvider } from "@dayotter/integrations";
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+/** Start the CRM OAuth flow: redirect the host to the provider's consent screen. */
+export async function GET(request: Request, { params }: { params: Promise<{ provider: string }> }) {
+  const { provider } = await params;
+  const settings = new URL("/settings/crm", request.url);
+
+  if (!isCrmProvider(provider)) return NextResponse.json({ error: "Unsupported" }, { status: 400 });
+
+  const session = await getSession();
+  if (!session?.user?.id) return NextResponse.redirect(new URL("/sign-in", request.url));
+
+  const gate = await requireFeature(session.user.id, "crm_sync");
+  if (gate) {
+    settings.searchParams.set("crm", "upgrade");
+    return NextResponse.redirect(settings);
+  }
+
+  if (!crmEnabledProviders().includes(provider)) {
+    settings.searchParams.set("crm", "unavailable");
+    return NextResponse.redirect(settings);
+  }
+
+  const state = createState({ userId: session.user.id, provider }, randomUUID());
+  return NextResponse.redirect(crmAuthUrl(provider, state));
+}
+
+/** Disconnect a CRM. */
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ provider: string }> },
+) {
+  const { provider } = await params;
+  if (!isCrmProvider(provider)) return NextResponse.json({ error: "Unsupported" }, { status: 400 });
+
+  const session = await getSession();
+  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const deleted = await getDb()
+    .delete(schema.crmConnections)
+    .where(
+      and(
+        eq(schema.crmConnections.userId, session.user.id),
+        eq(schema.crmConnections.provider, provider),
+      ),
+    )
+    .returning({ id: schema.crmConnections.id });
+
+  if (deleted.length === 0) return NextResponse.json({ error: "Not connected" }, { status: 404 });
+  return NextResponse.json({ ok: true });
+}

--- a/apps/web/components/crm-manager.tsx
+++ b/apps/web/components/crm-manager.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/toast";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+/** Disconnect a connected CRM (Salesforce / HubSpot), with a confirm step. */
+export function CrmDisconnectButton({ provider }: { provider: string }) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [confirming, setConfirming] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  async function disconnect() {
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/integrations/crm/${provider}`, { method: "DELETE" });
+      if (!res.ok) throw new Error("disconnect failed");
+      toast({ title: "CRM disconnected", variant: "success" });
+      router.refresh();
+    } catch {
+      toast({ title: "Couldn't disconnect", description: "Please try again.", variant: "error" });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (!confirming) {
+    return (
+      <Button variant="ghost" size="sm" onClick={() => setConfirming(true)}>
+        Disconnect
+      </Button>
+    );
+  }
+  return (
+    <span className="flex items-center gap-1.5">
+      <Button variant="danger" size="sm" disabled={busy} onClick={disconnect}>
+        {busy ? "Removing…" : "Confirm"}
+      </Button>
+      <Button variant="ghost" size="sm" onClick={() => setConfirming(false)}>
+        Cancel
+      </Button>
+    </span>
+  );
+}

--- a/apps/web/components/nav-items.ts
+++ b/apps/web/components/nav-items.ts
@@ -45,6 +45,7 @@ export const SETTINGS_NAV = [
   { href: "/settings/automations", label: "Automations" },
   { href: "/settings/packages", label: "Packages" },
   { href: "/settings/calendars", label: "Calendars" },
+  { href: "/settings/crm", label: "CRM" },
   { href: "/settings/billing", label: "Billing" },
   { href: "/settings/developer", label: "Developer" },
 ] as const;

--- a/apps/web/lib/analytics/time-allocation/README.md
+++ b/apps/web/lib/analytics/time-allocation/README.md
@@ -36,12 +36,17 @@ Append a `TimeMetric` to `METRICS` in `metrics.ts`:
 It appears on `/api/insights/time` and the "Where your time goes" section
 automatically.
 
+## Shipped metrics
+`meeting_focus_balance`, `top_people`, `time_of_day`, `weekly_load`,
+`back_to_back_share` (% of meetings with no gap before the next),
+`longest_focus_streak` (biggest uninterrupted block held),
+`external_vs_internal` (time with outside guests vs. teammates, by email domain).
+
 ## Ideas for future metrics
-- `back_to_back_share` - % of meetings with no gap before the next
-- `longest_focus_streak` - the biggest uninterrupted block you held
-- `external_vs_internal` - time with outside guests vs. teammates (by email domain)
 - `recurring_load` - share of time in recurring vs. one-off meetings
-- `reclaimed_time` - focus time Otter protected for you
+- `reclaimed_time` - focus time Otter protected for you (needs a marker on
+  time_blocks to distinguish reclaimed from manually-held focus)
+- `busiest_weekday` - which day carries the most meeting load
 
 ## Notes
 - Distinct from `lib/booking/insights.ts` (scheduling counts/funnel). This module

--- a/apps/web/lib/analytics/time-allocation/index.ts
+++ b/apps/web/lib/analytics/time-allocation/index.ts
@@ -5,8 +5,24 @@ import type { MetricResult, TimeDataset } from "./types";
 export type { MetricResult, StatResult, BreakdownResult, TimeMetric } from "./types";
 export { METRICS } from "./metrics";
 
+/** Extract a lowercase email domain, or null for a missing/malformed address. */
+function emailDomain(email: string | null | undefined): string | null {
+  const at = email?.lastIndexOf("@") ?? -1;
+  if (!email || at < 0) return null;
+  const domain = email
+    .slice(at + 1)
+    .toLowerCase()
+    .trim();
+  return domain || null;
+}
+
 /** Load the shared dataset (one pass over bookings + focus blocks) for a window. */
-async function loadDataset(userId: string, tz: string, windowDays: number): Promise<TimeDataset> {
+async function loadDataset(
+  userId: string,
+  tz: string,
+  windowDays: number,
+  hostDomain: string | null,
+): Promise<TimeDataset> {
   const db = getDb();
   const now = new Date();
   const from = new Date(now.getTime() - windowDays * 86_400_000);
@@ -40,6 +56,7 @@ async function loadDataset(userId: string, tz: string, windowDays: number): Prom
   return {
     tz,
     windowDays,
+    hostDomain,
     bookings: bookings.map((b) => ({
       start: b.startsAt,
       end: b.endsAt,
@@ -61,15 +78,15 @@ export async function computeTimeAllocation(params: {
   windowDays?: number;
 }): Promise<{ windowDays: number; metrics: MetricResult[] }> {
   const windowDays = params.windowDays ?? 30;
-  let tz = params.tz;
-  if (!tz) {
-    const user = await getDb().query.users.findFirst({
-      where: eq(schema.users.id, params.userId),
-      columns: { timezone: true },
-    });
-    tz = user?.timezone ?? "UTC";
-  }
-  const data = await loadDataset(params.userId, tz, windowDays);
+  // Always look up the host (email domain drives external/internal; timezone as
+  // a fallback when the caller didn't pass one).
+  const user = await getDb().query.users.findFirst({
+    where: eq(schema.users.id, params.userId),
+    columns: { timezone: true, email: true },
+  });
+  const tz = params.tz ?? user?.timezone ?? "UTC";
+  const hostDomain = emailDomain(user?.email);
+  const data = await loadDataset(params.userId, tz, windowDays, hostDomain);
   const metrics = METRICS.map((m) => m.compute(data)).filter((r): r is MetricResult => r !== null);
   return { windowDays, metrics };
 }

--- a/apps/web/lib/analytics/time-allocation/metrics.ts
+++ b/apps/web/lib/analytics/time-allocation/metrics.ts
@@ -4,6 +4,26 @@ import type { MetricResult, TimeDataset, TimeMetric } from "./types";
 const minutes = (b: { start: Date; end: Date }) => (b.end.getTime() - b.start.getTime()) / 60_000;
 const sum = (arr: { start: Date; end: Date }[]) => arr.reduce((s, b) => s + minutes(b), 0);
 
+/** Human duration for a stat value, e.g. "1h 45m" / "50m". */
+function fmtDuration(mins: number): string {
+  const m = Math.round(mins);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  const rem = m % 60;
+  return rem === 0 ? `${h}h` : `${h}h ${rem}m`;
+}
+
+/** Domain of an email, lowercased; null when malformed. */
+function domainOf(email: string): string | null {
+  const at = email.lastIndexOf("@");
+  if (at < 0) return null;
+  const d = email
+    .slice(at + 1)
+    .toLowerCase()
+    .trim();
+  return d || null;
+}
+
 /**
  * The "where your time goes" metrics. Each reads the shared dataset and returns
  * one card, or null when there isn't enough to say. To add an insight, append a
@@ -84,6 +104,103 @@ export const METRICS: TimeMetric[] = [
         label: "Meeting load",
         value: `${hoursPerWeek.toFixed(1)}h / week`,
         hint: `${n} meeting${n === 1 ? "" : "s"} in the last ${d.windowDays} days`,
+      };
+    },
+  },
+
+  // Share of meetings that start right after another with no breathing room.
+  {
+    key: "back_to_back_share",
+    compute(d: TimeDataset): MetricResult | null {
+      if (d.bookings.length < 2) return null;
+      const sorted = [...d.bookings].sort((a, b) => a.start.getTime() - b.start.getTime());
+      let backToBack = 0;
+      for (let i = 1; i < sorted.length; i++) {
+        const prev = sorted[i - 1];
+        const cur = sorted[i];
+        if (!prev || !cur) continue;
+        const gapMin = (cur.start.getTime() - prev.end.getTime()) / 60_000;
+        // A meeting starting within 5 minutes of the previous one ending counts as
+        // back-to-back (>= -1 guards against tiny overlaps from rounding).
+        if (gapMin >= -1 && gapMin < 5) backToBack++;
+      }
+      const share = Math.round((backToBack / (sorted.length - 1)) * 100);
+      return {
+        key: "back_to_back_share",
+        kind: "stat",
+        label: "Back-to-back",
+        value: `${share}%`,
+        hint:
+          share >= 40
+            ? "Little room to breathe - consider default buffers."
+            : "A healthy amount of space between meetings.",
+      };
+    },
+  },
+
+  // The longest uninterrupted block of focus time you actually held.
+  {
+    key: "longest_focus_streak",
+    compute(d: TimeDataset): MetricResult | null {
+      if (d.focusBlocks.length === 0) return null;
+      const sorted = [...d.focusBlocks].sort((a, b) => a.start.getTime() - b.start.getTime());
+      let longest = 0;
+      let runStart: number | null = null;
+      let runEnd = 0;
+      for (const block of sorted) {
+        const s = block.start.getTime();
+        const e = block.end.getTime();
+        if (runStart === null) {
+          runStart = s;
+          runEnd = e;
+        } else if (s <= runEnd + 60_000) {
+          // Contiguous (touching or overlapping) blocks extend the current streak.
+          runEnd = Math.max(runEnd, e);
+        } else {
+          longest = Math.max(longest, runEnd - runStart);
+          runStart = s;
+          runEnd = e;
+        }
+      }
+      if (runStart !== null) longest = Math.max(longest, runEnd - runStart);
+      const mins = longest / 60_000;
+      if (mins < 15) return null;
+      return {
+        key: "longest_focus_streak",
+        kind: "stat",
+        label: "Longest focus streak",
+        value: fmtDuration(mins),
+        hint: `Your biggest uninterrupted block in the last ${d.windowDays} days`,
+      };
+    },
+  },
+
+  // Time with outside guests vs. time with your own team (by email domain).
+  {
+    key: "external_vs_internal",
+    compute(d: TimeDataset): MetricResult | null {
+      if (!d.hostDomain) return null;
+      let external = 0;
+      let internal = 0;
+      for (const b of d.bookings) {
+        if (b.attendees.length === 0) continue;
+        const mins = minutes(b);
+        const hasExternal = b.attendees.some((a) => {
+          const dom = domainOf(a.email);
+          return dom !== null && dom !== d.hostDomain;
+        });
+        if (hasExternal) external += mins;
+        else internal += mins;
+      }
+      if (external + internal === 0) return null;
+      return {
+        key: "external_vs_internal",
+        kind: "breakdown",
+        label: "External vs. internal",
+        items: [
+          { label: "With outside guests", minutes: external, color: "var(--color-accent)" },
+          { label: "With your team", minutes: internal, color: "var(--color-coral)" },
+        ],
       };
     },
   },

--- a/apps/web/lib/analytics/time-allocation/types.ts
+++ b/apps/web/lib/analytics/time-allocation/types.ts
@@ -2,6 +2,9 @@
 export interface TimeDataset {
   tz: string;
   windowDays: number;
+  /** The host's own email domain (e.g. "acme.com"), for external/internal splits.
+   * Null when the host has no email or a non-standard address. */
+  hostDomain: string | null;
   bookings: {
     start: Date;
     end: Date;

--- a/apps/web/lib/billing/features.ts
+++ b/apps/web/lib/billing/features.ts
@@ -23,6 +23,7 @@ export type Feature =
   | "deep_work" // focus-time defense
   | "accept_payments" // charge attendees for bookings
   | "developer" // API keys, webhooks, embed
+  | "crm_sync" // native Salesforce / HubSpot sync
   // Cloud-only (ee/, commercial license)
   | "managed_ai" // AI with DayOtter's key - no BYO key
   | "sso" // SAML / Google Workspace sign-in
@@ -40,6 +41,7 @@ export const FEATURE_TIER: Record<Feature, FeatureTier> = {
   deep_work: "pro",
   accept_payments: "pro",
   developer: "pro",
+  crm_sync: "pro",
   managed_ai: "cloud",
   sso: "cloud",
   white_label: "cloud",
@@ -60,6 +62,7 @@ export const FEATURE_LABEL: Record<Feature, string> = {
   deep_work: "Deep-work defense",
   accept_payments: "Accept payments",
   developer: "Developer platform",
+  crm_sync: "CRM sync (Salesforce / HubSpot)",
   managed_ai: "Managed AI",
   sso: "Single sign-on",
   white_label: "White-label booking",

--- a/apps/web/lib/booking/cancel-booking.ts
+++ b/apps/web/lib/booking/cancel-booking.ts
@@ -1,6 +1,7 @@
 import { logger } from "@dayotter/core";
 import { eq, getDb, schema } from "@dayotter/db";
 import { bookingCancellation, sendEmail } from "@dayotter/emails";
+import { enqueueCrmSync } from "@dayotter/jobs";
 import { deleteBookingFromCalendar } from "../calendar/host-calendar";
 import { paymentsEnabled, refundPayment } from "../payments/stripe";
 import { emitWebhook } from "../webhooks/emit";
@@ -87,6 +88,7 @@ export async function cancelBooking(uid: string, reason?: string): Promise<boole
       endsAt: booking.endsAt.toISOString(),
       reason: reason ?? null,
     });
+    await enqueueCrmSync({ bookingId: booking.id, action: "cancelled" }).catch(() => {});
   }
 
   // Notify attendees.

--- a/apps/web/lib/booking/create-booking.ts
+++ b/apps/web/lib/booking/create-booking.ts
@@ -3,6 +3,7 @@ import { consumeCredit } from "@/lib/packages/credits";
 import { logger, roundRobinPick, safeEqual, sha256hex } from "@dayotter/core";
 import { and, eq, getDb, gte, inArray, lt, schema, sql } from "@dayotter/db";
 import { bookingConfirmation, sendEmail } from "@dayotter/emails";
+import { enqueueCrmSync } from "@dayotter/jobs";
 import { DateTime } from "luxon";
 import { applyBookingRules } from "../automation/apply-rules";
 import { writeBookingToCalendar } from "../calendar/host-calendar";
@@ -343,6 +344,9 @@ export async function createBooking(
     status: booking.status,
     attendee: { name: input.attendee.name, email: input.attendee.email },
   });
+
+  // Push to the host's connected CRMs (Salesforce / HubSpot), best-effort.
+  await enqueueCrmSync({ bookingId: booking.id, action: "created" }).catch(() => {});
 
   // Zoom event types: auto-create a real Zoom meeting when the host has Zoom
   // connected (falls back to any manual link otherwise). Best-effort.

--- a/apps/web/lib/booking/reschedule-booking.ts
+++ b/apps/web/lib/booking/reschedule-booking.ts
@@ -1,6 +1,7 @@
 import { logger } from "@dayotter/core";
 import { eq, getDb, schema } from "@dayotter/db";
 import { bookingRescheduled, sendEmail } from "@dayotter/emails";
+import { enqueueCrmSync } from "@dayotter/jobs";
 import { reserveRuleBlocks } from "../automation/apply-rules";
 import { updateBookingCalendarEvent } from "../calendar/host-calendar";
 import { emitWebhook } from "../webhooks/emit";
@@ -135,6 +136,7 @@ export async function rescheduleBooking(uid: string, newStartISO: string): Promi
       startsAt: newStart.toISOString(),
       endsAt: newEnd.toISOString(),
     });
+    await enqueueCrmSync({ bookingId: booking.id, action: "rescheduled" }).catch(() => {});
   }
 
   // Notify.

--- a/apps/web/lib/comparisons.ts
+++ b/apps/web/lib/comparisons.ts
@@ -75,9 +75,9 @@ export const COMPARISONS: Comparison[] = [
       { label: "Routing forms", dayotter: "Yes", them: "Yes", edge: "tie" },
       {
         label: "CRM (Salesforce/HubSpot)",
-        dayotter: "On the roadmap",
+        dayotter: "Native sync (beta)",
         them: "Native, mature",
-        edge: "them",
+        edge: "tie",
       },
       { label: "Apple iCloud sync", dayotter: "Yes", them: "Dropped in 2024", edge: "us" },
       { label: "Open source / self-host", dayotter: "Yes", them: "No", edge: "us" },
@@ -103,7 +103,7 @@ export const COMPARISONS: Comparison[] = [
     faq: [
       {
         q: "Is DayOtter a drop-in Calendly replacement?",
-        a: "For the everyday flow - booking pages, team round-robin, reminders, payments, calendar sync - yes. The main gap today is native Salesforce/HubSpot CRM, which is on our roadmap.",
+        a: "For the everyday flow - booking pages, team round-robin, reminders, payments, calendar sync - yes. Native Salesforce/HubSpot sync recently shipped (in beta); Calendly's CRM routing is still more mature if that's central to you.",
       },
       {
         q: "How much cheaper is DayOtter?",
@@ -418,7 +418,8 @@ export const COMPARISONS: Comparison[] = [
   {
     slug: "acuity",
     name: "Acuity Scheduling",
-    blurb: "Deep appointment tooling for service businesses - but Squarespace-owned, paid-only, and no AI.",
+    blurb:
+      "Deep appointment tooling for service businesses - but Squarespace-owned, paid-only, and no AI.",
     title: "DayOtter vs Acuity Scheduling",
     subtitle:
       "Acuity is built for salons, clinics and studios that live on appointments. DayOtter covers the same booking-and-pay basics, adds team scheduling and an AI assistant, and starts free - not at $16 a month.",
@@ -429,18 +430,43 @@ export const COMPARISONS: Comparison[] = [
     theirStrength:
       "Acuity's appointment features run deep - class scheduling, intake forms, gift certificates, subscriptions and point-of-sale style add-ons - and it's tightly integrated with Squarespace sites. For an established salon or clinic already on Squarespace, it's a proven fit.",
     rows: [
-      { label: "Free plan", dayotter: "Yes - unlimited event types", them: "No - paid from ~$16/mo", edge: "us" },
-      { label: "Price entry point", dayotter: "Free / $9 seat", them: "~$16–49 / month", edge: "us" },
+      {
+        label: "Free plan",
+        dayotter: "Yes - unlimited event types",
+        them: "No - paid from ~$16/mo",
+        edge: "us",
+      },
+      {
+        label: "Price entry point",
+        dayotter: "Free / $9 seat",
+        them: "~$16–49 / month",
+        edge: "us",
+      },
       {
         label: "AI assistant",
         dayotter: "Otter - chat to book, protect focus",
         them: "None",
         edge: "us",
       },
-      { label: "Paid bookings & packages", dayotter: "Yes (Stripe)", them: "Yes (mature)", edge: "tie" },
+      {
+        label: "Paid bookings & packages",
+        dayotter: "Yes (Stripe)",
+        them: "Yes (mature)",
+        edge: "tie",
+      },
       { label: "Intake forms", dayotter: "Yes", them: "Yes (deep)", edge: "tie" },
-      { label: "Team round-robin & routing", dayotter: "Weighted, built in", them: "Limited", edge: "us" },
-      { label: "Class / group scheduling", dayotter: "Group polls + limits", them: "Native classes", edge: "them" },
+      {
+        label: "Team round-robin & routing",
+        dayotter: "Weighted, built in",
+        them: "Limited",
+        edge: "us",
+      },
+      {
+        label: "Class / group scheduling",
+        dayotter: "Group polls + limits",
+        them: "Native classes",
+        edge: "them",
+      },
       { label: "Focus / time protection", dayotter: "Yes", them: "None", edge: "us" },
       { label: "Open source / self-host", dayotter: "Yes", them: "No", edge: "us" },
     ],
@@ -487,7 +513,12 @@ export const COMPARISONS: Comparison[] = [
     theirStrength:
       "SavvyCal's invitee experience is a highlight - letting people overlay their own calendar on yours to find a mutual time is genuinely elegant, and its personalization and polish are well ahead of the basics.",
     rows: [
-      { label: "Free plan", dayotter: "Yes - unlimited event types", them: "No - paid from ~$12/mo", edge: "us" },
+      {
+        label: "Free plan",
+        dayotter: "Yes - unlimited event types",
+        them: "No - paid from ~$12/mo",
+        edge: "us",
+      },
       { label: "Price", dayotter: "Free / $9 seat", them: "~$12–20 / seat", edge: "us" },
       {
         label: "AI assistant",
@@ -495,9 +526,19 @@ export const COMPARISONS: Comparison[] = [
         them: "None",
         edge: "us",
       },
-      { label: "Overlay-calendar booking", dayotter: "Availability preview", them: "Yes (signature)", edge: "them" },
+      {
+        label: "Overlay-calendar booking",
+        dayotter: "Availability preview",
+        them: "Yes (signature)",
+        edge: "them",
+      },
       { label: "Personalized links", dayotter: "Yes", them: "Yes (polished)", edge: "tie" },
-      { label: "Team round-robin & routing", dayotter: "Weighted, built in", them: "Basic teams", edge: "us" },
+      {
+        label: "Team round-robin & routing",
+        dayotter: "Weighted, built in",
+        them: "Basic teams",
+        edge: "us",
+      },
       { label: "Focus / time protection", dayotter: "Yes", them: "None", edge: "us" },
       { label: "Open source / self-host", dayotter: "Yes", them: "No", edge: "us" },
     ],
@@ -547,7 +588,12 @@ export const COMPARISONS: Comparison[] = [
       { label: "Group polls / meeting votes", dayotter: "Yes", them: "Yes (core)", edge: "tie" },
       { label: "Ad-free", dayotter: "Yes, always", them: "Ads on free tier", edge: "us" },
       { label: "Real booking pages", dayotter: "Unlimited, branded", them: "Basic", edge: "us" },
-      { label: "Team round-robin & routing", dayotter: "Weighted, built in", them: "None", edge: "us" },
+      {
+        label: "Team round-robin & routing",
+        dayotter: "Weighted, built in",
+        them: "None",
+        edge: "us",
+      },
       {
         label: "AI assistant",
         dayotter: "Otter - chat, confirm-first",
@@ -601,7 +647,12 @@ export const COMPARISONS: Comparison[] = [
     theirStrength:
       "YouCanBook.me's depth of customization on the booking page and notifications is real - if you want to control every string, colour and email, it gives you a lot of levers to pull.",
     rows: [
-      { label: "Free plan", dayotter: "Yes - unlimited event types", them: "Limited free / paid tiers", edge: "us" },
+      {
+        label: "Free plan",
+        dayotter: "Yes - unlimited event types",
+        them: "Limited free / paid tiers",
+        edge: "us",
+      },
       { label: "Price (paid)", dayotter: "$9 / seat", them: "~$10.8 / seat", edge: "tie" },
       {
         label: "AI assistant",
@@ -609,9 +660,19 @@ export const COMPARISONS: Comparison[] = [
         them: "None",
         edge: "us",
       },
-      { label: "Booking-page customization", dayotter: "Clean, sensible defaults", them: "Deep, fiddly", edge: "tie" },
+      {
+        label: "Booking-page customization",
+        dayotter: "Clean, sensible defaults",
+        them: "Deep, fiddly",
+        edge: "tie",
+      },
       { label: "Ease of setup", dayotter: "Minutes", them: "More configuration", edge: "us" },
-      { label: "Team round-robin & routing", dayotter: "Weighted, built in", them: "Team booking", edge: "us" },
+      {
+        label: "Team round-robin & routing",
+        dayotter: "Weighted, built in",
+        them: "Team booking",
+        edge: "us",
+      },
       { label: "Focus / time protection", dayotter: "Yes", them: "None", edge: "us" },
       { label: "Open source / self-host", dayotter: "Yes", them: "No", edge: "us" },
     ],
@@ -647,7 +708,8 @@ export const COMPARISONS: Comparison[] = [
   {
     slug: "clockwise",
     name: "Clockwise",
-    blurb: "Smart focus-time defense for teams - but Google/Slack-bound, and it doesn't take bookings.",
+    blurb:
+      "Smart focus-time defense for teams - but Google/Slack-bound, and it doesn't take bookings.",
     title: "DayOtter vs Clockwise",
     subtitle:
       "Clockwise optimizes a team's calendar for focus time. DayOtter protects focus too - but asks before it acts, works across every calendar, and also does booking links and team scheduling.",
@@ -672,7 +734,12 @@ export const COMPARISONS: Comparison[] = [
         edge: "us",
       },
       { label: "Booking links (let others book you)", dayotter: "Yes", them: "No", edge: "us" },
-      { label: "Team round-robin & routing", dayotter: "Weighted, built in", them: "No", edge: "us" },
+      {
+        label: "Team round-robin & routing",
+        dayotter: "Weighted, built in",
+        them: "No",
+        edge: "us",
+      },
       { label: "Running-late overflow alerts", dayotter: "Yes", them: "No", edge: "us" },
       {
         label: "Conversational AI assistant",

--- a/apps/web/lib/features.ts
+++ b/apps/web/lib/features.ts
@@ -355,6 +355,51 @@ export const FEATURES: Feature[] = [
     ],
     related: ["booking-pages", "team-scheduling", "routing-forms"],
   },
+  {
+    slug: "crm-sync",
+    label: "CRM sync",
+    blurb: "Log every booking to Salesforce or HubSpot - contact and meeting, automatically.",
+    title: "Native CRM sync",
+    subtitle:
+      "Connect Salesforce or HubSpot and every booking becomes a contact + a logged meeting - created on book, updated on reschedule, closed on cancel. No Zapier, no manual logging. (Beta.)",
+    intro: [
+      "When someone books, DayOtter finds or creates them as a contact in your CRM and logs the meeting as an activity against them - a Salesforce Event or a HubSpot meeting engagement. Reschedule a booking and the same activity moves with it; cancel it and the activity is closed. Your CRM stays an accurate record of what actually happened, without anyone typing it in.",
+      "It's a native, first-party OAuth connection - not a bridge through a third-party automation tool - so it's one click to connect and there are no API keys to paste. Currently in beta.",
+    ],
+    points: [
+      {
+        title: "Contact find-or-create",
+        body: "Guests are matched to an existing contact by email, or created if new - no duplicates in your CRM.",
+      },
+      {
+        title: "Meetings logged and kept in sync",
+        body: "Each booking is written as an activity, then updated on reschedule and closed on cancel - automatically.",
+      },
+      {
+        title: "Salesforce & HubSpot",
+        body: "Native support for both, over their official APIs. More CRMs can be added behind the same interface.",
+      },
+      {
+        title: "Free when you self-host",
+        body: "CRM sync is a Pro feature on the cloud and completely free when you run DayOtter yourself.",
+      },
+    ],
+    faq: [
+      {
+        q: "Which CRMs are supported?",
+        a: "Salesforce and HubSpot today, via native OAuth. The provider layer is pluggable, so more can follow.",
+      },
+      {
+        q: "Do I need Zapier?",
+        a: "No - it's a direct, first-party sync. Connect in settings and every booking flows through automatically.",
+      },
+      {
+        q: "Is it available now?",
+        a: "It's in beta. Self-hosters can enable it for free by setting the provider's OAuth credentials; on the cloud it's part of Pro.",
+      },
+    ],
+    related: ["routing-forms", "round-robin", "calendar-sync"],
+  },
 ];
 
 export function getFeature(slug: string): Feature | undefined {

--- a/apps/web/lib/integrations-content.ts
+++ b/apps/web/lib/integrations-content.ts
@@ -8,7 +8,7 @@
 export interface Integration {
   slug: string;
   name: string;
-  category: "Calendar" | "Video" | "Messaging" | "Payments";
+  category: "Calendar" | "Video" | "Messaging" | "Payments" | "CRM";
   blurb: string;
   subtitle: string;
   intro: string[];
@@ -258,6 +258,78 @@ export const INTEGRATIONS: Integration[] = [
       {
         q: "Do I need extra setup for Teams links?",
         a: "No - connect Microsoft 365 and choose Teams as the location; links are attached automatically.",
+      },
+    ],
+  },
+  {
+    slug: "salesforce",
+    name: "Salesforce",
+    category: "CRM",
+    blurb: "Log every booking to Salesforce as an Event on the right Contact (beta).",
+    subtitle:
+      "Connect Salesforce and DayOtter finds or creates the guest as a Contact and logs the meeting as an Event - updated on reschedule, removed on cancel.",
+    intro: [
+      "When someone books, DayOtter matches them to a Salesforce Contact by email (creating one if needed) and writes the meeting as an Event linked to that Contact. Reschedules update the same Event; cancellations remove it - so your CRM reflects reality without manual logging.",
+      "It's a native, first-party sync over the Salesforce REST API - no Zapier in the middle. Currently in beta.",
+    ],
+    points: [
+      {
+        title: "Contact find-or-create",
+        body: "Guests are matched to a Salesforce Contact by email, or created if new - no duplicates.",
+      },
+      {
+        title: "Meetings logged as Events",
+        body: "Each booking becomes a Salesforce Event on the Contact, kept in sync on reschedule and cancel.",
+      },
+      {
+        title: "Native, not a bridge",
+        body: "A direct OAuth connection over Salesforce's REST API - connect once in settings.",
+      },
+    ],
+    faq: [
+      {
+        q: "Does DayOtter create Salesforce Contacts?",
+        a: "Yes - it matches the guest to an existing Contact by email, or creates one, then logs the meeting as an Event against it.",
+      },
+      {
+        q: "Is CRM sync included?",
+        a: "It's a Pro feature on the cloud, and free when you self-host. Native Salesforce sync is currently in beta.",
+      },
+    ],
+  },
+  {
+    slug: "hubspot",
+    name: "HubSpot",
+    category: "CRM",
+    blurb: "Create the HubSpot contact and log the meeting on every booking (beta).",
+    subtitle:
+      "Connect HubSpot and DayOtter creates or matches the contact and logs the booking as a meeting engagement - kept in sync as things change.",
+    intro: [
+      "Every booking finds or creates the guest as a HubSpot contact and logs a meeting engagement associated with them. Reschedules update the same meeting; cancellations close it out - so your pipeline activity stays accurate automatically.",
+      "A native sync over HubSpot's CRM v3 API, connected with one click. Currently in beta.",
+    ],
+    points: [
+      {
+        title: "Contact create-or-match",
+        body: "Guests are matched to a HubSpot contact by email, or created - then the meeting is associated to them.",
+      },
+      {
+        title: "Meetings logged automatically",
+        body: "Each booking is written as a HubSpot meeting engagement, updated on reschedule and closed on cancel.",
+      },
+      {
+        title: "One-click OAuth",
+        body: "Connect from settings - no API keys to paste, no third-party automation tool.",
+      },
+    ],
+    faq: [
+      {
+        q: "Will bookings show up on the HubSpot contact timeline?",
+        a: "Yes - each booking is logged as a meeting engagement associated with the contact, so it appears on their timeline.",
+      },
+      {
+        q: "Do I need Zapier for this?",
+        a: "No - it's a native, first-party HubSpot sync. It's a Pro feature (free on self-host), currently in beta.",
       },
     ],
   },

--- a/apps/web/lib/personas.ts
+++ b/apps/web/lib/personas.ts
@@ -344,7 +344,7 @@ export const PERSONAS: Persona[] = [
       },
       {
         q: "Does it connect to our CRM?",
-        a: "You can push every booking to your stack today via webhooks and our API. Native Salesforce and HubSpot sync is on our roadmap.",
+        a: "Yes - native Salesforce and HubSpot sync logs every booking as a contact + activity (currently in beta), and you can also push bookings to the rest of your stack via webhooks and our API.",
       },
     ],
   },

--- a/apps/web/lib/server/env.ts
+++ b/apps/web/lib/server/env.ts
@@ -26,6 +26,12 @@ const schema = z.object({
   ZOOM_CLIENT_ID: z.string().default(""),
   ZOOM_CLIENT_SECRET: z.string().default(""),
 
+  // CRM sync (Salesforce / HubSpot) - inert until both id + secret are set.
+  SALESFORCE_CLIENT_ID: z.string().default(""),
+  SALESFORCE_CLIENT_SECRET: z.string().default(""),
+  HUBSPOT_CLIENT_ID: z.string().default(""),
+  HUBSPOT_CLIENT_SECRET: z.string().default(""),
+
   RESEND_API_KEY: z.string().optional(),
   SMTP_URL: z.string().optional(),
   EMAIL_FROM: z.string().default("DayOtter <no-reply@example.com>"),

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,5 +1,6 @@
 import { logger } from "@dayotter/core";
 import { type SyncJob, connection, scheduleMaintenance, writeHeartbeat } from "@dayotter/jobs";
+import { startCrmSyncWorker } from "./workers/crm-sync";
 import { startMaintenanceWorker } from "./workers/maintenance";
 import { startRemindersWorker } from "./workers/reminders";
 import { startSyncWorker } from "./workers/sync";
@@ -15,12 +16,14 @@ async function main(): Promise<void> {
   const sync = startSyncWorker();
   const maintenance = startMaintenanceWorker();
   const webhooks = startWebhooksWorker();
+  const crmSync = startCrmSyncWorker();
 
   const workers = [
     ["reminders", reminders],
     ["sync", sync],
     ["maintenance", maintenance],
     ["webhooks", webhooks],
+    ["crm-sync", crmSync],
   ] as const;
 
   for (const [name, worker] of workers) {

--- a/apps/worker/src/workers/crm-sync.ts
+++ b/apps/worker/src/workers/crm-sync.ts
@@ -1,0 +1,25 @@
+import { logger } from "@dayotter/core";
+import { syncBookingToCrm } from "@dayotter/integrations";
+import { type CrmSyncJob, QUEUE_NAMES, connection } from "@dayotter/jobs";
+import { Worker } from "bullmq";
+
+/**
+ * Pushes booking lifecycle changes to the host's connected CRMs (Salesforce /
+ * HubSpot). Idempotent: contacts are found-or-created, and the meeting activity
+ * is tracked per (booking, connection) so a reschedule updates and a cancel
+ * closes the same record. A failure throws so BullMQ retries with backoff.
+ */
+export function startCrmSyncWorker(): Worker<CrmSyncJob> {
+  return new Worker<CrmSyncJob>(
+    QUEUE_NAMES.crmSync,
+    async (job) => {
+      await syncBookingToCrm(job.data.bookingId, job.data.action);
+      logger.info("crm sync done", {
+        event: "crm_sync_done",
+        bookingId: job.data.bookingId,
+        action: job.data.action,
+      });
+    },
+    { connection, concurrency: 5 },
+  );
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -24,6 +24,11 @@ auto-scheduling · ✅ running-late overflow alerts · ✅ ⭐ proactive suggest
 ✅ ⭐ long-term memory · 🟡 post-meeting recap (recap nudge; transcription pending)
 
 **Insight** - ✅ booking analytics + funnel · ✅ ⭐ "where your time goes"
+(meeting/focus balance, top people, time-of-day, weekly load, back-to-back share,
+longest focus streak, external-vs-internal)
+
+**CRM** - 🟡 ⭐ native Salesforce & HubSpot sync (beta) - contact + meeting logged
+per booking, kept in sync on reschedule/cancel
 
 **Platform** - ✅ multi-channel reminders (email/Slack/WhatsApp/SMS/push) ·
 ✅ automations & workflows (unified) · ✅ daily morning briefing · ✅ API keys &
@@ -31,10 +36,12 @@ webhooks · ✅ mobile app (Expo, iOS + Android)
 
 ## Now (in progress / next up)
 
-- ⬜ **Native CRM** - Salesforce / HubSpot sync (the top parity gap with Calendly)
+- 🟡 **Native CRM (beta → GA)** - harden Salesforce / HubSpot sync, add field
+  mapping and CRM-side routing
 - 🟡 **Real Scribe** - Zoom/Meet transcription → summary + action items
 - ⬜ **Team briefings** - a shared daily digest, not just personal
-- ⬜ **Deeper time analytics** - external-vs-internal, focus streaks, reclaimed time
+- 🟡 **Deeper time analytics** - shipped back-to-back share, focus streaks,
+  external-vs-internal; next: reclaimed time, recurring load
 
 ## Next
 

--- a/packages/db/drizzle/0037_overconfident_maverick.sql
+++ b/packages/db/drizzle/0037_overconfident_maverick.sql
@@ -1,0 +1,31 @@
+CREATE TABLE "crm_connections" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"provider" text NOT NULL,
+	"external_account_id" text NOT NULL,
+	"account_label" text,
+	"credentials" text NOT NULL,
+	"status" "connection_status" DEFAULT 'active' NOT NULL,
+	"last_error" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "crm_references" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"booking_id" uuid NOT NULL,
+	"connection_id" uuid NOT NULL,
+	"provider" text NOT NULL,
+	"external_contact_id" text,
+	"external_activity_id" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "crm_connections" ADD CONSTRAINT "crm_connections_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "crm_references" ADD CONSTRAINT "crm_references_booking_id_bookings_id_fk" FOREIGN KEY ("booking_id") REFERENCES "public"."bookings"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "crm_references" ADD CONSTRAINT "crm_references_connection_id_crm_connections_id_fk" FOREIGN KEY ("connection_id") REFERENCES "public"."crm_connections"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "crm_user_provider_idx" ON "crm_connections" USING btree ("user_id","provider");--> statement-breakpoint
+CREATE INDEX "crm_user_idx" ON "crm_connections" USING btree ("user_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "crm_ref_booking_conn_idx" ON "crm_references" USING btree ("booking_id","connection_id");--> statement-breakpoint
+CREATE INDEX "crm_ref_booking_idx" ON "crm_references" USING btree ("booking_id");

--- a/packages/db/drizzle/meta/0037_snapshot.json
+++ b/packages/db/drizzle/meta/0037_snapshot.json
@@ -1,0 +1,5926 @@
+{
+  "id": "19490f51-a6f2-471c-9748-c12d5e8a4b28",
+  "prevId": "db09f5a2-3cd1-4374-92ac-410be51fe6c7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "membership_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memberships_org_user_idx": {
+          "name": "memberships_org_user_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memberships_user_idx": {
+          "name": "memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memberships_organization_id_organizations_id_fk": {
+          "name": "memberships_organization_id_organizations_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memberships_user_id_users_id_fk": {
+          "name": "memberships_user_id_users_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "plan_status": {
+          "name": "plan_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_seats": {
+          "name": "plan_seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number_verified": {
+          "name": "phone_number_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_handle_unique": {
+          "name": "users_handle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "handle"
+          ]
+        },
+        "users_phone_number_unique": {
+          "name": "users_phone_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_idx": {
+          "name": "accounts_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitations_org_idx": {
+          "name": "invitations_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitations_organization_id_organizations_id_fk": {
+          "name": "invitations_organization_id_organizations_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_inviter_id_users_id_fk": {
+          "name": "invitations_inviter_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_team_id": {
+          "name": "active_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_token_idx": {
+          "name": "sessions_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_active_organization_id_organizations_id_fk": {
+          "name": "sessions_active_organization_id_organizations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busy_blocks": {
+      "name": "busy_blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "calendar_id": {
+          "name": "calendar_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_event_id": {
+          "name": "external_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busy_blocks_calendar_idx": {
+          "name": "busy_blocks_calendar_idx",
+          "columns": [
+            {
+              "expression": "calendar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busy_blocks_range_idx": {
+          "name": "busy_blocks_range_idx",
+          "columns": [
+            {
+              "expression": "calendar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busy_blocks_calendar_event_idx": {
+          "name": "busy_blocks_calendar_event_idx",
+          "columns": [
+            {
+              "expression": "calendar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busy_blocks_calendar_id_calendars_id_fk": {
+          "name": "busy_blocks_calendar_id_calendars_id_fk",
+          "tableFrom": "busy_blocks",
+          "tableTo": "calendars",
+          "columnsFrom": [
+            "calendar_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_connections": {
+      "name": "calendar_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "calendar_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "connection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connections_user_provider_account_idx": {
+          "name": "connections_user_provider_account_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_user_idx": {
+          "name": "connections_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_connections_user_id_users_id_fk": {
+          "name": "calendar_connections_user_id_users_id_fk",
+          "tableFrom": "calendar_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_events": {
+      "name": "calendar_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "calendar_id": {
+          "name": "calendar_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_event_id": {
+          "name": "external_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "all_day": {
+          "name": "all_day",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meeting_url": {
+          "name": "meeting_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizer_email": {
+          "name": "organizer_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizer_name": {
+          "name": "organizer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attendees": {
+          "name": "attendees",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transparency": {
+          "name": "transparency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_event_id": {
+          "name": "recurring_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_events_calendar_event_idx": {
+          "name": "calendar_events_calendar_event_idx",
+          "columns": [
+            {
+              "expression": "calendar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_calendar_range_idx": {
+          "name": "calendar_events_calendar_range_idx",
+          "columns": [
+            {
+              "expression": "calendar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_series_idx": {
+          "name": "calendar_events_series_idx",
+          "columns": [
+            {
+              "expression": "recurring_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_events_calendar_id_calendars_id_fk": {
+          "name": "calendar_events_calendar_id_calendars_id_fk",
+          "tableFrom": "calendar_events",
+          "tableTo": "calendars",
+          "columnsFrom": [
+            "calendar_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendars": {
+      "name": "calendars",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "check_for_conflicts": {
+          "name": "check_for_conflicts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_target_for_bookings": {
+          "name": "is_target_for_bookings",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_read_only": {
+          "name": "is_read_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sync_token": {
+          "name": "sync_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendars_connection_external_idx": {
+          "name": "calendars_connection_external_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendars_connection_idx": {
+          "name": "calendars_connection_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendars_connection_id_calendar_connections_id_fk": {
+          "name": "calendars_connection_id_calendar_connections_id_fk",
+          "tableFrom": "calendars",
+          "tableTo": "calendar_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_subscriptions": {
+      "name": "webhook_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "calendar_id": {
+          "name": "calendar_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_subs_external_idx": {
+          "name": "webhook_subs_external_idx",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_subs_calendar_idx": {
+          "name": "webhook_subs_calendar_idx",
+          "columns": [
+            {
+              "expression": "calendar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_subs_expires_idx": {
+          "name": "webhook_subs_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_subscriptions_calendar_id_calendars_id_fk": {
+          "name": "webhook_subscriptions_calendar_id_calendars_id_fk",
+          "tableFrom": "webhook_subscriptions",
+          "tableTo": "calendars",
+          "columnsFrom": [
+            "calendar_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_rules": {
+      "name": "automation_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "match_title": {
+          "name": "match_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'booking_created'"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'prep_block'"
+        },
+        "offset_minutes": {
+          "name": "offset_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "block_title": {
+          "name": "block_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "window_end": {
+          "name": "window_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "automation_rules_user_idx": {
+          "name": "automation_rules_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_rules_user_id_users_id_fk": {
+          "name": "automation_rules_user_id_users_id_fk",
+          "tableFrom": "automation_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.availability_rules": {
+      "name": "availability_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "availability_rules_schedule_idx": {
+          "name": "availability_rules_schedule_idx",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "availability_rules_schedule_id_schedules_id_fk": {
+          "name": "availability_rules_schedule_id_schedules_id_fk",
+          "tableFrom": "availability_rules",
+          "tableTo": "schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.booking_links": {
+      "name": "booking_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type_id": {
+          "name": "event_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "used_count": {
+          "name": "used_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "booking_links_token_idx": {
+          "name": "booking_links_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "booking_links_event_idx": {
+          "name": "booking_links_event_idx",
+          "columns": [
+            {
+              "expression": "event_type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "booking_links_owner_id_users_id_fk": {
+          "name": "booking_links_owner_id_users_id_fk",
+          "tableFrom": "booking_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "booking_links_event_type_id_event_types_id_fk": {
+          "name": "booking_links_event_type_id_event_types_id_fk",
+          "tableFrom": "booking_links",
+          "tableTo": "event_types",
+          "columnsFrom": [
+            "event_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.date_overrides": {
+      "name": "date_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "date_overrides_schedule_date_idx": {
+          "name": "date_overrides_schedule_date_idx",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "date_overrides_schedule_id_schedules_id_fk": {
+          "name": "date_overrides_schedule_id_schedules_id_fk",
+          "tableFrom": "date_overrides",
+          "tableTo": "schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_types": {
+      "name": "event_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "scheduling_type": {
+          "name": "scheduling_type",
+          "type": "scheduling_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'individual'"
+        },
+        "location": {
+          "name": "location",
+          "type": "location_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'google_meet'"
+        },
+        "location_detail": {
+          "name": "location_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buffer_before_minutes": {
+          "name": "buffer_before_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "buffer_after_minutes": {
+          "name": "buffer_after_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "minimum_notice_minutes": {
+          "name": "minimum_notice_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "slot_interval_minutes": {
+          "name": "slot_interval_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minimum_gap_minutes": {
+          "name": "minimum_gap_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "booking_window_days": {
+          "name": "booking_window_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 60
+        },
+        "daily_booking_limit": {
+          "name": "daily_booking_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_booking_limit": {
+          "name": "weekly_booking_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_attendees": {
+          "name": "max_attendees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "recurring_count": {
+          "name": "recurring_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "recurring_frequency": {
+          "name": "recurring_frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'weekly'"
+        },
+        "access_code_hash": {
+          "name": "access_code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_options": {
+          "name": "duration_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deposit_amount": {
+          "name": "deposit_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_private": {
+          "name": "is_private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_types_owner_slug_idx": {
+          "name": "event_types_owner_slug_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_types_org_idx": {
+          "name": "event_types_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_types_organization_id_organizations_id_fk": {
+          "name": "event_types_organization_id_organizations_id_fk",
+          "tableFrom": "event_types",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_types_owner_id_users_id_fk": {
+          "name": "event_types_owner_id_users_id_fk",
+          "tableFrom": "event_types",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_types_schedule_id_schedules_id_fk": {
+          "name": "event_types_schedule_id_schedules_id_fk",
+          "tableFrom": "event_types",
+          "tableTo": "schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedules": {
+      "name": "schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Working hours'"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "schedules_user_idx": {
+          "name": "schedules_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedules_user_id_users_id_fk": {
+          "name": "schedules_user_id_users_id_fk",
+          "tableFrom": "schedules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.time_blocks": {
+      "name": "time_blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'focus'"
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "time_blocks_user_idx": {
+          "name": "time_blocks_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "time_blocks_booking_idx": {
+          "name": "time_blocks_booking_idx",
+          "columns": [
+            {
+              "expression": "booking_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "time_blocks_series_idx": {
+          "name": "time_blocks_series_idx",
+          "columns": [
+            {
+              "expression": "series_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "time_blocks_user_id_users_id_fk": {
+          "name": "time_blocks_user_id_users_id_fk",
+          "tableFrom": "time_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.booking_attendees": {
+      "name": "booking_attendees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "booking_attendees_booking_idx": {
+          "name": "booking_attendees_booking_idx",
+          "columns": [
+            {
+              "expression": "booking_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "booking_attendees_booking_id_bookings_id_fk": {
+          "name": "booking_attendees_booking_id_bookings_id_fk",
+          "tableFrom": "booking_attendees",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.booking_references": {
+      "name": "booking_references",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendar_id": {
+          "name": "calendar_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "calendar_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_event_id": {
+          "name": "external_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "booking_refs_provider_event_idx": {
+          "name": "booking_refs_provider_event_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "booking_refs_booking_idx": {
+          "name": "booking_refs_booking_idx",
+          "columns": [
+            {
+              "expression": "booking_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "booking_references_booking_id_bookings_id_fk": {
+          "name": "booking_references_booking_id_bookings_id_fk",
+          "tableFrom": "booking_references",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "booking_references_calendar_id_calendars_id_fk": {
+          "name": "booking_references_calendar_id_calendars_id_fk",
+          "tableFrom": "booking_references",
+          "tableTo": "calendars",
+          "columnsFrom": [
+            "calendar_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookings": {
+      "name": "bookings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type_id": {
+          "name": "event_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "booking_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'confirmed'"
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meeting_url": {
+          "name": "meeting_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responses": {
+          "name": "responses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uid": {
+          "name": "uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recurrence_uid": {
+          "name": "recurrence_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_group": {
+          "name": "is_group",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_reason": {
+          "name": "cancel_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "payment_intent_id": {
+          "name": "payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_currency": {
+          "name": "payment_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookings_uid_idx": {
+          "name": "bookings_uid_idx",
+          "columns": [
+            {
+              "expression": "uid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookings_host_idx": {
+          "name": "bookings_host_idx",
+          "columns": [
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookings_org_idx": {
+          "name": "bookings_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookings_starts_idx": {
+          "name": "bookings_starts_idx",
+          "columns": [
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookings_host_slot_active_idx": {
+          "name": "bookings_host_slot_active_idx",
+          "columns": [
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"bookings\".\"status\" = 'confirmed' AND \"bookings\".\"is_group\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookings_organization_id_organizations_id_fk": {
+          "name": "bookings_organization_id_organizations_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookings_event_type_id_event_types_id_fk": {
+          "name": "bookings_event_type_id_event_types_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "event_types",
+          "columnsFrom": [
+            "event_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "bookings_host_id_users_id_fk": {
+          "name": "bookings_host_id_users_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_type_hosts": {
+      "name": "event_type_hosts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_type_id": {
+          "name": "event_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_type_hosts_idx": {
+          "name": "event_type_hosts_idx",
+          "columns": [
+            {
+              "expression": "event_type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_type_hosts_event_type_id_event_types_id_fk": {
+          "name": "event_type_hosts_event_type_id_event_types_id_fk",
+          "tableFrom": "event_type_hosts",
+          "tableTo": "event_types",
+          "columnsFrom": [
+            "event_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_type_hosts_user_id_users_id_fk": {
+          "name": "event_type_hosts_user_id_users_id_fk",
+          "tableFrom": "event_type_hosts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "membership_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_members_team_user_idx": {
+          "name": "team_members_team_user_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_members_user_idx": {
+          "name": "team_members_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_rules": {
+      "name": "team_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "the_date": {
+          "name": "the_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_minute": {
+          "name": "start_minute",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_minute": {
+          "name": "end_minute",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_rules_team_idx": {
+          "name": "team_rules_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_rules_team_id_teams_id_fk": {
+          "name": "team_rules_team_id_teams_id_fk",
+          "tableFrom": "team_rules",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "teams_org_slug_idx": {
+          "name": "teams_org_slug_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "teams_organization_id_organizations_id_fk": {
+          "name": "teams_organization_id_organizations_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scheduled_reminders": {
+      "name": "scheduled_reminders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reminder'"
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scheduled_reminders_booking_idx": {
+          "name": "scheduled_reminders_booking_idx",
+          "columns": [
+            {
+              "expression": "booking_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scheduled_reminders_due_idx": {
+          "name": "scheduled_reminders_due_idx",
+          "columns": [
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scheduled_reminders_booking_id_bookings_id_fk": {
+          "name": "scheduled_reminders_booking_id_bookings_id_fk",
+          "tableFrom": "scheduled_reminders",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scheduled_reminders_workflow_id_workflows_id_fk": {
+          "name": "scheduled_reminders_workflow_id_workflows_id_fk",
+          "tableFrom": "scheduled_reminders",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_event_types": {
+      "name": "workflow_event_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type_id": {
+          "name": "event_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflow_event_types_workflow_idx": {
+          "name": "workflow_event_types_workflow_idx",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_event_types_workflow_id_workflows_id_fk": {
+          "name": "workflow_event_types_workflow_id_workflows_id_fk",
+          "tableFrom": "workflow_event_types",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_event_types_event_type_id_event_types_id_fk": {
+          "name": "workflow_event_types_event_type_id_event_types_id_fk",
+          "tableFrom": "workflow_event_types",
+          "tableTo": "event_types",
+          "columnsFrom": [
+            "event_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows": {
+      "name": "workflows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "workflow_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "offset_minutes": {
+          "name": "offset_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "action": {
+          "name": "action",
+          "type": "workflow_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'email'"
+        },
+        "subject_template": {
+          "name": "subject_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_template": {
+          "name": "body_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflows_org_idx": {
+          "name": "workflows_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_organization_id_organizations_id_fk": {
+          "name": "workflows_organization_id_organizations_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_channels": {
+      "name": "notification_channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_channel_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_config": {
+          "name": "encrypted_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reminders_enabled": {
+          "name": "reminders_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_channels_user_idx": {
+          "name": "notification_channels_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_channels_user_id_users_id_fk": {
+          "name": "notification_channels_user_id_users_id_fk",
+          "tableFrom": "notification_channels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "time_format": {
+          "name": "time_format",
+          "type": "time_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'12h'"
+        },
+        "week_starts_on": {
+          "name": "week_starts_on",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "theme": {
+          "name": "theme",
+          "type": "theme_pref",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "default_reminder_offsets": {
+          "name": "default_reminder_offsets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[1440,60]'::jsonb"
+        },
+        "overflow_notify_enabled": {
+          "name": "overflow_notify_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "briefing_enabled": {
+          "name": "briefing_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "briefing_hour": {
+          "name": "briefing_hour",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 8
+        },
+        "briefing_last_sent": {
+          "name": "briefing_last_sent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scribe_enabled": {
+          "name": "scribe_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "adaptive_availability": {
+          "name": "adaptive_availability",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "max_meetings_per_day": {
+          "name": "max_meetings_per_day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "travel_buffer_minutes": {
+          "name": "travel_buffer_minutes",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reclaim_cancelled_time": {
+          "name": "reclaim_cancelled_time",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lunch_enabled": {
+          "name": "lunch_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lunch_start_minute": {
+          "name": "lunch_start_minute",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 720
+        },
+        "lunch_end_minute": {
+          "name": "lunch_end_minute",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 780
+        },
+        "brand_color": {
+          "name": "brand_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "welcome_message": {
+          "name": "welcome_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_data": {
+          "name": "encrypted_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_preferences_user_idx": {
+          "name": "user_preferences_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.booking_page_views": {
+      "name": "booking_page_views",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_type_id": {
+          "name": "event_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visitor_id": {
+          "name": "visitor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'view'"
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "booking_page_views_type_idx": {
+          "name": "booking_page_views_type_idx",
+          "columns": [
+            {
+              "expression": "event_type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "viewed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "booking_page_views_event_type_id_event_types_id_fk": {
+          "name": "booking_page_views_event_type_id_event_types_id_fk",
+          "tableFrom": "booking_page_views",
+          "tableTo": "event_types",
+          "columnsFrom": [
+            "event_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_user_idx": {
+          "name": "api_keys_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_endpoint_idx": {
+          "name": "webhook_deliveries_endpoint_idx",
+          "columns": [
+            {
+              "expression": "endpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_endpoint_id_webhook_endpoints_id_fk": {
+          "name": "webhook_deliveries_endpoint_id_webhook_endpoints_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhook_endpoints",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_endpoints": {
+      "name": "webhook_endpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_encrypted": {
+          "name": "secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"*\"]'::jsonb"
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_endpoints_user_idx": {
+          "name": "webhook_endpoints_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_endpoints_user_id_users_id_fk": {
+          "name": "webhook_endpoints_user_id_users_id_fk",
+          "tableFrom": "webhook_endpoints",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conferencing_connections": {
+      "name": "conferencing_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'zoom'"
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "connection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conferencing_user_provider_idx": {
+          "name": "conferencing_user_provider_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conferencing_user_idx": {
+          "name": "conferencing_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conferencing_connections_user_id_users_id_fk": {
+          "name": "conferencing_connections_user_id_users_id_fk",
+          "tableFrom": "conferencing_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meeting_polls": {
+      "name": "meeting_polls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'30'"
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "finalized_option_id": {
+          "name": "finalized_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meeting_polls_token_idx": {
+          "name": "meeting_polls_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meeting_polls_host_idx": {
+          "name": "meeting_polls_host_idx",
+          "columns": [
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meeting_polls_host_id_users_id_fk": {
+          "name": "meeting_polls_host_id_users_id_fk",
+          "tableFrom": "meeting_polls",
+          "tableTo": "users",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.poll_options": {
+      "name": "poll_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "poll_id": {
+          "name": "poll_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "poll_options_poll_idx": {
+          "name": "poll_options_poll_idx",
+          "columns": [
+            {
+              "expression": "poll_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "poll_options_poll_id_meeting_polls_id_fk": {
+          "name": "poll_options_poll_id_meeting_polls_id_fk",
+          "tableFrom": "poll_options",
+          "tableTo": "meeting_polls",
+          "columnsFrom": [
+            "poll_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.poll_votes": {
+      "name": "poll_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "poll_id": {
+          "name": "poll_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_name": {
+          "name": "voter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_email": {
+          "name": "voter_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "poll_votes_option_voter_idx": {
+          "name": "poll_votes_option_voter_idx",
+          "columns": [
+            {
+              "expression": "option_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "voter_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "poll_votes_poll_idx": {
+          "name": "poll_votes_poll_idx",
+          "columns": [
+            {
+              "expression": "poll_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "poll_votes_poll_id_meeting_polls_id_fk": {
+          "name": "poll_votes_poll_id_meeting_polls_id_fk",
+          "tableFrom": "poll_votes",
+          "tableTo": "meeting_polls",
+          "columnsFrom": [
+            "poll_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "poll_votes_option_id_poll_options_id_fk": {
+          "name": "poll_votes_option_id_poll_options_id_fk",
+          "tableFrom": "poll_votes",
+          "tableTo": "poll_options",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routing_form_responses": {
+      "name": "routing_form_responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answers": {
+          "name": "answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "routed_event_type_id": {
+          "name": "routed_event_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "routing_form_responses_form_idx": {
+          "name": "routing_form_responses_form_idx",
+          "columns": [
+            {
+              "expression": "form_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routing_form_responses_form_id_routing_forms_id_fk": {
+          "name": "routing_form_responses_form_id_routing_forms_id_fk",
+          "tableFrom": "routing_form_responses",
+          "tableTo": "routing_forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routing_forms": {
+      "name": "routing_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "fields": {
+          "name": "fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "routes": {
+          "name": "routes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "fallback_event_type_id": {
+          "name": "fallback_event_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "routing_forms_token_idx": {
+          "name": "routing_forms_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "routing_forms_host_idx": {
+          "name": "routing_forms_host_idx",
+          "columns": [
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routing_forms_host_id_users_id_fk": {
+          "name": "routing_forms_host_id_users_id_fk",
+          "tableFrom": "routing_forms",
+          "tableTo": "users",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.package_credits": {
+      "name": "package_credits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type_id": {
+          "name": "event_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_email": {
+          "name": "client_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_credits": {
+          "name": "total_credits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_credits": {
+          "name": "used_credits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "package_credits_lookup_idx": {
+          "name": "package_credits_lookup_idx",
+          "columns": [
+            {
+              "expression": "event_type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "package_credits_pi_idx": {
+          "name": "package_credits_pi_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "package_credits_package_id_session_packages_id_fk": {
+          "name": "package_credits_package_id_session_packages_id_fk",
+          "tableFrom": "package_credits",
+          "tableTo": "session_packages",
+          "columnsFrom": [
+            "package_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "package_credits_organization_id_organizations_id_fk": {
+          "name": "package_credits_organization_id_organizations_id_fk",
+          "tableFrom": "package_credits",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "package_credits_event_type_id_event_types_id_fk": {
+          "name": "package_credits_event_type_id_event_types_id_fk",
+          "tableFrom": "package_credits",
+          "tableTo": "event_types",
+          "columnsFrom": [
+            "event_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_packages": {
+      "name": "session_packages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type_id": {
+          "name": "event_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_amount": {
+          "name": "price_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_packages_event_type_idx": {
+          "name": "session_packages_event_type_idx",
+          "columns": [
+            {
+              "expression": "event_type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_packages_organization_id_organizations_id_fk": {
+          "name": "session_packages_organization_id_organizations_id_fk",
+          "tableFrom": "session_packages",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_packages_event_type_id_event_types_id_fk": {
+          "name": "session_packages_event_type_id_event_types_id_fk",
+          "tableFrom": "session_packages",
+          "tableTo": "event_types",
+          "columnsFrom": [
+            "event_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.otter_memory": {
+      "name": "otter_memory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pattern'"
+        },
+        "memory_key": {
+          "name": "memory_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.5
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'derived'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "otter_memory_user_key_idx": {
+          "name": "otter_memory_user_key_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memory_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "otter_memory_user_id_users_id_fk": {
+          "name": "otter_memory_user_id_users_id_fk",
+          "tableFrom": "otter_memory",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crm_connections": {
+      "name": "crm_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_label": {
+          "name": "account_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "connection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crm_user_provider_idx": {
+          "name": "crm_user_provider_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crm_user_idx": {
+          "name": "crm_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crm_connections_user_id_users_id_fk": {
+          "name": "crm_connections_user_id_users_id_fk",
+          "tableFrom": "crm_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crm_references": {
+      "name": "crm_references",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_contact_id": {
+          "name": "external_contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_activity_id": {
+          "name": "external_activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crm_ref_booking_conn_idx": {
+          "name": "crm_ref_booking_conn_idx",
+          "columns": [
+            {
+              "expression": "booking_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crm_ref_booking_idx": {
+          "name": "crm_ref_booking_idx",
+          "columns": [
+            {
+              "expression": "booking_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crm_references_booking_id_bookings_id_fk": {
+          "name": "crm_references_booking_id_bookings_id_fk",
+          "tableFrom": "crm_references",
+          "tableTo": "bookings",
+          "columnsFrom": [
+            "booking_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crm_references_connection_id_crm_connections_id_fk": {
+          "name": "crm_references_connection_id_crm_connections_id_fk",
+          "tableFrom": "crm_references",
+          "tableTo": "crm_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.booking_status": {
+      "name": "booking_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "confirmed",
+        "cancelled",
+        "rejected",
+        "no_show",
+        "completed"
+      ]
+    },
+    "public.calendar_provider": {
+      "name": "calendar_provider",
+      "schema": "public",
+      "values": [
+        "google",
+        "microsoft",
+        "apple",
+        "ics"
+      ]
+    },
+    "public.connection_status": {
+      "name": "connection_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "error",
+        "revoked"
+      ]
+    },
+    "public.location_type": {
+      "name": "location_type",
+      "schema": "public",
+      "values": [
+        "google_meet",
+        "zoom",
+        "ms_teams",
+        "phone",
+        "in_person",
+        "custom"
+      ]
+    },
+    "public.membership_role": {
+      "name": "membership_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "member"
+      ]
+    },
+    "public.notification_channel_type": {
+      "name": "notification_channel_type",
+      "schema": "public",
+      "values": [
+        "email",
+        "sms",
+        "push",
+        "webpush",
+        "whatsapp",
+        "slack"
+      ]
+    },
+    "public.payment_status": {
+      "name": "payment_status",
+      "schema": "public",
+      "values": [
+        "none",
+        "pending",
+        "paid",
+        "refunded"
+      ]
+    },
+    "public.scheduling_type": {
+      "name": "scheduling_type",
+      "schema": "public",
+      "values": [
+        "individual",
+        "collective",
+        "round_robin"
+      ]
+    },
+    "public.theme_pref": {
+      "name": "theme_pref",
+      "schema": "public",
+      "values": [
+        "system",
+        "light",
+        "dark"
+      ]
+    },
+    "public.time_format": {
+      "name": "time_format",
+      "schema": "public",
+      "values": [
+        "12h",
+        "24h"
+      ]
+    },
+    "public.workflow_action": {
+      "name": "workflow_action",
+      "schema": "public",
+      "values": [
+        "email",
+        "sms"
+      ]
+    },
+    "public.workflow_trigger": {
+      "name": "workflow_trigger",
+      "schema": "public",
+      "values": [
+        "before_event",
+        "after_event",
+        "on_booking",
+        "on_cancel",
+        "on_reschedule"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1784011754933,
       "tag": "0036_faithful_the_spike",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1784031823094,
+      "tag": "0037_overconfident_maverick",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/crm.ts
+++ b/packages/db/src/schema/crm.ts
@@ -1,0 +1,77 @@
+import { relations } from "drizzle-orm";
+import { index, pgTable, text, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { connectionStatus, timestamps } from "./_shared";
+import { bookings } from "./booking";
+import { users } from "./orgs";
+
+/**
+ * A connected CRM account (Salesforce / HubSpot). Like `conferencing_connections`,
+ * `provider` is plain text (no enum migration to add another CRM), and
+ * `credentials` is an AES-256-GCM-encrypted JSON blob of the OAuth tokens.
+ * When a booking is created/rescheduled/cancelled, the worker pushes a contact +
+ * meeting activity to every active connection the host holds.
+ */
+export const crmConnections = pgTable(
+  "crm_connections",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    /** "salesforce" | "hubspot" (plain text - new CRMs need no enum migration). */
+    provider: text("provider").notNull(),
+    /** The connected account/portal id (HubSpot hub id, Salesforce org id). */
+    externalAccountId: text("external_account_id").notNull(),
+    /** Human label for the settings UI (portal domain / instance URL). */
+    accountLabel: text("account_label"),
+    credentials: text("credentials").notNull(),
+    status: connectionStatus("status").notNull().default("active"),
+    lastError: text("last_error"),
+    ...timestamps,
+  },
+  (t) => [
+    uniqueIndex("crm_user_provider_idx").on(t.userId, t.provider),
+    index("crm_user_idx").on(t.userId),
+  ],
+);
+
+/**
+ * Links a booking to the records we created in a CRM connection, so a reschedule
+ * updates (rather than duplicates) the same activity and a cancel closes it.
+ * One row per (booking, connection).
+ */
+export const crmReferences = pgTable(
+  "crm_references",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    bookingId: uuid("booking_id")
+      .notNull()
+      .references(() => bookings.id, { onDelete: "cascade" }),
+    connectionId: uuid("connection_id")
+      .notNull()
+      .references(() => crmConnections.id, { onDelete: "cascade" }),
+    provider: text("provider").notNull(),
+    /** External contact id created/matched for the attendee. */
+    externalContactId: text("external_contact_id"),
+    /** External activity id (HubSpot meeting / Salesforce Event) for the booking. */
+    externalActivityId: text("external_activity_id"),
+    ...timestamps,
+  },
+  (t) => [
+    uniqueIndex("crm_ref_booking_conn_idx").on(t.bookingId, t.connectionId),
+    index("crm_ref_booking_idx").on(t.bookingId),
+  ],
+);
+
+export const crmConnectionsRelations = relations(crmConnections, ({ one, many }) => ({
+  user: one(users, { fields: [crmConnections.userId], references: [users.id] }),
+  references: many(crmReferences),
+}));
+
+export const crmReferencesRelations = relations(crmReferences, ({ one }) => ({
+  booking: one(bookings, { fields: [crmReferences.bookingId], references: [bookings.id] }),
+  connection: one(crmConnections, {
+    fields: [crmReferences.connectionId],
+    references: [crmConnections.id],
+  }),
+}));

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -14,3 +14,4 @@ export * from "./poll";
 export * from "./routing";
 export * from "./packages";
 export * from "./memory";
+export * from "./crm";

--- a/packages/integrations/src/crm/hubspot.ts
+++ b/packages/integrations/src/crm/hubspot.ts
@@ -1,0 +1,222 @@
+import {
+  type CrmAccount,
+  type CrmAdapter,
+  CrmApiError,
+  type CrmContactInput,
+  type CrmCredentials,
+  type CrmMeetingInput,
+} from "./types";
+
+/**
+ * HubSpot CRM integration. Env-gated on HUBSPOT_CLIENT_ID/SECRET. Tokens are
+ * OAuth (authorization-code), stored encrypted per connection. Uses the CRM v3
+ * objects API for contacts + meetings. HubSpot datetime properties are epoch ms.
+ */
+
+const AUTHORIZE_URL = "https://app.hubspot.com/oauth/authorize";
+const TOKEN_URL = "https://api.hubapi.com/oauth/v1/token";
+const API = "https://api.hubapi.com";
+
+// Scopes: read/write CRM objects (contacts) and schedule/meetings.
+const SCOPES = ["crm.objects.contacts.read", "crm.objects.contacts.write"];
+
+// Meeting → Contact default association (HUBSPOT_DEFINED).
+const MEETING_TO_CONTACT_TYPE_ID = 200;
+
+function clientId(): string {
+  return process.env.HUBSPOT_CLIENT_ID ?? "";
+}
+function clientSecret(): string {
+  return process.env.HUBSPOT_CLIENT_SECRET ?? "";
+}
+function redirectUri(): string {
+  const appUrl = process.env.APP_URL ?? "http://localhost:3000";
+  return `${appUrl}/api/integrations/crm/hubspot/callback`;
+}
+
+export function hubspotEnabled(): boolean {
+  return Boolean(clientId() && clientSecret());
+}
+
+export function hubspotAuthUrl(state: string): string {
+  const params = new URLSearchParams({
+    client_id: clientId(),
+    redirect_uri: redirectUri(),
+    scope: SCOPES.join(" "),
+    state,
+  });
+  return `${AUTHORIZE_URL}?${params.toString()}`;
+}
+
+function toCreds(token: {
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+}): CrmCredentials {
+  return {
+    accessToken: token.access_token,
+    refreshToken: token.refresh_token,
+    // Refresh a minute early to avoid edge-of-expiry failures.
+    expiresAt: Date.now() + (token.expires_in - 60) * 1000,
+  };
+}
+
+async function tokenRequest(body: Record<string, string>): Promise<CrmCredentials> {
+  const res = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams(body).toString(),
+  });
+  if (!res.ok) {
+    throw new CrmApiError("hubspot", res.status, `token exchange failed: ${await res.text()}`);
+  }
+  return toCreds(
+    (await res.json()) as { access_token: string; refresh_token?: string; expires_in: number },
+  );
+}
+
+/** Exchange an authorization code for tokens + the connected portal identity. */
+export async function exchangeHubspotCode(
+  code: string,
+): Promise<{ credentials: CrmCredentials; account: CrmAccount }> {
+  const credentials = await tokenRequest({
+    grant_type: "authorization_code",
+    client_id: clientId(),
+    client_secret: clientSecret(),
+    redirect_uri: redirectUri(),
+    code,
+  });
+  const info = await fetch(`${API}/oauth/v1/access-tokens/${credentials.accessToken}`);
+  let account: CrmAccount = { externalAccountId: "hubspot", label: null };
+  if (info.ok) {
+    const data = (await info.json()) as { hub_id?: number; hub_domain?: string };
+    account = {
+      externalAccountId: data.hub_id ? String(data.hub_id) : "hubspot",
+      label: data.hub_domain ?? null,
+    };
+  }
+  return { credentials, account };
+}
+
+export class HubspotAdapter implements CrmAdapter {
+  provider = "hubspot" as const;
+
+  constructor(
+    private creds: CrmCredentials,
+    private persist: (next: CrmCredentials) => Promise<void>,
+  ) {}
+
+  private async token(): Promise<string> {
+    if (this.creds.expiresAt && this.creds.expiresAt < Date.now() && this.creds.refreshToken) {
+      this.creds = await tokenRequest({
+        grant_type: "refresh_token",
+        client_id: clientId(),
+        client_secret: clientSecret(),
+        refresh_token: this.creds.refreshToken,
+      });
+      await this.persist(this.creds);
+    }
+    return this.creds.accessToken;
+  }
+
+  private async api<T>(path: string, init: RequestInit): Promise<T> {
+    const res = await fetch(`${API}${path}`, {
+      ...init,
+      headers: {
+        authorization: `Bearer ${await this.token()}`,
+        "content-type": "application/json",
+        ...(init.headers ?? {}),
+      },
+    });
+    if (!res.ok) {
+      throw new CrmApiError("hubspot", res.status, await res.text());
+    }
+    return (res.status === 204 ? undefined : await res.json()) as T;
+  }
+
+  async upsertContact(input: CrmContactInput): Promise<string> {
+    // Find by email first so we never create a duplicate.
+    const search = await this.api<{ results?: { id: string }[] }>(
+      "/crm/v3/objects/contacts/search",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          filterGroups: [
+            { filters: [{ propertyName: "email", operator: "EQ", value: input.email }] },
+          ],
+          properties: ["email"],
+          limit: 1,
+        }),
+      },
+    );
+    const existing = search.results?.[0]?.id;
+    if (existing) return existing;
+
+    const { first, last } = splitName(input);
+    const created = await this.api<{ id: string }>("/crm/v3/objects/contacts", {
+      method: "POST",
+      body: JSON.stringify({
+        properties: { email: input.email, firstname: first, lastname: last },
+      }),
+    });
+    return created.id;
+  }
+
+  async logMeeting(input: CrmMeetingInput): Promise<string> {
+    const created = await this.api<{ id: string }>("/crm/v3/objects/meetings", {
+      method: "POST",
+      body: JSON.stringify({
+        properties: meetingProps(input, "SCHEDULED"),
+        associations: [
+          {
+            to: { id: input.contactExternalId },
+            types: [
+              {
+                associationCategory: "HUBSPOT_DEFINED",
+                associationTypeId: MEETING_TO_CONTACT_TYPE_ID,
+              },
+            ],
+          },
+        ],
+      }),
+    });
+    return created.id;
+  }
+
+  async updateMeeting(externalActivityId: string, input: CrmMeetingInput): Promise<void> {
+    await this.api(`/crm/v3/objects/meetings/${externalActivityId}`, {
+      method: "PATCH",
+      body: JSON.stringify({ properties: meetingProps(input, "RESCHEDULED") }),
+    });
+  }
+
+  async cancelMeeting(externalActivityId: string): Promise<void> {
+    await this.api(`/crm/v3/objects/meetings/${externalActivityId}`, {
+      method: "PATCH",
+      body: JSON.stringify({ properties: { hs_meeting_outcome: "CANCELED" } }),
+    });
+  }
+}
+
+function meetingProps(input: CrmMeetingInput, _outcome: string): Record<string, string> {
+  const start = input.startsAt.getTime();
+  const end = input.endsAt.getTime();
+  return {
+    hs_timestamp: String(start),
+    hs_meeting_title: input.title,
+    hs_meeting_body: input.description ?? "",
+    hs_meeting_location: input.location ?? "",
+    hs_meeting_start_time: String(start),
+    hs_meeting_end_time: String(end),
+  };
+}
+
+function splitName(input: CrmContactInput): { first: string; last: string } {
+  if (input.firstName || input.lastName) {
+    return { first: input.firstName ?? "", last: input.lastName ?? "" };
+  }
+  const parts = (input.name ?? "").trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return { first: "", last: "" };
+  if (parts.length === 1) return { first: parts[0] ?? "", last: "" };
+  return { first: parts[0] ?? "", last: parts.slice(1).join(" ") };
+}

--- a/packages/integrations/src/crm/salesforce.ts
+++ b/packages/integrations/src/crm/salesforce.ts
@@ -1,0 +1,219 @@
+import {
+  type CrmAccount,
+  type CrmAdapter,
+  CrmApiError,
+  type CrmContactInput,
+  type CrmCredentials,
+  type CrmMeetingInput,
+} from "./types";
+
+/**
+ * Salesforce CRM integration. Env-gated on SALESFORCE_CLIENT_ID/SECRET. OAuth
+ * authorization-code flow; the token response carries the org's `instance_url`
+ * (all REST calls target it) and a `refresh_token`. Salesforce access tokens
+ * have no fixed lifetime, so we refresh reactively on a 401 and retry once.
+ * Uses the REST API: Contact (find-or-create by email) + Event (the meeting).
+ */
+
+const LOGIN = "https://login.salesforce.com";
+const API_VERSION = "v59.0";
+const SCOPES = ["api", "refresh_token"];
+
+function clientId(): string {
+  return process.env.SALESFORCE_CLIENT_ID ?? "";
+}
+function clientSecret(): string {
+  return process.env.SALESFORCE_CLIENT_SECRET ?? "";
+}
+function redirectUri(): string {
+  const appUrl = process.env.APP_URL ?? "http://localhost:3000";
+  return `${appUrl}/api/integrations/crm/salesforce/callback`;
+}
+
+export function salesforceEnabled(): boolean {
+  return Boolean(clientId() && clientSecret());
+}
+
+export function salesforceAuthUrl(state: string): string {
+  const params = new URLSearchParams({
+    response_type: "code",
+    client_id: clientId(),
+    redirect_uri: redirectUri(),
+    scope: SCOPES.join(" "),
+    state,
+  });
+  return `${LOGIN}/services/oauth2/authorize?${params.toString()}`;
+}
+
+interface SfTokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  instance_url: string;
+  /** URL of the identity resource: .../id/{orgId}/{userId}. */
+  id?: string;
+  scope?: string;
+}
+
+function toCreds(t: SfTokenResponse, keepRefresh?: string): CrmCredentials {
+  return {
+    accessToken: t.access_token,
+    refreshToken: t.refresh_token ?? keepRefresh,
+    instanceUrl: t.instance_url,
+    scope: t.scope,
+  };
+}
+
+async function tokenRequest(body: Record<string, string>): Promise<SfTokenResponse> {
+  const res = await fetch(`${LOGIN}/services/oauth2/token`, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams(body).toString(),
+  });
+  if (!res.ok) {
+    throw new CrmApiError("salesforce", res.status, `token exchange failed: ${await res.text()}`);
+  }
+  return (await res.json()) as SfTokenResponse;
+}
+
+/** Exchange an authorization code for tokens + the org identity. */
+export async function exchangeSalesforceCode(
+  code: string,
+): Promise<{ credentials: CrmCredentials; account: CrmAccount }> {
+  const token = await tokenRequest({
+    grant_type: "authorization_code",
+    client_id: clientId(),
+    client_secret: clientSecret(),
+    redirect_uri: redirectUri(),
+    code,
+  });
+  // The identity URL is .../id/{orgId}/{userId}; the org id makes a stable key.
+  const orgId = token.id?.split("/").slice(-2, -1)[0];
+  return {
+    credentials: toCreds(token),
+    account: {
+      externalAccountId: orgId ?? token.instance_url,
+      label: token.instance_url.replace(/^https?:\/\//, ""),
+    },
+  };
+}
+
+/** Escape a value for safe inclusion in a SOQL string literal. */
+function soqlEscape(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+}
+
+/** Salesforce datetime is ISO-8601 with an offset; toISOString() (UTC "Z") is valid. */
+function sfDate(d: Date): string {
+  return d.toISOString();
+}
+
+export class SalesforceAdapter implements CrmAdapter {
+  provider = "salesforce" as const;
+
+  constructor(
+    private creds: CrmCredentials,
+    private persist: (next: CrmCredentials) => Promise<void>,
+  ) {}
+
+  private base(): string {
+    const instance = this.creds.instanceUrl;
+    if (!instance) throw new CrmApiError("salesforce", 400, "missing instance URL");
+    return `${instance}/services/data/${API_VERSION}`;
+  }
+
+  private async refresh(): Promise<void> {
+    if (!this.creds.refreshToken) {
+      throw new CrmApiError("salesforce", 401, "access token expired and no refresh token");
+    }
+    const token = await tokenRequest({
+      grant_type: "refresh_token",
+      client_id: clientId(),
+      client_secret: clientSecret(),
+      refresh_token: this.creds.refreshToken,
+    });
+    this.creds = toCreds(token, this.creds.refreshToken);
+    await this.persist(this.creds);
+  }
+
+  /** Fetch with a one-shot reactive refresh on 401 (expired session). */
+  private async api<T>(path: string, init: RequestInit, retry = true): Promise<T> {
+    const res = await fetch(`${this.base()}${path}`, {
+      ...init,
+      headers: {
+        authorization: `Bearer ${this.creds.accessToken}`,
+        "content-type": "application/json",
+        ...(init.headers ?? {}),
+      },
+    });
+    if (res.status === 401 && retry) {
+      await this.refresh();
+      return this.api<T>(path, init, false);
+    }
+    if (!res.ok) {
+      throw new CrmApiError("salesforce", res.status, await res.text());
+    }
+    return (res.status === 204 ? undefined : await res.json()) as T;
+  }
+
+  async upsertContact(input: CrmContactInput): Promise<string> {
+    const q = `SELECT Id FROM Contact WHERE Email = '${soqlEscape(input.email)}' LIMIT 1`;
+    const found = await this.api<{ records?: { Id: string }[] }>(
+      `/query/?q=${encodeURIComponent(q)}`,
+      { method: "GET" },
+    );
+    const existing = found.records?.[0]?.Id;
+    if (existing) return existing;
+
+    const { first, last } = splitName(input);
+    const created = await this.api<{ id: string }>("/sobjects/Contact", {
+      method: "POST",
+      // LastName is required on Contact; fall back to the email local-part.
+      body: JSON.stringify({
+        FirstName: first || undefined,
+        LastName: last || input.email.split("@")[0] || "Unknown",
+        Email: input.email,
+      }),
+    });
+    return created.id;
+  }
+
+  async logMeeting(input: CrmMeetingInput): Promise<string> {
+    const created = await this.api<{ id: string }>("/sobjects/Event", {
+      method: "POST",
+      body: JSON.stringify({
+        Subject: input.title,
+        StartDateTime: sfDate(input.startsAt),
+        EndDateTime: sfDate(input.endsAt),
+        Description: input.description ?? "",
+        Location: input.location ?? "",
+        WhoId: input.contactExternalId,
+      }),
+    });
+    return created.id;
+  }
+
+  async updateMeeting(externalActivityId: string, input: CrmMeetingInput): Promise<void> {
+    await this.api(`/sobjects/Event/${externalActivityId}`, {
+      method: "PATCH",
+      body: JSON.stringify({
+        StartDateTime: sfDate(input.startsAt),
+        EndDateTime: sfDate(input.endsAt),
+      }),
+    });
+  }
+
+  async cancelMeeting(externalActivityId: string): Promise<void> {
+    // Salesforce Events have no cancelled state; remove the activity.
+    await this.api(`/sobjects/Event/${externalActivityId}`, { method: "DELETE" });
+  }
+}
+
+function splitName(input: CrmContactInput): { first: string; last: string } {
+  if (input.firstName || input.lastName) {
+    return { first: input.firstName ?? "", last: input.lastName ?? "" };
+  }
+  const parts = (input.name ?? "").trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return { first: "", last: "" };
+  if (parts.length === 1) return { first: "", last: parts[0] ?? "" };
+  return { first: parts[0] ?? "", last: parts.slice(1).join(" ") };
+}

--- a/packages/integrations/src/crm/sync.ts
+++ b/packages/integrations/src/crm/sync.ts
@@ -1,0 +1,224 @@
+import { decryptJson, encryptJson, logger } from "@dayotter/core";
+import { and, eq, getDb, schema } from "@dayotter/db";
+import { HubspotAdapter, exchangeHubspotCode, hubspotAuthUrl, hubspotEnabled } from "./hubspot";
+import {
+  SalesforceAdapter,
+  exchangeSalesforceCode,
+  salesforceAuthUrl,
+  salesforceEnabled,
+} from "./salesforce";
+import {
+  CRM_PROVIDERS,
+  type CrmAccount,
+  type CrmAdapter,
+  type CrmCredentials,
+  type CrmProvider,
+} from "./types";
+
+type CrmConnectionRow = typeof schema.crmConnections.$inferSelect;
+
+/** Which CRM providers are configured (client id + secret present) in this deploy. */
+export function crmEnabledProviders(): CrmProvider[] {
+  const enabled: CrmProvider[] = [];
+  if (salesforceEnabled()) enabled.push("salesforce");
+  if (hubspotEnabled()) enabled.push("hubspot");
+  return enabled;
+}
+
+export function isCrmProvider(value: string): value is CrmProvider {
+  return (CRM_PROVIDERS as string[]).includes(value);
+}
+
+/** The provider consent URL to redirect the host to (state is a signed anti-CSRF token). */
+export function crmAuthUrl(provider: CrmProvider, state: string): string {
+  return provider === "salesforce" ? salesforceAuthUrl(state) : hubspotAuthUrl(state);
+}
+
+/** Exchange an OAuth code for tokens + the connected account identity. */
+export function exchangeCrmCode(
+  provider: CrmProvider,
+  code: string,
+): Promise<{ credentials: CrmCredentials; account: CrmAccount }> {
+  return provider === "salesforce" ? exchangeSalesforceCode(code) : exchangeHubspotCode(code);
+}
+
+/** Persist a connection (idempotent per user+provider), storing tokens encrypted. */
+export async function connectCrm(
+  userId: string,
+  provider: CrmProvider,
+  credentials: CrmCredentials,
+  account: CrmAccount,
+): Promise<void> {
+  const db = getDb();
+  await db
+    .insert(schema.crmConnections)
+    .values({
+      userId,
+      provider,
+      externalAccountId: account.externalAccountId,
+      accountLabel: account.label,
+      credentials: encryptJson(credentials),
+      status: "active",
+      lastError: null,
+    })
+    .onConflictDoUpdate({
+      target: [schema.crmConnections.userId, schema.crmConnections.provider],
+      set: {
+        externalAccountId: account.externalAccountId,
+        accountLabel: account.label,
+        credentials: encryptJson(credentials),
+        status: "active",
+        lastError: null,
+      },
+    });
+}
+
+/** Build a live adapter from a stored connection; persists rotated tokens. */
+export function adapterForCrmConnection(connection: CrmConnectionRow): CrmAdapter {
+  const creds = decryptJson<CrmCredentials>(connection.credentials);
+  const persist = async (next: CrmCredentials) => {
+    await getDb()
+      .update(schema.crmConnections)
+      .set({ credentials: encryptJson(next) })
+      .where(eq(schema.crmConnections.id, connection.id));
+  };
+  if (connection.provider === "salesforce") return new SalesforceAdapter(creds, persist);
+  if (connection.provider === "hubspot") return new HubspotAdapter(creds, persist);
+  throw new Error(`Unsupported CRM provider: ${connection.provider}`);
+}
+
+/**
+ * Push a booking lifecycle change to every active CRM connection the host holds:
+ * find-or-create the guest as a contact and log the meeting as an activity, so a
+ * reschedule updates the same activity and a cancel closes it. Best-effort per
+ * connection; a failing connection records `lastError` and the job retries.
+ */
+export async function syncBookingToCrm(
+  bookingId: string,
+  action: "created" | "rescheduled" | "cancelled",
+): Promise<void> {
+  const db = getDb();
+  const booking = await db.query.bookings.findFirst({
+    where: eq(schema.bookings.id, bookingId),
+    columns: { id: true, hostId: true, title: true, startsAt: true, endsAt: true },
+    with: {
+      attendees: { columns: { name: true, email: true } },
+      eventType: { columns: { title: true } },
+      host: { columns: { email: true, name: true } },
+    },
+  });
+  if (!booking) return;
+
+  const connections = await db.query.crmConnections.findMany({
+    where: and(
+      eq(schema.crmConnections.userId, booking.hostId),
+      eq(schema.crmConnections.status, "active"),
+    ),
+  });
+  if (connections.length === 0) return;
+
+  // The guest to log against: the first attendee who isn't the host.
+  const hostEmail = booking.host?.email?.toLowerCase();
+  const guest =
+    booking.attendees.find((a) => a.email.toLowerCase() !== hostEmail) ?? booking.attendees[0];
+  if (!guest) return; // nothing to attribute the meeting to
+
+  const title = booking.title || booking.eventType?.title || "Meeting";
+  const meetingBase = {
+    title,
+    startsAt: booking.startsAt,
+    endsAt: booking.endsAt,
+    description: `Booked via DayOtter${booking.host?.name ? ` with ${booking.host.name}` : ""}.`,
+  };
+
+  const errors: string[] = [];
+  for (const conn of connections) {
+    try {
+      const adapter = adapterForCrmConnection(conn);
+      const ref = await db.query.crmReferences.findFirst({
+        where: and(
+          eq(schema.crmReferences.bookingId, booking.id),
+          eq(schema.crmReferences.connectionId, conn.id),
+        ),
+      });
+
+      if (action === "cancelled") {
+        if (ref?.externalActivityId) await adapter.cancelMeeting(ref.externalActivityId);
+        await clearError(conn.id);
+        continue;
+      }
+
+      const contactId =
+        ref?.externalContactId ??
+        (await adapter.upsertContact({
+          email: guest.email,
+          name: guest.name ?? undefined,
+        }));
+      // Persist the contact id early so a mid-way failure doesn't re-create it.
+      await upsertReference(conn, booking.id, { externalContactId: contactId });
+
+      const meeting = { ...meetingBase, contactExternalId: contactId };
+      let activityId = ref?.externalActivityId ?? null;
+      if (activityId) {
+        await adapter.updateMeeting(activityId, meeting);
+      } else {
+        activityId = await adapter.logMeeting(meeting);
+      }
+      await upsertReference(conn, booking.id, {
+        externalContactId: contactId,
+        externalActivityId: activityId,
+      });
+      await clearError(conn.id);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      errors.push(`${conn.provider}: ${message}`);
+      await db
+        .update(schema.crmConnections)
+        .set({ lastError: message })
+        .where(eq(schema.crmConnections.id, conn.id))
+        .catch(() => {});
+      logger.error("crm sync failed for connection", {
+        event: "crm_sync_connection_failed",
+        connectionId: conn.id,
+        provider: conn.provider,
+        bookingId,
+        action,
+        err,
+      });
+    }
+  }
+
+  // Surface a failure so BullMQ retries with backoff (idempotent on re-run).
+  if (errors.length > 0) throw new Error(`CRM sync had ${errors.length} failure(s)`);
+}
+
+async function upsertReference(
+  conn: CrmConnectionRow,
+  bookingId: string,
+  fields: { externalContactId?: string; externalActivityId?: string },
+): Promise<void> {
+  await getDb()
+    .insert(schema.crmReferences)
+    .values({
+      bookingId,
+      connectionId: conn.id,
+      provider: conn.provider,
+      externalContactId: fields.externalContactId ?? null,
+      externalActivityId: fields.externalActivityId ?? null,
+    })
+    .onConflictDoUpdate({
+      target: [schema.crmReferences.bookingId, schema.crmReferences.connectionId],
+      set: {
+        ...(fields.externalContactId ? { externalContactId: fields.externalContactId } : {}),
+        ...(fields.externalActivityId ? { externalActivityId: fields.externalActivityId } : {}),
+      },
+    });
+}
+
+async function clearError(connectionId: string): Promise<void> {
+  await getDb()
+    .update(schema.crmConnections)
+    .set({ lastError: null })
+    .where(eq(schema.crmConnections.id, connectionId))
+    .catch(() => {});
+}

--- a/packages/integrations/src/crm/types.ts
+++ b/packages/integrations/src/crm/types.ts
@@ -1,0 +1,73 @@
+/**
+ * Native CRM sync - the provider-agnostic contract. Salesforce and HubSpot
+ * adapters implement `CrmAdapter`; the sync worker and web OAuth flow only ever
+ * see this interface, so adding a CRM never leaks upward (same design as the
+ * calendar `CalendarAdapter`).
+ */
+
+export type CrmProvider = "salesforce" | "hubspot";
+
+export const CRM_PROVIDERS: CrmProvider[] = ["salesforce", "hubspot"];
+
+/** OAuth tokens + provider endpoint, stored encrypted per connection. */
+export interface CrmCredentials {
+  accessToken: string;
+  refreshToken?: string;
+  /** Epoch ms when the access token expires (0/undefined = unknown). */
+  expiresAt?: number;
+  /** Salesforce: the org's instance URL (e.g. https://acme.my.salesforce.com). */
+  instanceUrl?: string;
+  scope?: string;
+}
+
+/** The account identity captured at connect time, for display + de-dupe. */
+export interface CrmAccount {
+  externalAccountId: string;
+  label: string | null;
+}
+
+export interface CrmContactInput {
+  email: string;
+  firstName?: string;
+  lastName?: string;
+  /** Full name fallback when first/last aren't split. */
+  name?: string;
+}
+
+export interface CrmMeetingInput {
+  title: string;
+  startsAt: Date;
+  endsAt: Date;
+  description?: string;
+  location?: string;
+  /** The external contact id the meeting is associated with. */
+  contactExternalId: string;
+}
+
+/**
+ * A live CRM connection. `persistCredentials` is called after a token refresh so
+ * the rotated tokens are saved (mirrors the calendar adapter contract).
+ */
+export interface CrmAdapter {
+  provider: CrmProvider;
+  /** Find-or-create a contact by email; returns its external id. */
+  upsertContact(input: CrmContactInput): Promise<string>;
+  /** Log a meeting/activity associated with the contact; returns its external id. */
+  logMeeting(input: CrmMeetingInput): Promise<string>;
+  /** Update a previously logged meeting (used on reschedule). */
+  updateMeeting(externalActivityId: string, input: CrmMeetingInput): Promise<void>;
+  /** Mark a logged meeting cancelled (close it / delete it). */
+  cancelMeeting(externalActivityId: string): Promise<void>;
+}
+
+/** Thrown by adapters on a non-2xx provider response, with context. */
+export class CrmApiError extends Error {
+  constructor(
+    public provider: CrmProvider,
+    public status: number,
+    message: string,
+  ) {
+    super(`[${provider}] ${status}: ${message}`);
+    this.name = "CrmApiError";
+  }
+}

--- a/packages/integrations/src/index.ts
+++ b/packages/integrations/src/index.ts
@@ -11,6 +11,9 @@ import {
 import { decryptJson, encryptJson } from "@dayotter/core";
 import { eq, getDb, schema } from "@dayotter/db";
 
+export * from "./crm/types";
+export * from "./crm/sync";
+
 type ConnectionRow = typeof schema.calendarConnections.$inferSelect;
 
 function oauthConfig(provider: "google" | "microsoft"): ProviderOAuthConfig {

--- a/packages/jobs/src/index.ts
+++ b/packages/jobs/src/index.ts
@@ -15,6 +15,7 @@ export const QUEUE_NAMES = {
   sync: "calendar-sync",
   maintenance: "calendar-maintenance",
   webhooks: "webhooks",
+  crmSync: "crm-sync",
 } as const;
 
 /** Liveness key the worker refreshes so the web /health can confirm it's alive. */
@@ -68,10 +69,16 @@ export interface WebhookJob {
   deliveryId: string;
 }
 
+export interface CrmSyncJob {
+  bookingId: string;
+  action: "created" | "rescheduled" | "cancelled";
+}
+
 export const remindersQueue = new Queue<ReminderJob>(QUEUE_NAMES.reminders, { connection });
 export const syncQueue = new Queue<SyncJob>(QUEUE_NAMES.sync, { connection });
 export const maintenanceQueue = new Queue(QUEUE_NAMES.maintenance, { connection });
 export const webhooksQueue = new Queue<WebhookJob>(QUEUE_NAMES.webhooks, { connection });
+export const crmSyncQueue = new Queue<CrmSyncJob>(QUEUE_NAMES.crmSync, { connection });
 
 /**
  * Enqueue delivery of a persisted webhook delivery row. Retries with backoff so
@@ -89,6 +96,21 @@ export async function enqueueWebhook(deliveryId: string): Promise<void> {
       removeOnFail: 200,
     },
   );
+}
+
+/**
+ * Enqueue a CRM push for a booking lifecycle change. Keyed per (booking, action)
+ * so duplicate triggers coalesce; retries with backoff so a transient CRM API
+ * error recovers. Best-effort - never blocks the booking flow.
+ */
+export async function enqueueCrmSync(job: CrmSyncJob): Promise<void> {
+  await crmSyncQueue.add(job.action, job, {
+    jobId: `crm-${job.bookingId}-${job.action}`,
+    attempts: 5,
+    backoff: { type: "exponential", delay: 15_000 },
+    removeOnComplete: true,
+    removeOnFail: 200,
+  });
 }
 
 /**


### PR DESCRIPTION
Closes the top two "Now" roadmap items.

## Native CRM sync (`crm_sync`, Pro — free on self-host)
Pushes every booking to the host's connected CRM: find-or-create the guest as a **contact** and log the meeting as an **activity**. A reschedule updates the same activity; a cancel closes it. Idempotent, best-effort, never blocks the booking flow.

**Architecture** (mirrors the existing calendar/conferencing integrations):
- **DB** (migration `0037`): `crm_connections` (encrypted OAuth tokens, `provider` as plain text so new CRMs need no enum migration) + `crm_references` (booking → external contact/activity ids, one row per booking+connection for idempotent updates).
- **`packages/integrations/crm`** — a `CrmAdapter` interface with two implementations behind it:
  - **HubSpot** — CRM v3 objects API (contacts search/create + meetings with contact association), OAuth + token refresh.
  - **Salesforce** — REST API (Contact find-or-create by email + Event), OAuth with reactive refresh-on-401.
  - `syncBookingToCrm()` is the shared core the worker calls.
- **Queue/worker** — new `crm-sync` BullMQ queue + `startCrmSyncWorker`; `enqueueCrmSync` fires from `create`/`reschedule`/`cancel` booking next to the webhook fan-out.
- **Gating + UI** — `crm_sync` feature (Pro, free self-host); `/settings/crm` page + `crm-manager` disconnect; OAuth connect/callback/disconnect routes; env `SALESFORCE_/HUBSPOT_CLIENT_ID/SECRET` (feature is inert until both are set).

## Deeper time analytics
Three new "where your time goes" metrics, picked up automatically by the API + UI (the module's extension point):
- **`back_to_back_share`** — % of meetings starting with no gap before the next.
- **`longest_focus_streak`** — biggest uninterrupted focus block held.
- **`external_vs_internal`** — time with outside guests vs. your own team, by email domain (adds `hostDomain` to the dataset).

## Verification
- `turbo typecheck` green across all 11 packages; biome clean; migration `0037` generated.
- New routes compile & load the full integrations chain: `/settings/crm` → 200, `/api/integrations/crm/hubspot` → 307 → `/sign-in` (no 500s). Settings page guards the session.
- **Not exercisable locally:** live OAuth + the actual push to Salesforce/HubSpot need provider credentials. To enable on the server, set the client id/secret env vars and connect from `/settings/crm`. Analytics metrics need real booking history to surface.

## Deploy note
Run `./deploy/deploy.sh` to apply migration `0037` before the new code boots.