### PR TITLE
UI: consistent section widths + richer light-mode text + fuller feature card

### DIFF
--- a/apps/web/app/(marketing)/docs/[slug]/page.tsx
+++ b/apps/web/app/(marketing)/docs/[slug]/page.tsx
@@ -1,6 +1,7 @@
-import { Prose } from "@/components/marketing/page-shell";
+import { BreadcrumbJsonLd } from "@/components/seo/json-ld";
 import { GUIDES, getGuide } from "@/lib/docs";
-import { ArrowLeft } from "lucide-react";
+import type { DocBlock } from "@/lib/docs";
+import { AlertTriangle, ArrowLeft, ArrowRight, Info, Lightbulb } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
@@ -15,18 +16,72 @@ export async function generateMetadata({
   params: Promise<{ slug: string }>;
 }): Promise<Metadata> {
   const g = getGuide((await params).slug);
-  if (!g) return { title: "Docs - DayOtter" };
-  return { title: `${g.title} - DayOtter Docs`, description: g.summary };
+  if (!g) return { title: "Docs" };
+  const path = `/docs/${g.slug}`;
+  return {
+    title: `${g.title} - DayOtter Docs`,
+    description: g.summary,
+    alternates: { canonical: path },
+    openGraph: { title: `${g.title} - DayOtter Docs`, description: g.summary, url: path },
+  };
+}
+
+const anchor = (heading: string) =>
+  heading
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+
+const CALLOUT = {
+  tip: { Icon: Lightbulb, label: "Tip", tint: "var(--color-accent)" },
+  note: { Icon: Info, label: "Note", tint: "var(--color-sky)" },
+  warning: { Icon: AlertTriangle, label: "Heads up", tint: "var(--color-amber)" },
+} as const;
+
+function Callout({ tip }: { tip: NonNullable<DocBlock["tip"]> }) {
+  const { Icon, label, tint } = CALLOUT[tip.kind ?? "tip"];
+  return (
+    <div
+      className="my-6 flex gap-3 rounded-[var(--radius-lg)] border p-4"
+      style={{
+        borderColor: `color-mix(in srgb, ${tint} 35%, transparent)`,
+        background: `color-mix(in srgb, ${tint} 7%, var(--color-surface))`,
+      }}
+    >
+      <Icon size={18} className="mt-0.5 shrink-0" style={{ color: tint }} />
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-wide" style={{ color: tint }}>
+          {label}
+        </p>
+        <p className="mt-1 text-sm leading-relaxed text-[var(--color-text)]">{tip.text}</p>
+      </div>
+    </div>
+  );
 }
 
 export default async function DocGuidePage({ params }: { params: Promise<{ slug: string }> }) {
-  const g = getGuide((await params).slug);
+  const { slug } = await params;
+  const g = getGuide(slug);
   if (!g) notFound();
+
+  const headings = g.body.filter((b) => b.heading).map((b) => b.heading as string);
+  const idx = GUIDES.findIndex((x) => x.slug === g.slug);
+  const prev = idx > 0 ? GUIDES[idx - 1] : undefined;
+  const next = idx < GUIDES.length - 1 ? GUIDES[idx + 1] : undefined;
+  const related = (g.related ?? [])
+    .map((s) => getGuide(s))
+    .filter((x): x is NonNullable<typeof x> => Boolean(x));
 
   return (
     <article>
+      <BreadcrumbJsonLd
+        items={[
+          { name: "Docs", path: "/docs" },
+          { name: g.title, path: `/docs/${g.slug}` },
+        ]}
+      />
       <header className="border-b border-[var(--color-border)]">
-        <div className="mx-auto max-w-2xl px-6 py-14">
+        <div className="mx-auto max-w-3xl px-6 py-14">
           <Link
             href="/docs"
             className="mb-6 inline-flex items-center gap-1.5 text-sm text-[var(--color-muted)] transition-colors hover:text-[var(--color-text)]"
@@ -41,35 +96,119 @@ export default async function DocGuidePage({ params }: { params: Promise<{ slug:
         </div>
       </header>
 
-      <Prose>
-        {g.body.map((b, i) => (
-          <div key={i}>
-            {b.heading ? <h2>{b.heading}</h2> : null}
-            {b.paragraphs?.map((p, j) => (
-              <p key={j}>{p}</p>
-            ))}
-            {b.steps ? (
-              <ol>
-                {b.steps.map((s, j) => (
-                  <li key={j}>{s}</li>
+      <div className="mx-auto max-w-6xl gap-10 px-6 py-14 lg:grid lg:grid-cols-[1fr_220px]">
+        {/* Main content */}
+        <div
+          className="min-w-0 max-w-2xl text-[15px] leading-7 text-[var(--color-muted)]
+            [&_a]:text-[var(--color-accent)] [&_a:hover]:underline
+            [&_h2]:font-display [&_h2]:mt-12 [&_h2]:mb-3 [&_h2]:scroll-mt-24 [&_h2]:text-2xl [&_h2]:tracking-[-0.01em] [&_h2]:text-[var(--color-text)]
+            [&_p]:mb-4
+            [&_strong]:font-semibold [&_strong]:text-[var(--color-text)]
+            [&_ul]:mb-4 [&_ul]:list-disc [&_ul]:pl-5 [&_ul]:space-y-2
+            [&_ol]:mb-4 [&_ol]:list-decimal [&_ol]:pl-5 [&_ol]:space-y-2
+            [&_li]:marker:text-[var(--color-faint)]"
+        >
+          {g.body.map((b, i) => (
+            <div key={i}>
+              {b.heading ? <h2 id={anchor(b.heading)}>{b.heading}</h2> : null}
+              {b.paragraphs?.map((p) => (
+                <p key={p.slice(0, 24)}>{p}</p>
+              ))}
+              {b.steps ? (
+                <ol>
+                  {b.steps.map((s) => (
+                    <li key={s.slice(0, 24)}>{s}</li>
+                  ))}
+                </ol>
+              ) : null}
+              {b.bullets ? (
+                <ul>
+                  {b.bullets.map((s) => (
+                    <li key={s.slice(0, 24)}>{s}</li>
+                  ))}
+                </ul>
+              ) : null}
+              {b.tip ? <Callout tip={b.tip} /> : null}
+            </div>
+          ))}
+
+          {related.length > 0 ? (
+            <section className="mt-14 border-t border-[var(--color-border)] pt-8">
+              <p className="eyebrow mb-4">Related guides</p>
+              <div className="grid gap-3 sm:grid-cols-2">
+                {related.map((r) => (
+                  <Link
+                    key={r.slug}
+                    href={`/docs/${r.slug}`}
+                    className="rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)] p-4 transition-colors hover:border-[var(--color-accent)]"
+                  >
+                    <p className="font-medium text-[var(--color-text)]">{r.title}</p>
+                    <p className="mt-1 text-sm text-[var(--color-muted)]">{r.summary}</p>
+                  </Link>
                 ))}
-              </ol>
-            ) : null}
-            {b.bullets ? (
-              <ul>
-                {b.bullets.map((s, j) => (
-                  <li key={j}>{s}</li>
+              </div>
+            </section>
+          ) : null}
+
+          {/* Prev / next */}
+          <nav className="mt-10 flex flex-col gap-3 border-t border-[var(--color-border)] pt-8 sm:flex-row sm:justify-between">
+            {prev ? (
+              <Link
+                href={`/docs/${prev.slug}`}
+                className="group inline-flex items-center gap-1.5 text-sm text-[var(--color-muted)] transition-colors hover:text-[var(--color-text)]"
+              >
+                <ArrowLeft
+                  size={15}
+                  className="transition-transform group-hover:-translate-x-0.5"
+                />
+                {prev.title}
+              </Link>
+            ) : (
+              <span />
+            )}
+            {next ? (
+              <Link
+                href={`/docs/${next.slug}`}
+                className="group inline-flex items-center gap-1.5 text-sm text-[var(--color-muted)] transition-colors hover:text-[var(--color-text)] sm:text-right"
+              >
+                {next.title}
+                <ArrowRight
+                  size={15}
+                  className="transition-transform group-hover:translate-x-0.5"
+                />
+              </Link>
+            ) : (
+              <span />
+            )}
+          </nav>
+
+          <p className="mt-10 text-sm text-[var(--color-muted)]">
+            Ready to try it? <Link href="/sign-up">Get started free</Link>, or browse{" "}
+            <Link href="/docs">all guides</Link>.
+          </p>
+        </div>
+
+        {/* On this page */}
+        {headings.length > 1 ? (
+          <aside className="hidden lg:block">
+            <div className="sticky top-24">
+              <p className="eyebrow mb-3">On this page</p>
+              <ul className="space-y-2 border-l border-[var(--color-border)]">
+                {headings.map((h) => (
+                  <li key={h}>
+                    <a
+                      href={`#${anchor(h)}`}
+                      className="-ml-px block border-l border-transparent pl-3 text-sm text-[var(--color-muted)] transition-colors hover:border-[var(--color-accent)] hover:text-[var(--color-text)]"
+                    >
+                      {h}
+                    </a>
+                  </li>
                 ))}
               </ul>
-            ) : null}
-          </div>
-        ))}
-        <hr />
-        <p>
-          Ready to try it? <Link href="/sign-up">Get started free</Link>, or browse{" "}
-          <Link href="/docs">all guides</Link>.
-        </p>
-      </Prose>
+            </div>
+          </aside>
+        ) : null}
+      </div>
     </article>
   );
 }

--- a/apps/web/app/(marketing)/docs/page.tsx
+++ b/apps/web/app/(marketing)/docs/page.tsx
@@ -6,8 +6,10 @@ import type { Metadata } from "next";
 import Link from "next/link";
 
 export const metadata: Metadata = {
-  title: "Documentation - DayOtter",
-  description: "Guides for setting up, using, and building on DayOtter.",
+  title: "Documentation",
+  description:
+    "In-depth guides for setting up, scheduling with, automating, and building on DayOtter - from your first booking link to CRM sync, the API, and self-hosting.",
+  alternates: { canonical: "/docs" },
 };
 
 const BUILD_LINKS = [
@@ -39,7 +41,7 @@ export default function DocsPage() {
       <MarketingHeader
         eyebrow="Docs"
         title="Documentation"
-        subtitle="Short, task-focused guides to get you booked - and a few pointers for building on DayOtter."
+        subtitle="Task-focused guides that go deep - from your first booking link to teams, AI, payments, CRM sync, the API, and self-hosting."
       />
       <section className="mx-auto max-w-3xl px-6 py-16">
         {DOC_CATEGORIES.map((cat) => {

--- a/apps/web/app/(marketing)/for/page.tsx
+++ b/apps/web/app/(marketing)/for/page.tsx
@@ -19,7 +19,7 @@ export default function ForHub() {
         title="Scheduling, shaped around how you work"
         subtitle="Same calm platform, tuned to your world. Find the version of DayOtter that fits what your days actually look like."
       />
-      <section className="mx-auto max-w-4xl px-6 py-16">
+      <section className="mx-auto max-w-5xl px-6 py-16">
         <div className="grid gap-4 sm:grid-cols-2">
           {PERSONAS.map((p) => (
             <Link

--- a/apps/web/app/(marketing)/glossary/[slug]/page.tsx
+++ b/apps/web/app/(marketing)/glossary/[slug]/page.tsx
@@ -52,7 +52,7 @@ export default async function GlossaryTermPage({
       />
       <MarketingHeader eyebrow={t.category} title={t.term} subtitle={t.short} />
 
-      <div className="mx-auto max-w-2xl px-6 py-16">
+      <div className="mx-auto max-w-3xl px-6 py-16">
         <section className="space-y-4 text-[15px] leading-7 text-[var(--color-muted)]">
           {t.body.map((p) => (
             <p key={p.slice(0, 24)}>{p}</p>

--- a/apps/web/app/(marketing)/glossary/page.tsx
+++ b/apps/web/app/(marketing)/glossary/page.tsx
@@ -19,7 +19,7 @@ export default function GlossaryHub() {
         title="The scheduling glossary"
         subtitle="Every term you'll meet in modern scheduling, defined plainly - and how DayOtter does each one."
       />
-      <section className="mx-auto max-w-4xl px-6 py-16">
+      <section className="mx-auto max-w-5xl px-6 py-16">
         {GLOSSARY_CATEGORIES.map((cat) => {
           const terms = GLOSSARY.filter((t) => t.category === cat);
           if (terms.length === 0) return null;

--- a/apps/web/app/(marketing)/vs/page.tsx
+++ b/apps/web/app/(marketing)/vs/page.tsx
@@ -19,7 +19,7 @@ export default function ComparisonsHub() {
         title="Honest comparisons"
         subtitle="No hand-waving. Here's where each tool wins - and where DayOtter is the better call."
       />
-      <section className="mx-auto max-w-4xl px-6 py-16">
+      <section className="mx-auto max-w-5xl px-6 py-16">
         <div className="grid gap-4 sm:grid-cols-2">
           {COMPARISONS.map((c) => (
             <Link

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -9,15 +9,17 @@
  * Geist sans (display + body) + Geist Mono labels. Light is default.
  */
 @theme {
-  /* Surfaces - warm, not sterile white */
+  /* Surfaces - warm ground, clean panels. surface-2 is the recessed tone: a
+     light, faintly cool neutral (leans to the violet accent) rather than a
+     muddy beige, so inset blocks read crisp and modern, not dated. */
   --color-bg: #faf9f6;
   --color-surface: #ffffff;
-  --color-surface-2: #f4f2ec;
+  --color-surface-2: #f3f2f8;
   --color-elevated: #ffffff;
 
-  /* Lines */
-  --color-border: #ebe8e0;
-  --color-border-strong: #dcd8cd;
+  /* Lines - clean, low-contrast neutrals that match the panels. */
+  --color-border: #e7e6ef;
+  --color-border-strong: #d7d5e1;
 
   /* Text - warm near-black. muted = body/secondary, faint = tertiary/labels.
      Kept richer (darker + warmer) than a flat grey so nothing reads washed-out. */

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -19,10 +19,11 @@
   --color-border: #ebe8e0;
   --color-border-strong: #dcd8cd;
 
-  /* Text - warm near-black */
+  /* Text - warm near-black. muted = body/secondary, faint = tertiary/labels.
+     Kept richer (darker + warmer) than a flat grey so nothing reads washed-out. */
   --color-text: #191720;
-  --color-muted: #6a6660;
-  --color-faint: #9c988e;
+  --color-muted: #55504a;
+  --color-faint: #837d72;
 
   /* Accent - otter violet (matches the illustration palette) */
   --color-accent: #6743e6;

--- a/apps/web/components/marketing/features.tsx
+++ b/apps/web/components/marketing/features.tsx
@@ -52,27 +52,43 @@ function ProviderChips() {
   );
 }
 
+function UserBubble({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="ml-auto w-fit max-w-[85%] rounded-[14px] rounded-br-sm bg-[var(--color-accent)] px-3.5 py-2 text-sm text-white">
+      {children}
+    </div>
+  );
+}
+
+function DraftCard({ kind, when }: { kind: string; when: string }) {
+  return (
+    <div className="rounded-[12px] border border-[var(--color-border)] bg-[var(--color-surface-2)] p-3">
+      <div className="flex items-center gap-2 text-xs text-[var(--color-muted)]">
+        <Sparkles size={13} className="text-[var(--color-accent)]" /> Draft - nothing's booked until
+        you say so
+      </div>
+      <p className="mt-1.5 text-sm font-medium">
+        {kind} · {when}
+      </p>
+      <div className="mt-2.5 flex gap-2">
+        <span className="rounded-sm bg-[var(--color-accent)] px-3 py-1 text-xs font-medium text-white">
+          Confirm
+        </span>
+        <span className="rounded-sm border border-[var(--color-border-strong)] px-3 py-1 text-xs">
+          Edit
+        </span>
+      </div>
+    </div>
+  );
+}
+
 function AIMock() {
   return (
-    <div className="space-y-2.5">
-      <div className="ml-auto w-fit max-w-[85%] rounded-[14px] rounded-br-sm bg-[var(--color-accent)] px-3.5 py-2 text-sm text-white">
-        "Hold two hours for deep work tomorrow"
-      </div>
-      <div className="rounded-[12px] border border-[var(--color-border)] bg-[var(--color-surface-2)] p-3">
-        <div className="flex items-center gap-2 text-xs text-[var(--color-muted)]">
-          <Sparkles size={13} className="text-[var(--color-accent)]" /> Draft - nothing's booked
-          until you say so
-        </div>
-        <p className="mt-1.5 text-sm font-medium">Deep work · Tomorrow, 9:00–11:00 AM</p>
-        <div className="mt-2.5 flex gap-2">
-          <span className="rounded-sm bg-[var(--color-accent)] px-3 py-1 text-xs font-medium text-white">
-            Confirm
-          </span>
-          <span className="rounded-sm border border-[var(--color-border-strong)] px-3 py-1 text-xs">
-            Edit
-          </span>
-        </div>
-      </div>
+    <div className="flex h-full flex-col justify-center gap-3">
+      <UserBubble>"Hold two hours for deep work tomorrow"</UserBubble>
+      <DraftCard kind="Deep work" when="Tomorrow, 9:00–11:00 AM" />
+      <UserBubble>"And move my 3pm with Dana to Thursday"</UserBubble>
+      <DraftCard kind="Reschedule · 1:1 with Dana" when="Thu, 2:30 PM" />
     </div>
   );
 }

--- a/apps/web/components/marketing/hero.tsx
+++ b/apps/web/components/marketing/hero.tsx
@@ -20,7 +20,7 @@ export function Hero() {
         }}
       />
 
-      <div className="relative mx-auto max-w-5xl px-6 pt-16 text-center sm:pt-24">
+      <div className="relative mx-auto max-w-6xl px-6 pt-16 text-center sm:pt-24">
         <FadeUp>
           <span className="eyebrow">Meet Otter, your scheduling assistant</span>
         </FadeUp>

--- a/apps/web/components/marketing/sections.tsx
+++ b/apps/web/components/marketing/sections.tsx
@@ -25,7 +25,7 @@ const AFTER = [
 /** The before/after story - the calm case for switching, plainly told. */
 export function Shift() {
   return (
-    <section className="mx-auto max-w-5xl px-6 py-24">
+    <section className="mx-auto max-w-6xl px-6 py-24">
       <Reveal className="mx-auto max-w-2xl text-center">
         <span className="eyebrow">The shift</span>
         <h2 className="font-display mt-4 text-4xl leading-tight tracking-[-0.02em] sm:text-5xl">
@@ -111,8 +111,8 @@ export function HowItWorks() {
 
 export function Manifesto() {
   return (
-    <section className="mx-auto max-w-4xl px-6 py-20 text-center">
-      <Reveal>
+    <section className="mx-auto max-w-6xl px-6 py-20 text-center">
+      <Reveal className="mx-auto max-w-3xl">
         <p className="font-display text-3xl leading-[1.3] tracking-[-0.01em] sm:text-[2.6rem]">
           We built DayOtter because your time is the one thing you can't get back.{" "}
           <em className="text-[var(--color-accent)]">
@@ -155,14 +155,14 @@ const HOME_FAQ = [
 /** Home-page FAQ - plain answers to the questions people actually ask. */
 export function FAQ() {
   return (
-    <section id="faq" className="mx-auto max-w-3xl px-6 py-24">
+    <section id="faq" className="mx-auto max-w-6xl px-6 py-24">
       <Reveal className="mx-auto max-w-2xl text-center">
         <span className="eyebrow">Good questions</span>
         <h2 className="font-display mt-4 text-4xl leading-tight tracking-[-0.02em] sm:text-5xl">
           The honest answers.
         </h2>
       </Reveal>
-      <Reveal className="mt-12">
+      <Reveal className="mx-auto mt-12 max-w-3xl">
         <div className="divide-y divide-[var(--color-border)] border-y border-[var(--color-border)]">
           {HOME_FAQ.map((item) => (
             <details key={item.q} className="group py-5 [&_summary::-webkit-details-marker]:hidden">

--- a/apps/web/components/marketing/showcase.tsx
+++ b/apps/web/components/marketing/showcase.tsx
@@ -42,7 +42,7 @@ const MOMENTS = [
 
 export function DayWithOtter() {
   return (
-    <section className="mx-auto max-w-3xl px-6 py-24">
+    <section className="mx-auto max-w-6xl px-6 py-24">
       <Reveal className="mx-auto max-w-2xl text-center">
         <span className="eyebrow">A day with Otter</span>
         <h2 className="font-display mt-4 text-4xl leading-tight tracking-[-0.02em] sm:text-5xl">
@@ -54,7 +54,7 @@ export function DayWithOtter() {
         </p>
       </Reveal>
 
-      <div className="relative mt-16">
+      <div className="relative mx-auto mt-16 max-w-2xl">
         {/* the spine */}
         <div
           className="absolute bottom-2 left-[68px] top-2 w-px bg-[var(--color-border)] sm:left-[84px]"
@@ -163,7 +163,7 @@ export function OtterDemo() {
   const isInfo = reply.type === "info";
 
   return (
-    <section className="mx-auto max-w-5xl px-6 py-24">
+    <section className="mx-auto max-w-6xl px-6 py-24">
       <div className="grid items-center gap-12 lg:grid-cols-2">
         <Reveal>
           <span className="eyebrow">Try it yourself</span>
@@ -330,14 +330,14 @@ function TeaserCell({ cell, strong }: { cell: Cell; strong?: boolean }) {
 export function CompareTeaser() {
   const count = COMPARISONS.length;
   return (
-    <section className="mx-auto max-w-4xl px-6 py-24">
+    <section className="mx-auto max-w-6xl px-6 py-24">
       <Reveal className="mx-auto max-w-2xl text-center">
         <span className="eyebrow">How we stack up</span>
         <h2 className="font-display mt-4 text-4xl leading-tight tracking-[-0.02em] sm:text-5xl">
           The same scheduling. More for less.
         </h2>
       </Reveal>
-      <Reveal className="mt-12">
+      <Reveal className="mx-auto mt-12 max-w-4xl">
         <div className="overflow-x-auto rounded-[var(--radius-xl)] border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-card)]">
           <table className="w-full min-w-[520px] border-collapse">
             <thead>

--- a/apps/web/lib/docs.ts
+++ b/apps/web/lib/docs.ts
@@ -1,5 +1,6 @@
 /** Local documentation content. Add a guide here and it appears on /docs +
- *  /docs/[slug]. Keep it task-oriented - what a person does, not how the code works. */
+ *  /docs/[slug]. Task-oriented - what a person does, and the details that
+ *  actually trip people up, not how the code works. */
 
 export interface DocBlock {
   heading?: string;
@@ -8,9 +9,17 @@ export interface DocBlock {
   steps?: string[];
   /** Rendered as an unordered list. */
   bullets?: string[];
+  /** A highlighted callout aside. */
+  tip?: { kind?: "tip" | "note" | "warning"; text: string };
 }
 
-export type DocCategory = "Get started" | "Features" | "Advanced";
+export type DocCategory =
+  | "Get started"
+  | "Scheduling"
+  | "Teams"
+  | "AI & automation"
+  | "Payments"
+  | "Build & self-host";
 
 export interface DocGuide {
   slug: string;
@@ -19,43 +28,68 @@ export interface DocGuide {
   category: DocCategory;
   readMinutes: number;
   body: DocBlock[];
+  /** Slugs of closely related guides, shown at the foot of the page. */
+  related?: string[];
 }
 
 export const GUIDES: DocGuide[] = [
+  // ─── Get started ──────────────────────────────────────────────────────────
   {
     slug: "getting-started",
     title: "Getting started",
-    summary: "From sign-up to a shareable booking link in about five minutes.",
+    summary: "From sign-up to a booking link people can use - in about five minutes.",
     category: "Get started",
-    readMinutes: 4,
+    readMinutes: 6,
+    related: ["connect-a-calendar", "create-a-booking-type", "your-booking-page"],
     body: [
       {
         paragraphs: [
-          "DayOtter turns your calendars into a link people can book. Here's the whole path, start to finish.",
+          "DayOtter turns the calendars you already keep into a link other people can book - without the email tennis, the double-bookings, or the timezone math. This guide walks the whole path once, so you know where everything lives before you go deeper on any one piece.",
+          "There are two ways to use DayOtter, and you can mix them freely: share a link and let people book themselves, or just tell Otter (the built-in assistant) what you want and approve the draft. Nothing here requires the AI - it's there when you want it.",
         ],
       },
       {
         heading: "The five-minute setup",
         steps: [
-          "Create your account at /sign-up (email, Google, or phone).",
-          "Connect a calendar so DayOtter knows when you're busy - Settings → Calendars.",
-          "Set the hours you're open under Availability.",
-          "Create a booking type (e.g. a 30-minute intro) under Booking Types.",
-          "Copy your booking link from the dashboard and share it.",
+          "Create your account at /sign-up with email, Google, or your phone number.",
+          "Connect a calendar (Settings → Calendars) so DayOtter can see when you're already busy. This is what prevents double-bookings.",
+          "Set the hours you're open under Availability - the only times DayOtter will ever offer.",
+          "Create a booking type under Booking Types - say, a 30-minute intro call - with its length, location, and any questions you want answered up front.",
+          "Copy your booking link from the dashboard and share it, or add it to your email signature and website.",
         ],
+      },
+      {
+        tip: {
+          kind: "tip",
+          text: "In a hurry? After connecting a calendar, open Ask Otter and say “create a 30-minute intro call.” It drafts the booking type for you - review it and tap Confirm.",
+        },
       },
       {
         heading: "What happens when someone books",
         paragraphs: [
-          "They open your link, see only the times you're genuinely free, and pick one. The meeting lands on your connected calendar with a video link attached, and both of you get a confirmation and reminders. No back-and-forth, no double-booking.",
+          "They open your link and see only the times you're genuinely free - computed against every calendar you connected, in their own timezone. They pick a slot, answer any intake questions, and confirm.",
+          "The meeting is written to your calendar with a video link attached (Google Meet, Zoom, or Teams, depending on the booking type). Both of you get a confirmation email, and reminders go out automatically before it starts. If you take payment, they pay at this step and the slot is held only once payment clears.",
         ],
       },
       {
-        heading: "Next steps",
+        heading: "Find your way around",
         bullets: [
-          "Add reminder channels so nudges reach you where you are.",
-          "Protect focus time with buffers, daily limits, and focus blocks.",
-          "Invite teammates and share availability as a team.",
+          "Home - today and this week at a glance, plus Otter and “Otter noticed” suggestions.",
+          "Booking Types - the meeting templates people book from.",
+          "Availability - weekly hours, date overrides, and the defenses that protect your time.",
+          "Bookings - everything scheduled: reschedule, cancel, or mark a no-show.",
+          "Teams, Routing, Polls - the group tools (all free to self-host, no paywall).",
+          "Insights - where your time actually goes, and your booking funnel.",
+          "Settings - calendars, notifications, payments, CRM, billing, and the developer tools.",
+        ],
+      },
+      {
+        heading: "Sensible next steps",
+        bullets: [
+          "Add reminder channels (Slack, SMS, WhatsApp, push) so nudges reach you where you already are.",
+          "Protect focus time with buffers, daily limits, and focus blocks so meetings don't eat the day.",
+          "Brand your public page with a colour, a welcome message, and your logo.",
+          "Invite teammates and share availability if you schedule as a group.",
         ],
       },
     ],
@@ -66,101 +100,235 @@ export const GUIDES: DocGuide[] = [
     summary:
       "Link Google, Outlook, iCloud, or any feed so you're never offered a time you're busy.",
     category: "Get started",
-    readMinutes: 3,
+    readMinutes: 5,
+    related: ["set-your-availability", "getting-started", "create-a-booking-type"],
     body: [
       {
         paragraphs: [
-          "DayOtter never invents availability - it reads your real calendars. Connect every calendar that holds commitments so a booking can't land on top of one.",
+          "DayOtter never invents availability - it reads your real calendars. Connecting every calendar that holds commitments is the single most important setup step: it's what guarantees a booking can never land on top of something you've already got.",
+          "A connection does two jobs: it reads your busy times (so conflicts are respected) and it can write new bookings back (so meetings show up where you actually look). You control which calendar each new booking is written to, and which calendars only count for conflicts.",
         ],
       },
       {
         heading: "Supported calendars",
         bullets: [
-          "Google Calendar and Microsoft 365 / Outlook (one-click OAuth).",
-          "Apple iCloud (with an app-specific password).",
-          "Any read-only ICS / webcal feed, for calendars you can only subscribe to.",
+          "Google Calendar - one-click OAuth. Real-time sync via Google's push channels.",
+          "Microsoft 365 / Outlook - one-click OAuth via Microsoft Graph, also real-time.",
+          "Apple iCloud - connect over CalDAV using an app-specific password (not your Apple ID password).",
+          "Any ICS / webcal feed - read-only subscriptions, for calendars you can't OAuth into (a shared team calendar, a sports schedule, a partner's feed).",
         ],
       },
       {
         heading: "Connect one",
         steps: [
           "Go to Settings → Calendars.",
-          "Pick your provider and approve access.",
-          "Choose which of that account's calendars DayOtter should check for conflicts.",
+          "Pick your provider and approve access. For Apple, generate an app-specific password at appleid.apple.com first, then paste it in.",
+          "Choose which of that account's calendars DayOtter should check for conflicts - tick every calendar that represents real commitments.",
+          "Pick the target calendar new bookings are written to (usually your main work calendar).",
         ],
+      },
+      {
+        tip: {
+          kind: "note",
+          text: "Connect more than one account if your life is split across them - a work Google and a personal iCloud, say. DayOtter merges them into one honest view of when you're free, so a dentist appointment in your personal calendar still blocks a work slot.",
+        },
       },
       {
         heading: "Busy, not private",
         paragraphs: [
-          "DayOtter only sees that you're busy, never the details of your events. You also choose exactly which calendar new bookings are written to - keep the rest read-only, just for conflict checks. Connection tokens are encrypted at rest.",
+          "DayOtter only reads that you're busy at a given time - never the titles, attendees, or notes of your events. The calendars you mark read-only are used purely for conflict checks and are never written to.",
+          "Connection tokens are encrypted at rest (AES-256-GCM). You can disconnect any account at any time from the same screen, which immediately stops all reading and writing for it.",
+        ],
+      },
+      {
+        heading: "If availability looks wrong",
+        bullets: [
+          "A slot you expected to be blocked is offered → the conflicting event lives in a calendar you didn't tick for conflict-checking. Add it under Settings → Calendars.",
+          "Bookings aren't appearing in your calendar → check which account is set as the write target, and that DayOtter still has access (re-approve if you changed your password).",
+          "Apple stopped syncing → app-specific passwords can be revoked from your Apple ID; generate a new one and reconnect.",
         ],
       },
     ],
   },
   {
-    slug: "create-a-booking-type",
-    title: "Create a booking type",
-    summary: "One booking type per kind of meeting - shaped exactly how you work.",
-    category: "Features",
+    slug: "your-booking-page",
+    title: "Your booking page & profile",
+    summary: "Brand the public page people land on, and choose exactly what they see.",
+    category: "Get started",
     readMinutes: 4,
+    related: ["create-a-booking-type", "getting-started"],
     body: [
       {
         paragraphs: [
-          "A booking type is a shareable meeting template: its length, where it happens, and the rules around it. Make one for each kind of meeting you take.",
+          "Your public page is where invitees land - at dayotter.com/your-handle (or your own domain on Pro). It lists the booking types you've made public, styled the way you set it. It's the first impression, so it's worth a couple of minutes.",
+        ],
+      },
+      {
+        heading: "Make it yours",
+        bullets: [
+          "Handle - the /your-handle part of the URL. Pick something short and recognisable under Settings → Profile.",
+          "Accent colour - themes buttons and highlights on your public pages to match your brand.",
+          "Welcome message - a short line of context shown at the top of your page (“Book time with me - I usually reply within a day”).",
+          "Avatar and display name - the face and name people see.",
+        ],
+      },
+      {
+        heading: "Control what's listed",
+        paragraphs: [
+          "Only booking types marked public appear on your page. Keep internal or paid types private and share their direct links with just the people who need them. Reorder types so your most important one is first.",
+        ],
+      },
+      {
+        tip: {
+          kind: "tip",
+          text: "For a single high-stakes meeting - a candidate, a big prospect - generate a one-off link from the booking type instead of sharing your whole page. It works once and then expires, so your full calendar stays private.",
+        },
+      },
+    ],
+  },
+
+  // ─── Scheduling ───────────────────────────────────────────────────────────
+  {
+    slug: "create-a-booking-type",
+    title: "Create a booking type",
+    summary: "One template per kind of meeting - shaped exactly how you work.",
+    category: "Scheduling",
+    readMinutes: 6,
+    related: ["set-your-availability", "your-booking-page", "payments-and-packages"],
+    body: [
+      {
+        paragraphs: [
+          "A booking type is a reusable meeting template: how long it runs, where it happens, and every rule around it. Make one for each distinct kind of meeting you take - a quick intro, a paid consult, a recurring coaching session - and share whichever links you like.",
         ],
       },
       {
         heading: "The essentials",
         bullets: [
-          "Title, URL slug, and duration (offer several lengths if you like).",
-          "Location: Google Meet, Zoom, Microsoft Teams, phone, or in person.",
-          "Buffers before and after, and a minimum notice so nobody books you in five minutes.",
-          "Daily and weekly limits to cap how much you take on.",
-          "Intake questions so you show up prepared.",
+          "Title and URL slug - what people see, and the /handle/slug link.",
+          "Duration - a single length, or several the invitee can choose from (15 / 30 / 60).",
+          "Location - Google Meet, Zoom, Microsoft Teams, phone, in person, or a custom link. Video links are generated per booking automatically when the provider is connected.",
+          "Description - what the meeting is for; shown on the booking page.",
         ],
       },
       {
-        heading: "Private and one-off links",
+        heading: "Guardrails that protect your day",
+        bullets: [
+          "Buffers - reserve a few minutes before and/or after so meetings never stack edge-to-edge.",
+          "Minimum notice - the shortest lead time you'll accept, so nobody books you in five minutes.",
+          "Daily / weekly limits - cap how many of this type you'll take (e.g. max 4 demos a day).",
+          "Date range - only allow bookings within a rolling window (e.g. the next 30 days).",
+        ],
+      },
+      {
+        heading: "Intake questions",
         paragraphs: [
-          "Mark a type private to keep it off your public page and share it only with the people you choose. Or generate a one-off link for a single meeting that expires once it's used - handy when you don't want to expose your whole calendar.",
+          "Add questions invitees answer when they book - short text, long text, multiple choice, or required/optional. Answers arrive with the booking so you show up prepared, and they can also drive routing (send different answers to different people). Ask only what you'll actually use.",
+        ],
+      },
+      {
+        heading: "Recurring, private, and one-off",
+        bullets: [
+          "Recurring - offer a weekly, biweekly, or monthly series; one confirmation books the whole run.",
+          "Private - keep the type off your public page and share its direct link only.",
+          "One-off link - a single-use link that expires after it's booked, for a single meeting.",
+          "Group - let several people book the same slot up to a capacity (a webinar, office hours).",
         ],
       },
       {
         heading: "Paid bookings",
         paragraphs: [
-          "Connect Stripe and set a price to take payment at booking time - useful for consultations or paid sessions. Free types stay free.",
+          "Connect Stripe and set a price (or a deposit) to take payment at booking time. The slot is held only once payment succeeds. Free types stay free. See Payments & packages for the full flow, including selling prepaid session bundles.",
         ],
+      },
+      {
+        tip: {
+          kind: "tip",
+          text: "Start with one booking type and share it. It's tempting to model every scenario up front, but you'll learn what you actually need faster by shipping one link and iterating.",
+        },
       },
     ],
   },
   {
     slug: "set-your-availability",
     title: "Set your availability",
-    summary:
-      "Weekly hours, date exceptions, multiple schedules, and defenses that protect your time.",
-    category: "Features",
-    readMinutes: 4,
+    summary: "Weekly hours, date exceptions, multiple schedules, and defenses that hold.",
+    category: "Scheduling",
+    readMinutes: 6,
+    related: ["create-a-booking-type", "connect-a-calendar", "manage-bookings"],
     body: [
       {
-        heading: "Weekly hours",
         paragraphs: [
-          "Under Availability, set the hours you're open on each day. Add multiple ranges per day (say, a morning and an afternoon block), then Save. These are the times DayOtter will ever offer.",
+          "Availability is the outer boundary of when you'll ever be offered. DayOtter then subtracts your real calendar busy times from inside those hours, so what invitees see is the intersection: open hours, minus everything you've already got on.",
         ],
       },
       {
-        heading: "Date overrides and schedules",
+        heading: "Weekly hours",
         paragraphs: [
-          "Override specific dates - a day off, a one-time early start. Running different offerings? Create multiple named schedules (e.g. “Consulting hours”) and assign each booking type to the right one.",
+          "Under Availability, set the hours you're open each day. Add multiple ranges per day - a morning and an afternoon block with lunch in between - and save. Set your schedule's timezone once; invitees always see times converted to their own, and DST is handled for you.",
+        ],
+      },
+      {
+        heading: "Date overrides and multiple schedules",
+        paragraphs: [
+          "Override specific dates for a day off, a conference, or a one-time early start - without touching your normal weekly pattern.",
+          "Running distinct offerings? Create multiple named schedules (say, “Consulting hours” and “Office hours”) and assign each booking type to the right one. A demo can run 9-5 weekdays while coaching runs Tuesday evenings, from the same account.",
         ],
       },
       {
         heading: "Defenses that hold",
         bullets: [
-          "Focus blocks: reserve deep-work time that's off-limits to bookings.",
-          "Adaptive availability: cap meetings per day; once a day is full, it stops offering slots.",
-          "Travel buffers: reserve time around in-person meetings automatically.",
-          "A protected lunch that never gets booked over.",
+          "Focus blocks - reserve deep-work time that's off-limits to bookings. Ask Otter to find and hold them for you.",
+          "Adaptive availability - cap meetings per day; once a day hits the cap, DayOtter stops offering slots that day even if hours remain.",
+          "Travel buffers - automatically reserve time around in-person meetings so back-to-back locations don't collide.",
+          "Protected lunch - a daily window that never gets booked over.",
+          "Reclaim cancelled time - when a meeting is cancelled, optionally turn the freed slot into a focus block instead of re-opening it.",
         ],
+      },
+      {
+        tip: {
+          kind: "note",
+          text: "Buffers and minimum notice can be set per booking type too. Availability sets your overall boundary; the booking type fine-tunes it for that specific meeting.",
+        },
+      },
+    ],
+  },
+  {
+    slug: "manage-bookings",
+    title: "Manage & reschedule bookings",
+    summary: "Reschedule, cancel, handle no-shows, and let Otter do the shuffle.",
+    category: "Scheduling",
+    readMinutes: 4,
+    related: ["set-your-availability", "reminders-and-notifications", "the-otter-assistant"],
+    body: [
+      {
+        paragraphs: [
+          "Every scheduled meeting lives under Bookings. From there you (and your invitees, from their confirmation email) can move or cancel it - and the right people are always notified automatically.",
+        ],
+      },
+      {
+        heading: "Reschedule",
+        paragraphs: [
+          "Open a booking and pick a new time from your live availability, or ask Otter (“move my 3pm with Dana to Thursday afternoon”). The calendar event updates in place, the video link is preserved, attendees are notified, and reminders re-schedule to the new time. No new thread, no duplicate event.",
+        ],
+      },
+      {
+        heading: "Cancel",
+        paragraphs: [
+          "Cancelling notifies attendees, removes the event from your calendar, and clears its pending reminders. If you took payment, you can refund at the same time. If you've enabled reclaim-cancelled-time, the freed slot becomes a focus block instead of re-opening for booking.",
+        ],
+      },
+      {
+        heading: "No-shows and recurring series",
+        bullets: [
+          "Mark a no-show - past meetings auto-complete; flag the ones that didn't happen so your analytics stay honest and you can send a warm rebook nudge.",
+          "Recurring series - manage the whole run together, or a single occurrence, from the booking.",
+        ],
+      },
+      {
+        tip: {
+          kind: "tip",
+          text: "Turn on the running-late nudge (Settings → Preferences). If a meeting runs over, Otter quietly messages your next attendee that you're a few minutes out - no awkward apology needed.",
+        },
       },
     ],
   },
@@ -168,90 +336,488 @@ export const GUIDES: DocGuide[] = [
     slug: "reminders-and-notifications",
     title: "Reminders & notifications",
     summary: "Reach people where they already are, so meetings don't get missed.",
-    category: "Features",
-    readMinutes: 3,
+    category: "Scheduling",
+    readMinutes: 4,
+    related: ["manage-bookings", "workflows-and-automations", "voice-and-messaging"],
     body: [
       {
         paragraphs: [
-          "The best reminder is the one someone actually reads. Email reminders are always on; add more channels on top for you and your attendees.",
+          "The best reminder is the one someone actually reads. Email reminders are always on for both sides; layer on more channels for yourself, and set the lead times that fit how you work.",
         ],
       },
       {
         heading: "Channels",
         bullets: [
-          "Slack, SMS, WhatsApp, mobile push, and browser (web) push.",
-          "Add and verify each under Settings → Notifications - DayOtter sends a test to confirm it works.",
+          "Slack - reminders and Otter's nudges in a channel or DM, via an incoming webhook.",
+          "SMS and WhatsApp - text reminders (and two-way “talk to Otter” messaging) via Twilio.",
+          "Mobile push - through the DayOtter app.",
+          "Browser (web) push - desktop reminders even when the tab is closed.",
         ],
       },
       {
-        heading: "Timing",
+        heading: "Set them up",
+        steps: [
+          "Go to Settings → Notifications.",
+          "Add a channel and enter its destination (Slack webhook URL, phone number, etc.).",
+          "DayOtter sends a test so you can confirm it works before relying on it.",
+          "Choose default lead times - e.g. a day before to plan and an hour before to get moving.",
+        ],
+      },
+      {
+        tip: {
+          kind: "note",
+          text: "Lead times are a default every new booking inherits, so you set them once. A single booking type can override them if it needs different timing.",
+        },
+      },
+      {
+        heading: "Beyond reminders",
         paragraphs: [
-          "Choose the lead times that fit you - a day before to plan, an hour before to get moving. Every new booking inherits them, so you set it once.",
+          "For richer sequences - a follow-up after the meeting, a no-show rebook nudge, a prep note the morning of - use Workflows. And turn on the daily morning briefing to get a calm summary of your day before it starts.",
         ],
       },
     ],
   },
+
+  // ─── Teams ────────────────────────────────────────────────────────────────
   {
     slug: "team-scheduling",
     title: "Team scheduling",
     summary: "Round-robin, collective availability, and shared team rules - from one link.",
-    category: "Features",
-    readMinutes: 3,
+    category: "Teams",
+    readMinutes: 5,
+    related: ["routing-forms", "group-polls", "create-a-booking-type"],
     body: [
+      {
+        paragraphs: [
+          "Teams let several people share a single booking link. DayOtter picks the right host and time based on how you've set the team up - so no one carries all the meetings, and invitees never see the machinery.",
+        ],
+      },
       {
         heading: "Create a team",
         steps: [
           "Go to Teams and create a team.",
-          "Add members by email (they need a DayOtter account).",
-          "Create a team booking type and pick how it schedules.",
+          "Add members by email (they receive an invitation; they'll need a DayOtter account to host).",
+          "Give each member a weight - higher gets booked more often; set 0 to pause someone who's away.",
+          "Create a team booking type and choose how it schedules.",
         ],
       },
       {
         heading: "Collective vs round-robin",
-        paragraphs: [
-          "A collective type finds a slot when everyone required is free. A round-robin type spreads incoming bookings across the team so no one carries them all. Either way it's a single link - DayOtter picks the right host and time.",
+        bullets: [
+          "Collective - offers only slots where everyone required is free at once. For panels, group calls, and reviews.",
+          "Round-robin - spreads incoming bookings across the team, weighted and load-balanced, only ever to a host who's genuinely free at that time. For demos, support, and first-round screens.",
         ],
       },
       {
-        heading: "Shared view and rules",
+        heading: "Shared view and working agreements",
         paragraphs: [
-          "See the whole team's free/busy for the week in one place, and set team rules - holidays, no-meeting windows - that every member's links respect.",
+          "See the whole team's free/busy for the week in one place. Set team rules - company holidays, no-meeting windows like Focus Fridays - that every member's links respect automatically, in each member's own timezone.",
         ],
+      },
+      {
+        heading: "Team briefings",
+        paragraphs: [
+          "Turn on a daily team briefing (admins only, on the team page) for a shared morning digest: total meetings today, load per member, who's busiest, and focus time held - delivered over email and your channels.",
+        ],
+      },
+      {
+        tip: {
+          kind: "note",
+          text: "Weighted round-robin, routing, collective booking, and polls are all in the open core - free to self-host, with no per-seat paywall.",
+        },
       },
     ],
   },
   {
-    slug: "the-otter-assistant",
-    title: "Ask Otter (the AI assistant)",
-    summary: "Chat or talk to your calendar - it drafts every change and never acts without a tap.",
-    category: "Advanced",
-    readMinutes: 3,
+    slug: "routing-forms",
+    title: "Routing forms",
+    summary: "Ask a couple of questions, then send each visitor to the right person or meeting.",
+    category: "Teams",
+    readMinutes: 4,
+    related: ["team-scheduling", "create-a-booking-type"],
     body: [
       {
         paragraphs: [
-          "Otter is the assistant on your dashboard. Ask it in plain language - by typing or by voice - and it reads your real availability to get things done.",
+          "A routing form sits in front of your booking pages. It asks a question or two, then applies simple rules to decide where the visitor goes - a specific person, a team, or a particular booking type. Enterprise leads reach a senior rep; support questions reach the right queue; the wrong person never fields the wrong meeting.",
+        ],
+      },
+      {
+        heading: "Build one",
+        steps: [
+          "Go to Routing and create a form.",
+          "Add the questions that determine routing (company size, product interest, issue type).",
+          "Write rules, checked top to bottom: “if Company size is Enterprise → senior AE round-robin.”",
+          "Set a fallback destination for anything that doesn't match a rule.",
+          "Share the form's link where inbound lands - your site, an ad, an email.",
+        ],
+      },
+      {
+        heading: "For sales: qualify and book instantly",
+        paragraphs: [
+          "Routing doubles as lead qualification. A scored lead drops straight onto the right rep's live availability - no reply-and-wait gap where interest cools. Combine it with weighted round-robin behind the rule to favour your best closers and pause anyone who's out.",
+        ],
+      },
+      {
+        tip: {
+          kind: "tip",
+          text: "Keep the form to one or two questions. Every extra field costs you conversions; ask only what genuinely changes where the booking should go.",
+        },
+      },
+    ],
+  },
+  {
+    slug: "group-polls",
+    title: "Group polls",
+    summary: "Propose a few times, let people vote, lock in the winner as a real booking.",
+    category: "Teams",
+    readMinutes: 3,
+    related: ["team-scheduling", "manage-bookings"],
+    body: [
+      {
+        paragraphs: [
+          "When you can't pin everyone to a fixed collective slot - a panel, a committee, a group dinner - a poll finds the time the most people can make. Propose candidate times, share the link, and let each invitee mark what works.",
+        ],
+      },
+      {
+        heading: "Run a poll",
+        steps: [
+          "Go to Polls and create one; add a handful of candidate times.",
+          "Share the link with everyone who needs to attend.",
+          "Watch votes come in - each person ticks the slots that work for them.",
+          "Finalise the most-supported slot; it becomes a real booking with invites and reminders attached.",
+        ],
+      },
+      {
+        tip: {
+          kind: "note",
+          text: "Unlike a bare poll tool, finalising a DayOtter poll creates the actual calendar event for everyone and sends reminders - there's no separate “now go book it” step, and no ads on your invitees.",
+        },
+      },
+    ],
+  },
+
+  // ─── AI & automation ──────────────────────────────────────────────────────
+  {
+    slug: "the-otter-assistant",
+    title: "Ask Otter (the AI assistant)",
+    summary: "Chat or talk to your calendar - it drafts every change and never acts without a tap.",
+    category: "AI & automation",
+    readMinutes: 5,
+    related: ["voice-and-messaging", "workflows-and-automations", "manage-bookings"],
+    body: [
+      {
+        paragraphs: [
+          "Otter is the assistant built into your dashboard. Ask it in plain language - typing or by voice - and it reads your real availability and bookings to get things done. It's an executive assistant for your calendar, not a chatbot bolted onto a link.",
         ],
       },
       {
         heading: "What you can ask",
         bullets: [
+          "“What's next on my calendar?” / “How busy am I Thursday?”",
+          "“Book 30 minutes with Priya Thursday afternoon.”",
+          "“Find me a free two-hour block this week for deep work and hold it.”",
           "“Move my 3pm to Friday morning.”",
-          "“Find me a free hour this week for deep work.”",
-          "“Create a 20-minute intro call booking type.”",
+          "“Create a 20-minute intro-call booking type.”",
           "“Turn off SMS reminders.”",
         ],
       },
       {
         heading: "Confirm-first, always",
         paragraphs: [
-          "Otter can create booking types, hold focus time, change your availability and preferences, manage reminder channels, and more - but it only ever proposes. Every change is an editable card you approve, and anything destructive asks twice.",
+          "Otter can create booking types, hold focus time, book/reschedule/cancel meetings, change availability and preferences, manage reminder channels, and more - but it only ever proposes. Every change is an editable card you approve, and anything destructive (like a cancel or delete) asks a second time. Nothing lands on your calendar without your explicit OK.",
+        ],
+      },
+      {
+        heading: "Hands-free voice mode",
+        paragraphs: [
+          "Open Ask Otter and it starts in voice mode by default: tap the orb and talk, and Otter listens, thinks, and speaks its reply, then listens again. Confirm a proposed change by tapping Confirm or simply saying “confirm.” Prefer typing? Switch to text chat from the same panel.",
+        ],
+      },
+      {
+        heading: "It learns your patterns",
+        paragraphs: [
+          "Over time Otter builds a private memory of how you work - your typical meeting length, who you meet most, your busiest days, the hours you actually keep - and uses it to make sharper suggestions. It's your data, used to help you; you can see and clear it.",
         ],
       },
       {
         heading: "Turning it on",
         paragraphs: [
-          "On the cloud, Otter is ready when you sign in. Self-hosting? Add your own ANTHROPIC_API_KEY and it turns on.",
+          "On the DayOtter cloud, Otter is ready the moment you sign in. Self-hosting? Add your own ANTHROPIC_API_KEY to the environment and it turns on - no metered per-use cost, it's your key.",
         ],
+      },
+    ],
+  },
+  {
+    slug: "voice-and-messaging",
+    title: "Voice & messaging (WhatsApp, SMS, receptionist)",
+    summary: "Talk to Otter, text it, or let it answer the phone and book for you.",
+    category: "AI & automation",
+    readMinutes: 4,
+    related: ["the-otter-assistant", "reminders-and-notifications"],
+    body: [
+      {
+        paragraphs: [
+          "Otter isn't only in the app. It reaches you (and your callers) over voice, WhatsApp, and SMS - all confirm-first, all optional, all off until you configure the channel.",
+        ],
+      },
+      {
+        heading: "Talk to Otter over WhatsApp / SMS",
+        paragraphs: [
+          "With Twilio connected, text the number in your settings to ask Otter to book, move, or check meetings from your phone's messaging app. It replies with a draft; reply YES to confirm. Great for capturing a scheduling thought the moment you have it.",
+        ],
+      },
+      {
+        heading: "The AI voice receptionist",
+        paragraphs: [
+          "Point a Twilio phone number's voice webhook at DayOtter and Otter can answer calls for one host - understand what the caller needs, answer from a knowledge source you provide, and hand them a booking link (or text it) to lock in a time. Set VOICE_RECEPTIONIST_HANDLE to the host it answers for.",
+        ],
+      },
+      {
+        tip: {
+          kind: "warning",
+          text: "Inbound webhooks are verified with Twilio's signature and fail closed, so only genuine Twilio requests are processed. Register your webhooks at ${APP_URL}/api/webhooks/twilio (messaging) and .../voice (voice).",
+        },
+      },
+    ],
+  },
+  {
+    slug: "workflows-and-automations",
+    title: "Workflows & automations",
+    summary: "Automatic messages and calendar actions that fire around your meetings.",
+    category: "AI & automation",
+    readMinutes: 4,
+    related: ["reminders-and-notifications", "manage-bookings"],
+    body: [
+      {
+        paragraphs: [
+          "Workflows send the right message at the right moment without you lifting a finger. Automations take actions on your calendar when a booking matches a rule. Together they turn “I should really follow up / block prep time” into something that just happens.",
+        ],
+      },
+      {
+        heading: "Attendee workflows",
+        bullets: [
+          "Reminders - before the meeting, on the channels you choose.",
+          "Follow-ups - a thank-you and rebook link after it ends.",
+          "No-show nudges - a warm “sorry we missed you, grab another time” for missed meetings.",
+          "Custom messages - your own copy, with variables like the attendee's name, the time, and the join link.",
+        ],
+      },
+      {
+        heading: "Calendar automations",
+        paragraphs: [
+          "Write rules like “every interview → hold a 15-minute prep block before it,” or “every in-person meeting → reserve travel time around it.” When a booking matches, DayOtter creates the time block automatically. Recurring weekly blocks are materialised ahead of time so they're always there.",
+        ],
+      },
+      {
+        tip: {
+          kind: "tip",
+          text: "Not sure where to start? Ask Otter - “remind attendees a day before and follow up after” - and it drafts the workflow for you to confirm.",
+        },
+      },
+    ],
+  },
+  {
+    slug: "insights",
+    title: "Insights & where your time goes",
+    summary: "See your meeting load, your booking funnel, and how your week actually splits.",
+    category: "AI & automation",
+    readMinutes: 3,
+    related: ["set-your-availability", "the-otter-assistant"],
+    body: [
+      {
+        paragraphs: [
+          "Insights answers two different questions: how well your booking pages convert, and where your time actually goes once meetings are on the calendar.",
+        ],
+      },
+      {
+        heading: "Booking analytics",
+        paragraphs: [
+          "Track views, starts, and completed bookings per type - your funnel - plus totals over time. If a page gets views but few bookings, that's a signal to simplify its intake questions or widen its availability.",
+        ],
+      },
+      {
+        heading: "Where your time goes",
+        bullets: [
+          "Meetings vs. focus - the core balance of your week.",
+          "Who you spend the most time with, and external-vs-internal (by email domain).",
+          "When in the day your meetings land, and your back-to-back share.",
+          "Your longest focus streak, recurring vs one-off load, and time reclaimed from cancellations.",
+        ],
+      },
+      {
+        tip: {
+          kind: "note",
+          text: "These metrics need a little history to be meaningful - they read your last 30 days of bookings and focus blocks. Give it a couple of weeks of real use before drawing conclusions.",
+        },
+      },
+    ],
+  },
+
+  // ─── Payments ─────────────────────────────────────────────────────────────
+  {
+    slug: "payments-and-packages",
+    title: "Payments & prepaid packages",
+    summary: "Charge to book, take deposits, and sell bundles of sessions - via Stripe.",
+    category: "Payments",
+    readMinutes: 4,
+    related: ["create-a-booking-type", "manage-bookings"],
+    body: [
+      {
+        paragraphs: [
+          "Connect Stripe and any booking type can require payment - the full price or a deposit - before the slot is held. It's ideal for consultations, coaching, lessons, and anything where your time is the product. Free types stay free.",
+        ],
+      },
+      {
+        heading: "Take payment to book",
+        steps: [
+          "Connect Stripe under Settings → Payments (or the Billing area).",
+          "Open a booking type and set a price, or a deposit amount.",
+          "Share the link - invitees pay at checkout, and the slot is confirmed only once payment succeeds.",
+        ],
+      },
+      {
+        heading: "Prepaid session packages",
+        paragraphs: [
+          "Sell a bundle up front - ten lessons, a block of coaching hours - and the client draws down one credit per booking. They pay once, receive a credit balance, and book as they go. You can also grant credits manually (a comped session, a referral). Balances are tracked atomically, so they never go wrong.",
+        ],
+      },
+      {
+        heading: "Refunds and no-shows",
+        bullets: [
+          "Cancelling a paid booking can refund it in the same step.",
+          "Deposits are a gentle middle ground - enough commitment to deter no-shows without charging the full fee.",
+        ],
+      },
+      {
+        tip: {
+          kind: "note",
+          text: "On the DayOtter cloud, accepting payments is part of Pro. Self-hosting? It's free - you just bring your own Stripe keys.",
+        },
+      },
+    ],
+  },
+
+  // ─── Build & self-host ────────────────────────────────────────────────────
+  {
+    slug: "crm-sync",
+    title: "CRM sync (Salesforce & HubSpot)",
+    summary: "Log every booking to your CRM automatically - contact plus meeting activity.",
+    category: "Build & self-host",
+    readMinutes: 4,
+    related: ["routing-forms", "developer-api"],
+    body: [
+      {
+        paragraphs: [
+          "Native CRM sync means every booking becomes a record in Salesforce or HubSpot without anyone typing it in. DayOtter finds or creates the guest as a contact and logs the meeting as an activity against them - updated when the booking moves, closed when it's cancelled.",
+        ],
+      },
+      {
+        heading: "Connect",
+        steps: [
+          "Register an OAuth app with your CRM (redirect: ${APP_URL}/api/integrations/crm/<provider>/callback).",
+          "Set the provider's client id and secret in DayOtter's environment.",
+          "Go to Settings → CRM and connect - one click, no keys to paste into DayOtter itself.",
+        ],
+      },
+      {
+        heading: "What gets synced",
+        bullets: [
+          "Contact - matched by email or created (no duplicates).",
+          "Meeting - a Salesforce Event or a HubSpot meeting engagement, associated with the contact.",
+          "On reschedule - the same activity is updated; on cancel, it's closed/removed.",
+        ],
+      },
+      {
+        tip: {
+          kind: "warning",
+          text: "CRM sync is currently in beta. Test it against a sandbox org before pointing it at production data, and watch Settings → CRM for the last-sync status.",
+        },
+      },
+    ],
+  },
+  {
+    slug: "developer-api",
+    title: "Developer: API, webhooks & embed",
+    summary: "Keys and REST endpoints, signed booking events, and the embeddable widget.",
+    category: "Build & self-host",
+    readMinutes: 5,
+    related: ["crm-sync", "self-hosting"],
+    body: [
+      {
+        paragraphs: [
+          "DayOtter is API-first: everything the UI does, it does through the same endpoints you can call. Use the REST API to read and write bookings, event types, and availability; webhooks to react to events; and the embed widget to put booking on your own site.",
+        ],
+      },
+      {
+        heading: "API keys",
+        steps: [
+          "Go to Settings → Developer and create an API key.",
+          "Send it as a bearer token: Authorization: Bearer <key>.",
+          "Call the /api/v1 endpoints for bookings, event types, availability, and more.",
+        ],
+      },
+      {
+        heading: "Webhooks",
+        paragraphs: [
+          "Register an endpoint URL and subscribe to booking.created, booking.rescheduled, and booking.cancelled. Each delivery is signed with an HMAC-SHA-256 signature over a timestamped body (Stripe-style), so you can verify authenticity and reject replays. Deliveries retry with backoff and record their terminal status.",
+        ],
+      },
+      {
+        heading: "Embed",
+        paragraphs: [
+          "Drop the booking widget onto your own page so people book without leaving your site. The public booking pages are also just URLs, so you can link or iframe them anywhere.",
+        ],
+      },
+      {
+        tip: {
+          kind: "tip",
+          text: "Webhook consumer URLs are validated against internal IP ranges and pinned to the resolved public IP (defeating DNS-rebinding), and redirects aren't followed. Point them only at endpoints you control.",
+        },
+      },
+    ],
+  },
+  {
+    slug: "self-hosting",
+    title: "Self-hosting DayOtter",
+    summary: "Run the whole platform on your own infrastructure, with every feature unlocked.",
+    category: "Build & self-host",
+    readMinutes: 5,
+    related: ["developer-api", "the-otter-assistant"],
+    body: [
+      {
+        paragraphs: [
+          "DayOtter's core is open-source (AGPLv3) and ships with Docker. Self-hosted, every Pro feature is free - teams, routing, AI, payments, CRM - because the paywall only exists on the hosted cloud. You bring the keys for the integrations you want; everything else just works.",
+        ],
+      },
+      {
+        heading: "Ways in",
+        bullets: [
+          "One-click on AWS - a CloudFormation template boots the full stack on a single instance.",
+          "One command on any Ubuntu/Debian box - the installer sets up Docker, generates secrets, and starts everything.",
+          "Manual - clone the repo and bring the compose stack up yourself.",
+          "Behind your own nginx - publish the app on localhost and terminate TLS with your existing reverse proxy.",
+        ],
+      },
+      {
+        heading: "What runs",
+        bullets: [
+          "web - the Next.js app (booking pages, dashboard, API).",
+          "worker - background jobs: reminders, calendar sync, webhooks, briefings, CRM sync.",
+          "postgres and redis - the database and the queue/cache.",
+          "A one-shot migrate step that applies database migrations on every deploy.",
+        ],
+      },
+      {
+        heading: "Turning on integrations",
+        paragraphs: [
+          "Everything except the calendar core is off until you add its keys: Google/Microsoft OAuth, an SMTP or Resend key for email, ANTHROPIC_API_KEY for Otter, Twilio for SMS/WhatsApp/voice, Stripe for payments, and the Salesforce/HubSpot client credentials for CRM. Each is inert (and hidden) until configured.",
+        ],
+      },
+      {
+        tip: {
+          kind: "warning",
+          text: "On redeploy, always run the migration step before the new app boots - the deploy script does this in order. Otherwise new code can start against an un-migrated database. See the deploy README for the exact sequence.",
+        },
       },
     ],
   },
@@ -261,4 +827,11 @@ export function getGuide(slug: string): DocGuide | undefined {
   return GUIDES.find((g) => g.slug === slug);
 }
 
-export const DOC_CATEGORIES: DocCategory[] = ["Get started", "Features", "Advanced"];
+export const DOC_CATEGORIES: DocCategory[] = [
+  "Get started",
+  "Scheduling",
+  "Teams",
+  "AI & automation",
+  "Payments",
+  "Build & self-host",
+];


### PR DESCRIPTION
Addresses three marketing-UI issues, thoroughly and across all pages.

## 1. Inconsistent section widths (the "broken" feel)
Home-page sections were a zig-zag of `max-w-6xl / 5xl / 4xl / 3xl`, so the left/right gutters shifted in and out as you scrolled. **Every home section now shares one boundary** — measured identical at **1152px wide, 64px gutter** across all 12 sections. Naturally-narrow content (the day timeline, FAQ list, compare table, manifesto) is centered *within* the shared frame via an inner `max-w-*`, so it stays readable while the section edges line up.

Other marketing pages normalized too: hubs → `max-w-5xl`; glossary prose → `max-w-3xl` (matching the shared `MarketingHeader`).

## 2. Dull grey in light mode
`--color-muted` (`#6a6660` → `#55504a`) and `--color-faint` (`#9c988e` → `#837d72`) were washed-out. Darkened + warmed them so nav links, body copy, and labels read with proper contrast. **Dark mode is untouched** (it has its own token values).

## 3. Feature-card whitespace ("Ask Otter anything")
The tall bento card held a single short mock, leaving dead space. It now shows a **two-turn conversation** (hold focus → reschedule), filling ~85% of the card height (measured) — reads intentional.

## Verification
- `tsc --noEmit` green; biome clean; no console errors.
- Section boundaries measured in-browser: all 12 home sections = 1152px / 64px-left (uniform).
- Feature card content fill measured at 85% with 2 conversation turns.
- Light-mode greys + marketing-page widths confirmed by screenshot (hero + glossary detail).

> Note: the framer `whileInView` sections don't render in the headless preview's backgrounded tab, so mid-page sections were verified by measuring the live DOM rather than screenshots.