### PR TITLE
feat: analytics module (Mixpanel/GA4/PostHog, opt-out) + agent skill docs

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,0 +1,91 @@
+# DayOtter — agent onboarding
+
+You're working on **DayOtter**: an open-core, AI-native team-scheduling platform
+(a genuinely-open Calendly/Cal.com alternative) at [dayotter.com](https://dayotter.com).
+This file is the fast path to being productive. Read it, then load the relevant
+skill under [`.claude/skills/`](../.claude/skills/) for the area you're touching.
+
+## What this is
+
+- **Monorepo** — Turborepo + pnpm. Apps in `apps/*`, shared logic in `packages/*`.
+- **AGPLv3, self-host the whole product for free** — including every AI feature.
+  A small `apps/web/lib/ee/` layer holds cloud-only infrastructure, inert unless
+  `DAYOTTER_CLOUD=1`. Never move a core feature behind that flag.
+- **API-first** — all domain logic lives in `packages/*`, never only in `apps/web`.
+  Web and (upcoming) mobile are peer clients of a stable REST/OpenAPI surface.
+
+## Layout
+
+```
+apps/web       Next.js 15 App Router (marketing + app + REST API routes)
+apps/worker    BullMQ workers (calendar sync, reminders, briefings, webhooks, CRM)
+apps/mobile    Expo/React Native (early)
+packages/core        crypto, logger, SSRF (safeFetch), the availability engine
+packages/db          Drizzle schema (split by domain) + migrations
+packages/calendar    provider adapters (Google, Microsoft, CalDAV)
+packages/integrations  adapters-for-connection, CRM (Salesforce/HubSpot)
+packages/jobs        BullMQ queue definitions + connection
+packages/notifications | emails | auth | plugin-host | plugin-sdk | plugins
+```
+
+## Build / test / verify — run before you claim done
+
+```bash
+pnpm turbo typecheck                 # all packages (15 projects)
+pnpm --filter @dayotter/core test    # 30 tests incl. DST correctness
+pnpm --filter @dayotter/web test     # ~85 tests (vitest)
+npx biome check --write <files>      # format + lint (biome, not prettier/eslint)
+```
+
+Preview the web app via the launch config `web` (or `web-cloud` for the hosted
+edition). Never start dev servers with a bare `pnpm dev` in a way that detaches —
+use the preview tooling. Dev-mode home page can blank client-side during Fast
+Refresh; SSR is complete, so it's a dev quirk, not a bug.
+
+## Load-bearing invariants (do not violate)
+
+1. **Timezone discipline.** Store instants in UTC (`timestamptz`); wall-clock
+   values always carry an explicit IANA zone and are resolved through Luxon. The
+   availability engine returns absolute instants; booker tz is presentation-only.
+   DST is covered by `packages/core/src/availability/engine.test.ts` — keep green.
+2. **Confirm-first AI.** AI proposes an editable draft; it never mutates the
+   calendar without explicit user confirmation. AI scope is scheduling only.
+3. **Secrets encrypted at rest.** OAuth tokens, phone numbers, channel configs →
+   AES-256-GCM via `@dayotter/core` crypto (`ENCRYPTION_KEY`). Never log plaintext.
+4. **Untrusted egress goes through `safeFetch`** (`@dayotter/core`) — HTTPS-only,
+   DNS-resolved-IP pinned, no redirects. Webhooks, plugin HTTP, CRM calls use it.
+5. **Single runtime.** The stack is I/O-bound; crypto is already native. An audit
+   concluded **no Go/Rust** is warranted — don't add a second runtime.
+
+## Editions — the flag that changes behavior
+
+`DAYOTTER_CLOUD=1` (deploy-time, `apps/web/lib/billing/edition.ts` → `isCloud`)
+switches self-hosted → cloud:
+- **Self-hosted (default):** every Pro feature free, no billing. Billing settings
+  show "everything unlocked." CRM/messaging/AI configured via env.
+- **Cloud:** free tier + $9/seat Pro plan gate differentiators; `ee/` unlocks.
+
+If billing shows "self-hosted" on a hosted deploy, the env flag isn't set — that's
+config, not a code bug. See the `editions-and-billing` skill.
+
+## Recent decisions log (newest first)
+
+- **Analytics module** (Mixpanel + GA4 + PostHog) — `apps/web/lib/analytics.ts`.
+  Two independent switches: per-provider env vars (deployer) + per-browser opt-out
+  (end user, Settings → Preferences). All emit paths gate on `analyticsAllowed()`.
+- **Calendar push is best-effort** — a failed Google `watch`/subscription must not
+  fail the sync (`apps/worker/src/workers/sync.ts`); polling is the fallback.
+- **Auth redirect** — the `(auth)` layout bounces signed-in users to `/dashboard`.
+- **Perf/dedup audit (#33)** — availability engine uses integer-ms math; DB index
+  `bookings(eventTypeId, startsAt)`; unified `safeFetch`; booking lifecycle fan-out
+  (`apps/web/lib/booking/lifecycle.ts`); briefing worker dedup; CRM shared helpers.
+- **Plugin/extension system (#32)** — in-process, config-listed plugins under
+  `packages/plugins`, `plugin_data` storage, host registry. Only enable trusted ones.
+- **Marketing width tiers** — 5xl (browse/hubs/detail), 3xl (articles/legal),
+  6xl (home/pricing). Illustrations may carry baked light frames (dark-mode edges).
+
+## Reference docs (human-facing, authoritative)
+
+`docs/ARCHITECTURE.md`, `docs/DECISIONS.md`, `docs/EDITIONS.md`, `docs/AI.md`,
+`docs/ENTERPRISE.md`, `docs/SELF_HOSTING.md`, `docs/ROADMAP.md`. The skills in
+`.claude/skills/` are the agent-oriented "how to work here" companions to these.

--- a/.claude/skills/analytics/SKILL.md
+++ b/.claude/skills/analytics/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: analytics
+description: DayOtter's optional client analytics module (Mixpanel + Google Analytics 4 + PostHog) in apps/web/lib/analytics.ts. Two independent switches — per-provider env config (deployer) and a per-browser opt-out (end user). Load this when adding tracking, wiring a new provider, or changing consent behavior.
+---
+
+# Analytics
+
+Optional, provider-agnostic client analytics. **Two independent switches**, both
+must allow before anything is captured:
+
+1. **Deployer config** — each provider loads only when its `NEXT_PUBLIC_*` env var
+   is set. No env vars → zero analytics code loads (self-host/local default).
+   - `NEXT_PUBLIC_MIXPANEL_TOKEN`, `NEXT_PUBLIC_GA_ID`,
+     `NEXT_PUBLIC_POSTHOG_KEY` (+ `NEXT_PUBLIC_POSTHOG_HOST`).
+   - `analyticsConfigured` / `configuredProviders` reflect what's wired.
+2. **End-user consent** — even when configured, the visitor can opt out in
+   Settings → Preferences (`components/analytics-preferences.tsx`). Consent is a
+   per-browser `localStorage` flag (opt-out; on by default when configured).
+
+## The single gate
+
+Every emit path (`track`, `identify`, `pageview`) short-circuits on
+`analyticsAllowed()` (configured AND not opted out). `setAnalyticsEnabled(false)`
+opts out immediately: calls `posthog.opt_out_capturing()` and `resetAnalytics()`.
+`resetAnalytics()` also runs on sign-out (app-nav / mobile-nav).
+
+## How to add tracking
+
+```ts
+import { track, identify } from "@/lib/analytics"; // client components only
+track("Booking Confirmed", { eventType, durationMin });
+```
+
+Track **meaningful product events** (flow completions, key clicks) — not every
+page view (route page-views are already reported by `components/analytics.tsx`).
+Analytics must **never break the app**: all provider calls are wrapped in try/catch.
+
+## Loading
+
+`components/analytics.tsx` (mounted in the root layout) loads the SDKs only when
+allowed — Mixpanel via dynamic `import`, GA4 + PostHog via their official inline
+snippets (`next/script`, `afterInteractive`). Provider auto page-view is disabled;
+`pageview()` is the single source of truth across all three.
+
+To add a fourth provider: add its env + `*Like` interface + emit calls in
+`lib/analytics.ts`, and a loader branch in `components/analytics.tsx`. Keep it
+gated by `analyticsAllowed()`.

--- a/.claude/skills/calendar-availability/SKILL.md
+++ b/.claude/skills/calendar-availability/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: calendar-availability
+description: How scheduling actually works in DayOtter — the pure availability engine (DST-correct, integer-ms slot math), the busy_blocks cache the sync worker maintains, provider adapters, best-effort push subscriptions, and the booking lifecycle fan-out. Load this when touching availability, calendar sync, busy caching, bookings, or the sync/reminder workers.
+---
+
+# Calendar & availability
+
+## The engine (`packages/core/src/availability/engine.ts`)
+
+`computeAvailability(input)` is **pure and deterministic** — same inputs, same
+slots — which is why it's trivially unit-tested. It:
+- iterates day-by-day in the schedule's timezone (Luxon) so **DST is correct**,
+- steps slots with **integer-millisecond math** (a perf refactor; equivalent to
+  Luxon `.plus({minutes})`, verified byte-identical by the DST tests),
+- checks the pre-sorted busy intervals with buffers, returns **absolute instants**.
+
+`intersectAvailability` powers collective team scheduling ("when are we all free").
+
+**Rule:** the engine reads only the cached busy blocks, never a provider API. The
+booker's timezone is applied at the edge, never inside the math. Any change to
+slot math must keep `engine.test.ts` (incl. the DST cases) green.
+
+## The busy cache & sync worker (`apps/worker/src/workers/sync.ts`)
+
+The sync worker incrementally pulls each connection's calendars (Google
+`syncToken` / MS `deltaLink` / CalDAV poll), upserts `calendar_events` (rich model)
+and its lean `busy_blocks` projection in one pass, and advances the cursor.
+
+**Push subscriptions are best-effort.** `ensureSubscription` registers a provider
+watch/webhook, but a failure there (e.g. Google "Push notifications are not
+supported by this resource", unverified webhook domain, read-only calendar) is
+caught and logged — it must **not** fail the sync, because the events already
+synced and polling keeps the cache fresh. Push is an optimization, not a
+dependency. Also skipped entirely when `APP_URL` isn't a public `https://` URL.
+
+## Booking lifecycle
+
+Create / reschedule / cancel go through `apps/web/lib/booking/lifecycle.ts`
+(`fanOutBookingLifecycle`) which dedups the side effects: emit webhook + enqueue
+CRM sync + run plugin booking hooks. Add new booking side effects there, not in
+each route.
+
+Indexes that matter: `bookings_host_slot_active_idx` (unique, prevents
+double-booking a host at one instant) + a GiST exclusion constraint for overlap;
+`bookings(eventTypeId, startsAt)` for range scans.
+
+## Gotchas
+
+- Two insights windows differ on purpose: the insights *page* uses `[-30d, +30d]`;
+  time-allocation (`lib/analytics/time-allocation`) uses a rolling ±windowDays
+  (`spanDays` normalizes rates) so upcoming meetings still register.
+- Group event types (`isGroup`) are exempt from the single-slot guards; capacity
+  is enforced transactionally in `createBooking`.

--- a/.claude/skills/dayotter-overview/SKILL.md
+++ b/.claude/skills/dayotter-overview/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: dayotter-overview
+description: Orientation for the DayOtter monorepo — layout, the single sources of truth (availability engine, sync worker), the load-bearing invariants (timezone discipline, confirm-first AI, encryption, SSRF-safe egress, single runtime), and how to build/test/verify. Load this first when starting work anywhere in the repo.
+---
+
+# DayOtter overview
+
+Open-core, AI-native team scheduling. Turborepo + pnpm. AGPLv3 — the whole
+product, including AI, self-hosts for free. Cloud-only infra lives in
+`apps/web/lib/ee/`, inert unless `DAYOTTER_CLOUD=1`.
+
+## Where code lives (API-first: domain logic in packages, never only in apps/web)
+
+- `packages/core` — crypto (AES-256-GCM), logger, SSRF `safeFetch`, and the
+  **availability engine** (`availability/engine.ts`, pure + unit-tested).
+- `packages/db` — Drizzle schema split by domain + migrations (`drizzle/`).
+- `packages/calendar` — provider adapters (Google / Microsoft / CalDAV).
+- `packages/integrations` — `adapterForConnection`, CRM (Salesforce/HubSpot).
+- `packages/jobs` — BullMQ queue names + Redis connection.
+- `packages/{notifications,emails,auth,plugin-host,plugin-sdk,plugins}`.
+- `apps/web` — Next.js 15 App Router: `(marketing)` + `(app)` + `(auth)` route
+  groups and the REST API under `app/api`. Domain helpers in `apps/web/lib/*`.
+- `apps/worker` — BullMQ workers: sync, reminders, briefings, webhooks, CRM sync.
+
+Two **single sources of truth** everything else reads from:
+- **Availability engine** — computes bookable slots from schedule + busy cache.
+- **Sync worker** — projects provider calendars into the `busy_blocks` cache the
+  engine reads. The engine never calls a provider directly.
+
+## Invariants (enforced in review — see docs/DECISIONS.md)
+
+1. **Timezone discipline.** UTC instants in the DB; wall-clock always carries an
+   IANA zone, resolved through Luxon. Engine returns absolute instants; booker tz
+   is presentation-only. DST is unit-tested — keep `engine.test.ts` green.
+2. **Confirm-first AI, scheduling-scoped.** AI drafts an editable proposal; never
+   silently mutates the calendar. No general assistant/email/task features.
+3. **Encryption at rest.** OAuth tokens, phone numbers, channel configs via
+   `@dayotter/core` crypto + `ENCRYPTION_KEY`. Plaintext never hits DB or logs.
+4. **SSRF-safe egress.** All untrusted outbound HTTP uses `safeFetch` (HTTPS-only,
+   resolved-IP pinned, no redirects).
+5. **Single runtime.** I/O-bound stack, native crypto — audited: no Go/Rust.
+
+## Verify before "done"
+
+```bash
+pnpm turbo typecheck
+pnpm --filter @dayotter/core test   # 30, incl. DST
+pnpm --filter @dayotter/web test    # ~85
+npx biome check --write <files>     # biome — NOT prettier/eslint
+```
+
+Migrations: Drizzle, in `packages/db/drizzle` (numbered). Add schema in
+`packages/db/src/schema/*`, generate a migration, don't hand-edit applied ones.
+
+## Related skills
+
+`editions-and-billing`, `calendar-availability`, `plugins-extensibility`,
+`analytics`, `frontend-conventions`. Human docs: `docs/ARCHITECTURE.md`,
+`docs/DECISIONS.md`.

--- a/.claude/skills/editions-and-billing/SKILL.md
+++ b/.claude/skills/editions-and-billing/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: editions-and-billing
+description: How DayOtter's self-hosted vs cloud editions work, gated by the DAYOTTER_CLOUD deploy flag and lib/billing/edition.ts. Load this when touching billing, CRM, messaging, managed AI, the ee/ layer, or any feature that should behave differently on the hosted product — or when a "self-hosted / not configured" message shows up where cloud behavior was expected.
+---
+
+# Editions & billing
+
+DayOtter ships in two editions chosen **at deploy time** by one env var.
+
+```ts
+// apps/web/lib/billing/edition.ts
+export const isCloud = process.env.DAYOTTER_CLOUD === "1";
+export const isSelfHosted = !isCloud;
+```
+
+- **Self-hosted (flag unset — the default):** every Pro feature is unlocked, no
+  billing. The billing settings page shows "Self-hosted — everything unlocked."
+  Integrations (CRM, messaging, AI keys) are configured via environment variables.
+- **Cloud (`DAYOTTER_CLOUD=1`):** a free tier + a $9/seat/mo Pro plan gate the
+  differentiator features, and the commercially-licensed `apps/web/lib/ee/` layer
+  (managed AI, hosted messaging, SSO…) becomes available.
+
+**A self-hoster can never accidentally paywall themselves** — the flag defaults
+off. So never move a core feature behind `isCloud`; only cloud-*infrastructure*
+lives in `ee/` (see `apps/web/lib/ee/LICENSE.md`).
+
+## Debugging "wrong edition" reports
+
+If a hosted deployment shows the self-hosted billing card, or CRM shows
+"Coming soon / not configured," the root cause is almost always **`DAYOTTER_CLOUD`
+is not set in that environment** — this is deploy config, not a code bug. The
+gate itself reads `process.env` at runtime in server components and is correct.
+
+- Billing: `apps/web/app/(app)/settings/billing/page.tsx` branches on `isCloud`.
+- CRM messaging is **edition-aware** (`settings/crm/page.tsx`): self-hosters get
+  the actionable env instruction (`SALESFORCE_CLIENT_ID` / `HUBSPOT_CLIENT_ID`…);
+  cloud users see "Coming soon" rather than a meaningless "set an env var."
+- CRM providers only appear as connectable when their client id/secret env is
+  set (`crmEnabledProviders()` in `packages/integrations`). In cloud, the platform
+  sets those once; end users then just click Connect (OAuth, no keys to paste).
+
+## When adding an edition-gated surface
+
+1. Import `isCloud` from `@/lib/billing/edition`.
+2. Give self-hosters an **actionable** path (which env var to set), and cloud
+   users the plan/upgrade path — don't show env instructions to cloud users.
+3. Verify both editions locally: launch config `web` (self-hosted) and `web-cloud`
+   (sets `DAYOTTER_CLOUD=1`).
+
+Docs: `docs/EDITIONS.md`, `docs/ENTERPRISE.md`.

--- a/.claude/skills/frontend-conventions/SKILL.md
+++ b/.claude/skills/frontend-conventions/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: frontend-conventions
+description: apps/web UI conventions — theme tokens and class-based dark mode, the marketing/docs/blog width tiers, brand typography (Geist, no serif), illustration gotchas (baked light frames cause dark-mode edges), reveal animations, and the Card system. Load this when doing marketing or app UI work so new pages match the rest of the site.
+---
+
+# Frontend conventions (apps/web)
+
+## Theme & tokens
+
+- **Dark mode is class-based** — `.dark` on `<html>`, driven by the theme toggle
+  (not `prefers-color-scheme`). Tokens live in `app/globals.css` (light `@theme`
+  block + `.dark` overrides). Always style via CSS variables
+  (`var(--color-surface)`, `--color-text`, `--color-muted`, `--color-faint`,
+  `--color-border`, `--color-accent`…), never hard-coded hex.
+- **Typography: Geist sans everywhere** (`font-display` for headings). No Fraunces/
+  serif — that was deliberately removed.
+- Use the `Card` / `CardHeader` / `CardBody` system (`components/ui/card.tsx`) for
+  app surfaces so elevation/rhythm stays consistent.
+
+## Width tiers (keep pages consistent — a "smooth feel" across navigation)
+
+- **Browse** (`max-w-5xl`): hub/index pages, detail pages, docs index.
+- **Read** (`max-w-3xl`): articles, blog, changelog, status, legal (the shared
+  `Prose` in `components/marketing/page-shell.tsx`), vs/glossary detail.
+- **Landing** (`max-w-6xl`): home sections, pricing, the docs-article grid.
+
+When adding a marketing/docs page, pick the tier that matches its type — don't
+introduce a new width.
+
+## Illustrations (dark-mode gotcha)
+
+Brand PNGs under `public/brand/illustrations/` are otter scenes. Most have
+transparent/dark edges and sit fine on dark backgrounds. **`otter-banner.png` had
+a baked light frame** (a light border ring) that read as a "weird white edge" in
+dark mode — it was trimmed at the source and wrapped in `overflow-hidden`. If you
+add an illustration with a light background/rim, either trim the source or frame
+it so it doesn't clash on the dark theme. Badges are transparent-edged; scene
+portraits (focus/agenda) have light skies that are content, not frames.
+
+## Reveal animations / dev quirk
+
+Marketing sections use scroll reveal (opacity/transform) and can render
+`content-visibility` off-screen. In headless/dev captures a deep-scroll section
+may screenshot blank even though it's in the DOM — force a repaint (resize) or
+verify via measured layout / SSR HTML rather than assuming it's broken. The dev
+home page can also blank during Fast Refresh; SSR is complete — it's a dev quirk.
+
+## Settings & app layout
+
+The app shell is a fixed sidebar + a single scrolling `<main>`. Sub-nav rails
+(e.g. settings) should be `lg:sticky lg:self-start` so only content scrolls, not
+the rail. Toggles: border in *both* states + `inline-flex items-center` so the
+knob stays centered and the track doesn't shift on toggle.

--- a/.claude/skills/plugins-extensibility/SKILL.md
+++ b/.claude/skills/plugins-extensibility/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: plugins-extensibility
+description: DayOtter's plugin/extension system — in-process, config-listed plugins that extend the product without forking (notes, scribing, custom integrations, booking hooks). Covers the plugin-sdk/plugin-host packages, plugin_data storage, the host context (safeHttp via safeFetch), and the trust model. Load this when adding an extension point, writing a plugin, or touching the plugin host.
+---
+
+# Plugins & extensibility
+
+DayOtter is extensible **without forking**: plugins add capabilities (notes,
+scribing, custom integrations, extra booking side effects, AI tweaks) that run
+alongside the core product.
+
+## Model — in-process, config-listed
+
+- Plugins live in `packages/plugins/*`, are authored against `@dayotter/plugin-sdk`,
+  and are hosted by `@dayotter/plugin-host`.
+- They are **listed in config and run in-process** (chosen over a sandboxed
+  runtime for simplicity/perf). **Trust model: only enable plugins you trust** —
+  an enabled plugin has in-process access. Say so in any UI that enables them.
+- Per-plugin persistence uses the `plugin_data` table (migration 0040) via the
+  host registry — plugins don't get raw DB access.
+
+## Host context & safe egress
+
+The host hands each plugin a context with a **`safeHttp.fetch`** that delegates to
+core `safeFetch` (HTTPS-only, DNS-resolved-IP pinned, no redirects). Plugins must
+never make raw outbound requests — route them through the provided client so SSRF
+protections and no-redirect guarantees hold. See `packages/plugin-host/src/context.ts`.
+
+## Extension points
+
+Booking lifecycle hooks fire from `apps/web/lib/booking/lifecycle.ts`
+(`runPluginBookingHooks` inside `fanOutBookingLifecycle`). When adding a new
+extension point:
+1. Define the hook shape in `plugin-sdk`.
+2. Invoke it from the host, wrapped so a misbehaving plugin can't break the core
+   flow (best-effort, logged).
+3. Give plugins data access only through the host registry / `plugin_data`.
+
+Example plugins (notes, webhook-relay) live in `packages/plugins` as references.
+
+Human docs: search `docs/` for the plugin/extension guide.

--- a/.env.example
+++ b/.env.example
@@ -84,9 +84,13 @@ TURNSTILE_SECRET=
 NEXT_PUBLIC_TURNSTILE_SITE_KEY=
 
 # ---- Analytics (optional) ----
-# Nothing loads unless set. Mixpanel project token + GA4 measurement id.
+# Nothing loads unless set - each provider is independent, mix and match freely.
+# End users can additionally opt out per-browser in Settings -> Preferences.
+# Mixpanel project token + GA4 measurement id + PostHog project key/host.
 NEXT_PUBLIC_MIXPANEL_TOKEN=
 NEXT_PUBLIC_GA_ID=
+NEXT_PUBLIC_POSTHOG_KEY=
+NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 
 # ---- AI scheduling (optional) ----
 # Anthropic API key. AI quick-add is hidden unless set. Confirm-first, scheduling-only.

--- a/apps/web/app/(app)/settings/preferences/page.tsx
+++ b/apps/web/app/(app)/settings/preferences/page.tsx
@@ -1,3 +1,4 @@
+import { AnalyticsPreferences } from "@/components/analytics-preferences";
 import { PreferencesForm } from "@/components/preferences-form";
 import { getSession } from "@/lib/auth/session";
 import { eq, getDb, schema } from "@dayotter/db";
@@ -11,24 +12,27 @@ export default async function PreferencesSettingsPage() {
   });
 
   return (
-    <PreferencesForm
-      initial={{
-        timeFormat: prefs?.timeFormat ?? "12h",
-        weekStartsOn: prefs?.weekStartsOn ?? 0,
-        theme: prefs?.theme ?? "system",
-        defaultReminderOffsets: prefs?.defaultReminderOffsets ?? [1440, 60],
-        adaptiveAvailability: prefs?.adaptiveAvailability ?? false,
-        maxMeetingsPerDay: prefs?.maxMeetingsPerDay ?? 5,
-        travelBufferMinutes: prefs?.travelBufferMinutes ?? 0,
-        reclaimCancelledTime: prefs?.reclaimCancelledTime ?? false,
-        overflowNotifyEnabled: prefs?.overflowNotifyEnabled ?? false,
-        briefingEnabled: prefs?.briefingEnabled ?? false,
-        briefingHour: prefs?.briefingHour ?? 8,
-        scribeEnabled: prefs?.scribeEnabled ?? false,
-        lunchEnabled: prefs?.lunchEnabled ?? false,
-        lunchStartMinute: prefs?.lunchStartMinute ?? 720,
-        lunchEndMinute: prefs?.lunchEndMinute ?? 780,
-      }}
-    />
+    <>
+      <PreferencesForm
+        initial={{
+          timeFormat: prefs?.timeFormat ?? "12h",
+          weekStartsOn: prefs?.weekStartsOn ?? 0,
+          theme: prefs?.theme ?? "system",
+          defaultReminderOffsets: prefs?.defaultReminderOffsets ?? [1440, 60],
+          adaptiveAvailability: prefs?.adaptiveAvailability ?? false,
+          maxMeetingsPerDay: prefs?.maxMeetingsPerDay ?? 5,
+          travelBufferMinutes: prefs?.travelBufferMinutes ?? 0,
+          reclaimCancelledTime: prefs?.reclaimCancelledTime ?? false,
+          overflowNotifyEnabled: prefs?.overflowNotifyEnabled ?? false,
+          briefingEnabled: prefs?.briefingEnabled ?? false,
+          briefingHour: prefs?.briefingHour ?? 8,
+          scribeEnabled: prefs?.scribeEnabled ?? false,
+          lunchEnabled: prefs?.lunchEnabled ?? false,
+          lunchStartMinute: prefs?.lunchStartMinute ?? 720,
+          lunchEndMinute: prefs?.lunchEndMinute ?? 780,
+        }}
+      />
+      <AnalyticsPreferences />
+    </>
   );
 }

--- a/apps/web/components/analytics-preferences.tsx
+++ b/apps/web/components/analytics-preferences.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { Card, CardBody, CardHeader } from "@/components/ui/card";
+import {
+  analyticsConfigured,
+  analyticsOptedOut,
+  configuredProviders,
+  setAnalyticsEnabled,
+} from "@/lib/analytics";
+import { cn } from "@/lib/cn";
+import { useEffect, useState } from "react";
+
+function Switch({ on, onClick }: { on: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={on}
+      onClick={onClick}
+      className={cn(
+        "inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border px-0.5 transition-colors",
+        on
+          ? "border-[var(--color-accent)] bg-[var(--color-accent)]"
+          : "border-[var(--color-border-strong)] bg-[var(--color-surface-2)]",
+      )}
+    >
+      <span
+        className={cn(
+          "h-5 w-5 rounded-full bg-white shadow-sm transition-transform",
+          on ? "translate-x-[18px]" : "translate-x-0",
+        )}
+      />
+    </button>
+  );
+}
+
+/**
+ * End-user analytics opt-out. Analytics only exists at all when the deploy has
+ * configured a provider; this lets the visitor turn it off in their browser.
+ * State lives in localStorage (see lib/analytics), so it's read after mount.
+ */
+export function AnalyticsPreferences() {
+  const [enabled, setEnabled] = useState(true);
+  useEffect(() => setEnabled(!analyticsOptedOut()), []);
+
+  function toggle() {
+    const next = !enabled;
+    setEnabled(next);
+    setAnalyticsEnabled(next);
+  }
+
+  return (
+    <Card className="mt-6">
+      <CardHeader
+        title="Analytics & privacy"
+        description="Anonymous product usage that helps improve DayOtter."
+      />
+      <CardBody>
+        {analyticsConfigured ? (
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <p className="text-sm font-medium text-[var(--color-text)]">
+                Share anonymous product analytics
+              </p>
+              <p className="mt-0.5 text-sm text-[var(--color-muted)]">
+                Sent to {configuredProviders.join(", ")}. Turn this off and nothing is captured from
+                this browser. Takes effect immediately.
+              </p>
+            </div>
+            <Switch on={enabled} onClick={toggle} />
+          </div>
+        ) : (
+          <p className="text-sm text-[var(--color-muted)]">
+            Analytics isn't enabled on this DayOtter instance - nothing is being collected. A
+            deployer can turn it on by setting a provider key (Mixpanel, Google Analytics, or
+            PostHog).
+          </p>
+        )}
+      </CardBody>
+    </Card>
+  );
+}

--- a/apps/web/components/analytics.tsx
+++ b/apps/web/components/analytics.tsx
@@ -1,9 +1,16 @@
 "use client";
 
-import { GA_ID, MIXPANEL_TOKEN, pageview } from "@/lib/analytics";
+import {
+  GA_ID,
+  MIXPANEL_TOKEN,
+  POSTHOG_HOST,
+  POSTHOG_KEY,
+  analyticsAllowed,
+  pageview,
+} from "@/lib/analytics";
 import { usePathname, useSearchParams } from "next/navigation";
 import Script from "next/script";
-import { Suspense, useEffect } from "react";
+import { Suspense, useEffect, useState } from "react";
 
 function RouteTracker() {
   const pathname = usePathname();
@@ -18,14 +25,20 @@ function RouteTracker() {
 }
 
 /**
- * Loads the configured analytics providers and reports SPA route changes. Renders
- * nothing (and loads nothing) when no analytics env vars are set.
+ * Loads the configured analytics providers and reports SPA route changes.
+ * Loads NOTHING when no provider env vars are set, or when the user has opted
+ * out in this browser (Settings -> Preferences).
  */
 export function Analytics() {
-  // Mixpanel: load the browser SDK lazily, only when a token is present.
+  // `analyticsAllowed` reads localStorage, so resolve it after mount to avoid a
+  // hydration mismatch and to respect a mid-session opt-out on the next load.
+  const [allowed, setAllowed] = useState(false);
+  useEffect(() => setAllowed(analyticsAllowed()), []);
+
+  // Mixpanel: load the browser SDK lazily, only when a token is present + allowed.
   useEffect(() => {
     const token = MIXPANEL_TOKEN;
-    if (!token || window.mixpanel) return;
+    if (!allowed || !token || window.mixpanel) return;
     let cancelled = false;
     import("mixpanel-browser").then((mod) => {
       if (cancelled) return;
@@ -37,7 +50,9 @@ export function Analytics() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [allowed]);
+
+  if (!allowed) return null;
 
   return (
     <>
@@ -52,6 +67,13 @@ export function Analytics() {
           </Script>
         </>
       ) : null}
+
+      {POSTHOG_KEY ? (
+        <Script id="posthog-init" strategy="afterInteractive">
+          {`!function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset get_distinct_id".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);posthog.init('${POSTHOG_KEY}',{api_host:'${POSTHOG_HOST}',capture_pageview:false});`}
+        </Script>
+      ) : null}
+
       <Suspense fallback={null}>
         <RouteTracker />
       </Suspense>

--- a/apps/web/components/app-nav.tsx
+++ b/apps/web/components/app-nav.tsx
@@ -3,6 +3,7 @@
 import { BrandMark } from "@/components/brand-mark";
 import { NAV } from "@/components/nav-items";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { resetAnalytics } from "@/lib/analytics";
 import { signOut } from "@/lib/auth/auth-client";
 import { cn } from "@/lib/cn";
 import { LogOut } from "lucide-react";
@@ -90,7 +91,12 @@ export function AppNav({ user }: { user: { name?: string | null; email: string }
           <button
             type="button"
             aria-label="Sign out"
-            onClick={() => signOut().then(() => router.push("/sign-in"))}
+            onClick={() =>
+              signOut().then(() => {
+                resetAnalytics();
+                router.push("/sign-in");
+              })
+            }
             className="rounded-md p-1.5 text-[var(--color-faint)] hover:bg-[var(--color-surface-2)] hover:text-[var(--color-text)]"
           >
             <LogOut size={16} />

--- a/apps/web/components/mobile-nav.tsx
+++ b/apps/web/components/mobile-nav.tsx
@@ -3,6 +3,7 @@
 import { BrandMark } from "@/components/brand-mark";
 import { NAV } from "@/components/nav-items";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { resetAnalytics } from "@/lib/analytics";
 import { signOut } from "@/lib/auth/auth-client";
 import { cn } from "@/lib/cn";
 import { LogOut, MoreHorizontal } from "lucide-react";
@@ -39,7 +40,12 @@ export function MobileNav() {
           <button
             type="button"
             aria-label="Sign out"
-            onClick={() => signOut().then(() => router.push("/sign-in"))}
+            onClick={() =>
+              signOut().then(() => {
+                resetAnalytics();
+                router.push("/sign-in");
+              })
+            }
             className="rounded-md p-1.5 text-[var(--color-faint)] hover:bg-[var(--color-surface-2)] hover:text-[var(--color-text)]"
           >
             <LogOut size={18} />

--- a/apps/web/lib/analytics.ts
+++ b/apps/web/lib/analytics.ts
@@ -1,16 +1,35 @@
 /**
- * Client analytics facade over Mixpanel + Google Analytics (GA4).
+ * Client analytics facade over Mixpanel, Google Analytics (GA4), and PostHog.
  *
- * Both are OPTIONAL and independent: nothing loads or tracks unless the matching
- * public env var is set, so local dev and self-hosters run analytics-free by
- * default. Import `track`/`identify` anywhere in a client component and call them
- * on real user actions - we deliberately track meaningful events (button clicks,
- * flow completions), not just page views.
+ * Two independent switches keep this optional:
+ *
+ * 1. **Deployer config** - each provider only loads when its `NEXT_PUBLIC_*` env
+ *    var is set. No env vars => zero analytics code loads (self-hosters and local
+ *    dev run analytics-free by default).
+ * 2. **End-user consent** - even when a provider is configured, the visitor can
+ *    opt out (Settings -> Preferences). Consent lives in `localStorage`, so it's
+ *    per-browser and needs no account. `track`/`identify`/`pageview` all no-op
+ *    while opted out.
+ *
+ * Import `track`/`identify` anywhere in a client component and call them on real
+ * user actions - we deliberately track meaningful events (button clicks, flow
+ * completions), not just page views.
  */
 
 export const MIXPANEL_TOKEN = process.env.NEXT_PUBLIC_MIXPANEL_TOKEN;
 export const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
-export const analyticsEnabled = Boolean(MIXPANEL_TOKEN || GA_ID);
+export const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+export const POSTHOG_HOST = process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://us.i.posthog.com";
+
+/** True when the deploy has wired up at least one analytics provider. */
+export const analyticsConfigured = Boolean(MIXPANEL_TOKEN || GA_ID || POSTHOG_KEY);
+
+/** The providers this deploy has enabled - drives the loader and the settings copy. */
+export const configuredProviders: string[] = [
+  MIXPANEL_TOKEN && "Mixpanel",
+  GA_ID && "Google Analytics",
+  POSTHOG_KEY && "PostHog",
+].filter((v): v is string => Boolean(v));
 
 type Props = Record<string, unknown>;
 
@@ -21,17 +40,73 @@ interface MixpanelLike {
   people?: { set: (traits: Props) => void };
 }
 
+interface PosthogLike {
+  capture: (event: string, props?: Props) => void;
+  identify: (id: string, traits?: Props) => void;
+  reset: () => void;
+  opt_in_capturing: () => void;
+  opt_out_capturing: () => void;
+}
+
 declare global {
   interface Window {
     mixpanel?: MixpanelLike;
+    posthog?: PosthogLike;
     gtag?: (...args: unknown[]) => void;
     dataLayer?: unknown[];
   }
 }
 
+// --- Consent -------------------------------------------------------------
+
+const CONSENT_KEY = "dayotter.analytics.optOut";
+
+/**
+ * Whether analytics may run right now: a provider is configured AND the user
+ * hasn't opted out in this browser. Analytics is on by default when configured;
+ * the user chooses to disable it. Every emit path goes through this gate.
+ */
+export function analyticsAllowed(): boolean {
+  if (typeof window === "undefined" || !analyticsConfigured) return false;
+  try {
+    return window.localStorage.getItem(CONSENT_KEY) !== "1";
+  } catch {
+    return true; // storage blocked -> don't punish the default
+  }
+}
+
+/** Read the current opt-out flag (true = the user has disabled analytics). */
+export function analyticsOptedOut(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(CONSENT_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+/** Toggle analytics for this browser. Opting out immediately stops all capture. */
+export function setAnalyticsEnabled(enabled: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(CONSENT_KEY, enabled ? "0" : "1");
+  } catch {
+    /* storage blocked - nothing to persist */
+  }
+  if (enabled) {
+    window.posthog?.opt_in_capturing();
+  } else {
+    // Stop the providers that support runtime opt-out and drop identity.
+    window.posthog?.opt_out_capturing();
+    resetAnalytics();
+  }
+}
+
+// --- Emit ----------------------------------------------------------------
+
 /** Record a named product event (e.g. "Booking Confirmed") with properties. */
 export function track(event: string, props?: Props): void {
-  if (typeof window === "undefined") return;
+  if (!analyticsAllowed()) return;
   try {
     window.mixpanel?.track(event, props);
   } catch {
@@ -42,11 +117,16 @@ export function track(event: string, props?: Props): void {
   } catch {
     /* noop */
   }
+  try {
+    window.posthog?.capture(event, props);
+  } catch {
+    /* noop */
+  }
 }
 
 /** Associate subsequent events with a signed-in user. */
 export function identify(userId: string, traits?: Props): void {
-  if (typeof window === "undefined") return;
+  if (!analyticsAllowed()) return;
   try {
     window.mixpanel?.identify(userId);
     if (traits) window.mixpanel?.people?.set(traits);
@@ -58,9 +138,14 @@ export function identify(userId: string, traits?: Props): void {
   } catch {
     /* noop */
   }
+  try {
+    window.posthog?.identify(userId, traits);
+  } catch {
+    /* noop */
+  }
 }
 
-/** Clear identity on sign-out. */
+/** Clear identity on sign-out. Runs regardless of consent (it only clears). */
 export function resetAnalytics(): void {
   if (typeof window === "undefined") return;
   try {
@@ -68,12 +153,17 @@ export function resetAnalytics(): void {
   } catch {
     /* noop */
   }
+  try {
+    window.posthog?.reset();
+  } catch {
+    /* noop */
+  }
 }
 
-/** Manual page-view (route changes) - auto page_view is disabled so this is the
- * single source of truth for both providers. */
+/** Manual page-view (route changes) - provider auto page-view is disabled so
+ * this is the single source of truth across all three. */
 export function pageview(url: string): void {
-  if (typeof window === "undefined") return;
+  if (!analyticsAllowed()) return;
   try {
     window.mixpanel?.track("Page Viewed", { url });
   } catch {
@@ -81,6 +171,11 @@ export function pageview(url: string): void {
   }
   try {
     if (GA_ID) window.gtag?.("event", "page_view", { page_path: url });
+  } catch {
+    /* noop */
+  }
+  try {
+    window.posthog?.capture("$pageview", { $current_url: url });
   } catch {
     /* noop */
   }


### PR DESCRIPTION
## Analytics module (optional, provider-agnostic)
Extends the existing Mixpanel+GA facade into a proper 3-provider module adding **PostHog**, with two independent switches:
1. **Deployer** — each provider loads only when its `NEXT_PUBLIC_*` env var is set (nothing loads otherwise).
2. **End user** — per-browser opt-out in Settings → Preferences (localStorage). Every `track`/`identify`/`pageview` gates on `analyticsAllowed()`; `resetAnalytics()` on sign-out.

Files: `lib/analytics.ts`, `components/analytics.tsx`, `components/analytics-preferences.tsx`, preferences page, `.env.example`.

## Contributor skill docs
- `.agents/AGENTS.md` — onboarding, load-bearing invariants, build/test/verify, recent-decisions log.
- `.claude/skills/*` — dayotter-overview, editions-and-billing, calendar-availability, plugins-extensibility, analytics, frontend-conventions.

Verified: web typecheck clean, 85 web tests pass, biome clean.