### PR TITLE
fix: calendar-connect CORS, self-clash/tz-alias inbox, host email, billing detail

### DIFF
--- a/apps/web/app/(app)/settings/calendars/page.tsx
+++ b/apps/web/app/(app)/settings/calendars/page.tsx
@@ -9,7 +9,6 @@ import { cn } from "@/lib/cn";
 import { zoomEnabled } from "@/lib/integrations/zoom";
 import { eq, getDb, schema } from "@dayotter/db";
 import { CheckCircle2, Plus } from "lucide-react";
-import Link from "next/link";
 
 export const dynamic = "force-dynamic";
 
@@ -143,12 +142,16 @@ export default async function CalendarsPage({
                   {p.name}
                 </span>
                 {p.available ? (
-                  <Link
+                  // Plain <a>, NOT next/link: this is an API route that 302s to the
+                  // provider's OAuth page. A <Link> makes Next RSC-prefetch/fetch it,
+                  // which then hits the provider cross-origin and fails CORS. A full
+                  // browser navigation is exactly what OAuth needs.
+                  <a
                     href={`/api/calendars/connect/${p.id}`}
                     className={buttonVariants({ variant: "outline", size: "sm" })}
                   >
                     <Plus size={15} /> Connect
-                  </Link>
+                  </a>
                 ) : (
                   <span className="text-xs text-[var(--color-faint)]">Coming soon</span>
                 )}

--- a/apps/web/app/api/billing/checkout/route.ts
+++ b/apps/web/app/api/billing/checkout/route.ts
@@ -39,15 +39,19 @@ export const POST = withUser(async (u) => {
     });
     return NextResponse.json({ url });
   } catch (err) {
-    // Surface the real Stripe failure server-side - almost always a config issue
-    // (invalid STRIPE_PRICE_PRO, a non-recurring price, or a test/live key mix-up),
-    // which the bare 502 otherwise hides from the operator.
+    // Almost always a Stripe config issue (invalid STRIPE_PRICE_PRO, a non-recurring
+    // price, or a test/live key mix-up). Log it AND return the detail - this route is
+    // owner/admin-only, so surfacing the real cause beats an opaque 502.
+    const detail = err instanceof Error ? err.message : String(err);
     logger.error("stripe checkout failed", {
       event: "billing_checkout_failed",
       userId: u.id,
       organizationId: org.id,
       err,
     });
-    return jsonError("Couldn't start checkout. Please try again.", 502);
+    return NextResponse.json(
+      { error: "Couldn't start checkout. Check the Stripe configuration.", detail },
+      { status: 500 },
+    );
   }
 });

--- a/apps/web/lib/booking/create-booking.ts
+++ b/apps/web/lib/booking/create-booking.ts
@@ -458,45 +458,50 @@ export async function createBooking(
     place: eventType.locationDetail,
   });
 
-  // Confirmation emails to attendee + host.
-  try {
-    const manageUrl = `${appUrl}/booking/${uid}`;
-    await sendEmail({
-      ...bookingConfirmation({
-        eventTitle: eventType.title,
-        start,
-        end,
-        timezone: input.attendee.timezone,
-        hostName: host.name ?? "your host",
-        attendeeName: input.attendee.name,
-        location: eventType.locationDetail ?? undefined,
-        meetingUrl,
-        manageUrl,
-      }),
-      to: input.attendee.email,
-    });
-    if (host.email) {
+  // Confirmation emails to attendee + host. Send them INDEPENDENTLY: a failure to
+  // the host (e.g. a provider that only allows verified recipients in test mode)
+  // must not stop the attendee's mail, and each failure is logged with its
+  // recipient so the cause is visible instead of a single opaque error.
+  const manageUrl = `${appUrl}/booking/${uid}`;
+  const sendConfirmation = async (
+    to: string,
+    timezone: string,
+    hostName: string,
+    recipient: "attendee" | "host",
+  ) => {
+    try {
       await sendEmail({
         ...bookingConfirmation({
           eventTitle: eventType.title,
           start,
           end,
-          timezone: host.timezone,
-          hostName: host.name ?? "you",
+          timezone,
+          hostName,
           attendeeName: input.attendee.name,
           location: eventType.locationDetail ?? undefined,
           meetingUrl,
           manageUrl,
         }),
-        to: host.email,
+        to,
+      });
+    } catch (err) {
+      logger.error("confirmation email failed", {
+        event: "confirmation_email_failed",
+        bookingId: booking.id,
+        recipient,
+        to,
+        err,
       });
     }
-  } catch (err) {
-    logger.error("confirmation email failed", {
-      event: "confirmation_email_failed",
-      bookingId: booking.id,
-      err,
-    });
+  };
+  await sendConfirmation(
+    input.attendee.email,
+    input.attendee.timezone,
+    host.name ?? "your host",
+    "attendee",
+  );
+  if (host.email) {
+    await sendConfirmation(host.email, host.timezone, host.name ?? "you", "host");
   }
 
   // Recurring series: create the remaining occurrences (best-effort each; an

--- a/apps/web/lib/calendar/inbox.ts
+++ b/apps/web/lib/calendar/inbox.ts
@@ -1,4 +1,17 @@
-import { and, eq, getDb, gte, ne, schema } from "@dayotter/db";
+import { and, eq, getDb, gte, inArray, ne, schema } from "@dayotter/db";
+
+/** Two IANA zones that are really the same place (e.g. Asia/Calcutta == Asia/Kolkata). */
+function sameZone(a: string, b: string): boolean {
+  if (a === b) return true;
+  const canon = (tz: string) => {
+    try {
+      return new Intl.DateTimeFormat("en-US", { timeZone: tz }).resolvedOptions().timeZone;
+    } catch {
+      return tz;
+    }
+  };
+  return canon(a) === canon(b);
+}
 
 export interface ReconnectItem {
   connectionId: string;
@@ -117,7 +130,7 @@ export async function inboxData(userId: string): Promise<InboxData> {
   const duplicates: DuplicateItem[] = [];
   if (calendarIds.length > 0) {
     const calSet = new Set(calendarIds);
-    const [bookings, events] = await Promise.all([
+    const [bookings, events, refs] = await Promise.all([
       db.query.bookings.findMany({
         where: and(
           eq(schema.bookings.hostId, userId),
@@ -132,11 +145,28 @@ export async function inboxData(userId: string): Promise<InboxData> {
           gte(schema.calendarEvents.endsAt, now),
           ne(schema.calendarEvents.transparency, "transparent"),
         ),
-        columns: { calendarId: true, title: true, startsAt: true, endsAt: true },
+        columns: {
+          calendarId: true,
+          title: true,
+          startsAt: true,
+          endsAt: true,
+          externalEventId: true,
+        },
         limit: 500,
       }),
+      db.query.bookingReferences.findMany({
+        where: inArray(schema.bookingReferences.calendarId, calendarIds),
+        columns: { externalEventId: true },
+      }),
     ]);
-    const relevant = events.filter((e) => calSet.has(e.calendarId));
+    // A booking DayOtter writes to the host's calendar syncs back as an event -
+    // that mirror must NOT be flagged as clashing with its own booking. Drop every
+    // booking mirror from the conflict candidates (genuinely overlapping DayOtter
+    // bookings are already prevented by the DB's no-overlap constraint).
+    const mirrorIds = new Set(refs.map((r) => r.externalEventId));
+    const relevant = events.filter(
+      (e) => calSet.has(e.calendarId) && !mirrorIds.has(e.externalEventId),
+    );
     for (const b of bookings) {
       const clash = relevant.find((e) => e.startsAt < b.endsAt && e.endsAt > b.startsAt);
       if (clash) {
@@ -165,7 +195,7 @@ export async function inboxData(userId: string): Promise<InboxData> {
   const timezoneMismatches: TimezoneItem[] = [];
   if (userTz) {
     for (const cal of connections.flatMap((c) => c.calendars)) {
-      if (cal.isTargetForBookings && cal.timezone && cal.timezone !== userTz) {
+      if (cal.isTargetForBookings && cal.timezone && !sameZone(cal.timezone, userTz)) {
         timezoneMismatches.push({
           calendarName: cal.name,
           calendarTz: cal.timezone,


### PR DESCRIPTION
Six reported production bugs.

1. **Calendar connect CORS** — the Connect button was a `next/link` to `/api/calendars/connect/*`; Next RSC-prefetches/fetches it, it 302s to Google/Microsoft OAuth, and the browser blocks it on CORS. Changed to a plain `<a>` (full navigation, which is what OAuth requires).
2. **False 'Double-booked' in inbox** — the booking DayOtter writes to the host's calendar syncs back and was flagged as clashing with *itself*. Now excludes booking mirrors (`booking_references.externalEventId`) from conflict + duplicate detection.
3. **False 'Timezone mismatch'** — `Asia/Calcutta` vs `Asia/Kolkata` are the same zone; compare via `Intl` canonicalization instead of string equality.
4. **Owner didn't get the booking email** — attendee + host confirmations were in one try/catch, so a host-side failure (e.g. an email provider in test mode that only sends to verified addresses) was masked. Now sent independently, each logged with its recipient.
5. **Billing 502** — the route now returns the real Stripe error `detail` (owner/admin-only) so the cause shows in-browser, not just a bare 502.

Verified: web typecheck clean, 85 tests, biome clean.