### PR TITLE
fix: activate subscription after checkout (webhook-independent) + make Otter free

### DIFF
--- a/apps/web/app/(app)/settings/billing/page.tsx
+++ b/apps/web/app/(app)/settings/billing/page.tsx
@@ -5,8 +5,14 @@ import { getSession } from "@/lib/auth/session";
 import { PRO_PRICE_USD, isCloud } from "@/lib/billing/edition";
 import { getEntitlements, primaryOrg } from "@/lib/billing/entitlements";
 import { FEATURE_LABEL, FEATURE_TIER, type Feature } from "@/lib/billing/features";
-import { seatCount } from "@/lib/billing/subscription";
-import { paymentsEnabled, proPriceId, subscriptionsEnabled } from "@/lib/payments/stripe";
+import { seatCount, syncSubscriptionById } from "@/lib/billing/subscription";
+import {
+  paymentsEnabled,
+  proPriceId,
+  retrieveSession,
+  subscriptionsEnabled,
+} from "@/lib/payments/stripe";
+import { logger } from "@dayotter/core";
 import { Check, Heart } from "lucide-react";
 
 export const dynamic = "force-dynamic";
@@ -28,7 +34,11 @@ function FeatureList() {
   );
 }
 
-export default async function BillingPage() {
+export default async function BillingPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ session_id?: string }>;
+}) {
   const session = await getSession();
   const userId = session!.user!.id;
 
@@ -52,6 +62,30 @@ export default async function BillingPage() {
         </Card>
       </div>
     );
+  }
+
+  // Just back from a successful checkout? Reconcile the subscription right now so
+  // the plan flips to Pro even when the Stripe webhook isn't reaching this deploy
+  // (the webhook stays the source of truth for later seat/cancel changes).
+  const sp = await searchParams;
+  if (sp.session_id) {
+    try {
+      const checkout = await retrieveSession(sp.session_id);
+      if (checkout.subscription) {
+        await syncSubscriptionById(
+          typeof checkout.subscription === "string"
+            ? checkout.subscription
+            : checkout.subscription.id,
+        );
+      }
+    } catch (err) {
+      logger.error("post-checkout reconcile failed", {
+        event: "billing_reconcile_failed",
+        userId,
+        sessionId: sp.session_id,
+        err,
+      });
+    }
   }
 
   const [ent, org] = await Promise.all([getEntitlements(userId), primaryOrg(userId)]);

--- a/apps/web/app/(marketing)/pricing/page.tsx
+++ b/apps/web/app/(marketing)/pricing/page.tsx
@@ -29,8 +29,9 @@ const TIERS: Tier[] = [
     name: "Free",
     price: "$0",
     cadence: "forever",
-    tagline: "Everything one person needs to get booked.",
+    tagline: "Everything one person needs to get booked - Otter included.",
     features: [
+      "Otter - your AI scheduling assistant",
       "Unlimited event types & booking pages",
       "Google, Microsoft & Apple calendar sync",
       "Group polls - find a time across a group",
@@ -45,8 +46,7 @@ const TIERS: Tier[] = [
     cadence: "per seat / month",
     tagline: "The full toolkit for teams that live in their calendar.",
     features: [
-      "Everything in Free",
-      "Otter - your AI scheduling assistant",
+      "Everything in Free, including Otter",
       "Team scheduling - weighted round-robin & collective",
       "Routing forms - qualify & route inbound",
       "Recurring meetings & focus auto-scheduling",

--- a/apps/web/app/api/billing/checkout/route.ts
+++ b/apps/web/app/api/billing/checkout/route.ts
@@ -34,7 +34,7 @@ export const POST = withUser(async (u) => {
       quantity: await seatCount(org.id),
       customerId: org.stripeCustomerId,
       customerEmail: u.email,
-      successUrl: `${appUrl}/settings/billing?upgraded=1`,
+      successUrl: `${appUrl}/settings/billing?upgraded=1&session_id={CHECKOUT_SESSION_ID}`,
       cancelUrl: `${appUrl}/settings/billing`,
     });
     return NextResponse.json({ url });

--- a/apps/web/lib/billing/features.ts
+++ b/apps/web/lib/billing/features.ts
@@ -31,7 +31,10 @@ export type Feature =
   | "hosted_messaging"; // SMS/WhatsApp via DayOtter's Twilio credits
 
 export const FEATURE_TIER: Record<Feature, FeatureTier> = {
-  ai: "pro",
+  // Otter (AI scheduling + NL command + the assistant chat) is a core USP - free
+  // for everyone, on cloud too. Cloud simply uses DayOtter's managed key (see
+  // managed_ai / lib/ee) so free users need no BYO key.
+  ai: "free",
   automation: "pro",
   workflows: "pro",
   analytics: "pro",


### PR DESCRIPTION
Two issues.

1. **Subscription stays Free after a successful payment.** Activation relies on the Stripe **webhook** (`checkout.session.completed` → `syncSubscriptionById`), which is likely not configured to reach the deploy (`STRIPE_WEBHOOK_SECRET` / endpoint). Added a **self-reconcile fallback**: checkout success now redirects to `?session_id={CHECKOUT_SESSION_ID}`, and the billing page retrieves that session → subscription and syncs it on load — so Pro flips on immediately without depending on the webhook. The webhook remains the source of truth for later seat/cancel changes.
2. **Otter (AI) should not be a Pro paywall — it's the USP.** `FEATURE_TIER.ai`: `pro` → `free`. The chat / NL command / recommendations now pass `requireFeature('ai')` for everyone; on cloud they use the managed Anthropic key, so free users need no BYO key. Pricing page moves Otter into the Free tier.

Verified: web typecheck clean, 85 tests, biome clean.