### PR TITLE
fix: guardrails for billing (price_ id) + email (verified From) misconfig

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,7 +73,9 @@ RESEND_API_KEY=
 # Alternative: any SMTP server, e.g. smtp://user:pass@smtp.example.com:587
 # (Resend also works over SMTP: smtps://resend:re_yourkey@smtp.resend.com:465)
 SMTP_URL=
-# The From address. With Resend it MUST be on a verified domain.
+# The From address. It MUST be on a domain you've verified with your provider -
+# an unverified/placeholder domain (e.g. example.com) makes EVERY email bounce
+# with a 550. Change this to your own verified domain before going live.
 EMAIL_FROM="DayOtter <no-reply@dayotter.com>"
 # Where the public contact form sends messages. Defaults to hello@dayotter.com.
 CONTACT_EMAIL=
@@ -145,6 +147,8 @@ NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
 # Set DAYOTTER_CLOUD=1 only for the hosted product (free tier + $9/seat Pro plan).
 DAYOTTER_CLOUD=
 # The recurring Stripe Price for the $9/seat Pro plan (cloud only).
+# MUST be a Price object ID (starts with "price_"), NOT a number/amount. Create a
+# Product with a recurring price in the Stripe Dashboard and copy its price_... id.
 STRIPE_PRICE_PRO=
 # Cloud-only (ee/) managed credentials - ignored when self-hosting.
 DAYOTTER_MANAGED_ANTHROPIC_KEY=

--- a/packages/emails/src/mailer.ts
+++ b/packages/emails/src/mailer.ts
@@ -52,8 +52,21 @@ async function sendViaResend(email: OutboundEmail, from: string, apiKey: string)
  *   3. neither         → warn loudly and drop (so a missing config surfaces in
  *      logs instead of silently swallowing every confirmation/reminder).
  */
+let warnedExampleFrom = false;
+
 export async function sendEmail(email: OutboundEmail): Promise<void> {
   const from = process.env.EMAIL_FROM ?? "DayOtter <no-reply@example.com>";
+
+  // The placeholder example.com sender is unverified everywhere, so EVERY email
+  // (booking confirmations, reminders) will be rejected (Resend 550). Warn once so
+  // this doesn't look like a code bug - the operator must set EMAIL_FROM to an
+  // address on a domain they've verified with their provider.
+  if (!warnedExampleFrom && from.includes("example.com")) {
+    warnedExampleFrom = true;
+    console.warn(
+      "[emails] EMAIL_FROM is unset/example.com - every email will be REJECTED as unverified. Set EMAIL_FROM to an address on a domain verified with your provider (e.g. Resend).",
+    );
+  }
 
   const resendKey = process.env.RESEND_API_KEY;
   if (resendKey) {


### PR DESCRIPTION
The prod logs showed both remaining issues are **config**, not code — this PR makes them impossible to miss:

- **Billing**: `STRIPE_PRICE_PRO` was set to a numeric amount; Stripe needs a **Price object ID** (`price_...`). `.env.example` now says so explicitly (and checkout already returns the real Stripe error detail from #39).
- **Email**: `EMAIL_FROM` fell back to `no-reply@example.com`, which is unverified, so every DayOtter confirmation/reminder 550-bounced — the client only received Google Calendar's own invite. The mailer now logs a loud one-time warning when the sender is on example.com, and `.env.example` spells out the verified-domain requirement.

No behavior change beyond the warning; typecheck + biome clean.