### PR TITLE
fix: availability page - fewer focus suggestions + two-column layout

### DIFF
--- a/apps/web/components/availability-editor.tsx
+++ b/apps/web/components/availability-editor.tsx
@@ -6,7 +6,7 @@ import { Card, CardBody, CardHeader } from "@/components/ui/card";
 import { Select } from "@/components/ui/select";
 import { cn } from "@/lib/cn";
 import { Check, Copy, Plus, X } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { type ReactNode, useEffect, useMemo, useState } from "react";
 
 interface Range {
   start: string; // "HH:MM"
@@ -75,10 +75,13 @@ const timeInputClass =
 export function AvailabilityEditor({
   initial,
   scheduleId,
+  sidebar,
 }: {
   initial: { timezone: string; days: Range[][]; overrides?: Override[] };
   /** When set, save to this named schedule; otherwise the legacy default endpoint. */
   scheduleId?: string;
+  /** Slotted into the top of the right-hand side panel (the schedule switcher). */
+  sidebar?: ReactNode;
 }) {
   const [timezone, setTimezone] = useState(initial.timezone);
   const [days, setDays] = useState<Range[][]>(initial.days);
@@ -180,11 +183,164 @@ export function AvailabilityEditor({
   }
 
   return (
-    <div className="space-y-6">
-      <Card>
-        <CardHeader title="Timezone" description="The zone your weekly hours are set in." />
-        <CardBody>
-          <div className="max-w-sm">
+    <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_20rem] lg:items-start">
+      {/* MAIN (left): the weekly grid + a single always-reachable Save. */}
+      <div className="space-y-6">
+        <Card>
+          <CardHeader
+            title="Weekly hours"
+            description="The hours you're open for bookings each week. Toggle a day off to block it entirely."
+            action={
+              <div className="flex flex-wrap items-center justify-end gap-1.5">
+                <span className="mr-1 text-xs font-medium uppercase tracking-wide text-[var(--color-faint)]">
+                  Quick set
+                </span>
+                {(
+                  [
+                    { key: "weekdays", label: "Weekdays 9–5" },
+                    { key: "everyday", label: "Every day 9–5" },
+                    { key: "clear", label: "Clear all" },
+                  ] as const
+                ).map((p) => (
+                  <button
+                    key={p.key}
+                    type="button"
+                    onClick={() => applyPreset(p.key)}
+                    className="rounded-full border border-[var(--color-border-strong)] px-3 py-1 text-xs font-medium text-[var(--color-text)] transition-colors hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]"
+                  >
+                    {p.label}
+                  </button>
+                ))}
+              </div>
+            }
+          />
+          <div className="divide-y divide-[var(--color-border)]">
+            {DAY_ORDER.map((dow) => {
+              const ranges = days[dow] ?? [];
+              const on = ranges.length > 0;
+              return (
+                <div
+                  key={dow}
+                  className={cn(
+                    "flex flex-col gap-3 px-4 py-3 transition-colors sm:flex-row sm:items-center",
+                    on ? "bg-[var(--color-surface)]" : "bg-[var(--color-surface-2)]/40",
+                  )}
+                >
+                  <div className="flex w-36 shrink-0 items-center gap-3 sm:self-start sm:pt-1.5">
+                    <Toggle
+                      on={on}
+                      onClick={() => update(dow, on ? [] : [{ start: "09:00", end: "17:00" }])}
+                    />
+                    <span className={cn("text-sm font-medium", !on && "text-[var(--color-muted)]")}>
+                      {DAY_LABELS[dow]}
+                    </span>
+                  </div>
+
+                  <div className="min-w-0 flex-1">
+                    {!on ? (
+                      <span className="text-sm text-[var(--color-faint)] sm:leading-8">
+                        Unavailable
+                      </span>
+                    ) : (
+                      <div className="space-y-2">
+                        {ranges.map((r, i) => (
+                          <div key={i} className="flex items-center gap-2">
+                            <input
+                              type="time"
+                              step={900}
+                              value={r.start}
+                              onChange={(e) =>
+                                update(
+                                  dow,
+                                  ranges.map((x, j) =>
+                                    j === i ? { ...x, start: e.target.value } : x,
+                                  ),
+                                )
+                              }
+                              className={timeInputClass}
+                            />
+                            <span className="text-[var(--color-muted)]">–</span>
+                            <input
+                              type="time"
+                              step={900}
+                              value={r.end}
+                              onChange={(e) =>
+                                update(
+                                  dow,
+                                  ranges.map((x, j) =>
+                                    j === i ? { ...x, end: e.target.value } : x,
+                                  ),
+                                )
+                              }
+                              className={timeInputClass}
+                            />
+                            <button
+                              type="button"
+                              aria-label="Remove"
+                              onClick={() =>
+                                update(
+                                  dow,
+                                  ranges.filter((_, j) => j !== i),
+                                )
+                              }
+                              className="rounded-md p-1.5 text-[var(--color-faint)] hover:bg-[var(--color-surface-2)] hover:text-[var(--color-danger)]"
+                            >
+                              <X size={15} />
+                            </button>
+                          </div>
+                        ))}
+                        <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+                          <button
+                            type="button"
+                            onClick={() =>
+                              update(dow, [...ranges, { start: "09:00", end: "17:00" }])
+                            }
+                            className="inline-flex items-center gap-1 text-sm text-[var(--color-accent)] hover:underline"
+                          >
+                            <Plus size={14} /> Add time
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => copyToAll(dow)}
+                            className="inline-flex items-center gap-1 text-sm text-[var(--color-muted)] hover:text-[var(--color-text)]"
+                          >
+                            <Copy size={13} /> Copy to all days
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </Card>
+
+        {/* Save lives with the hours it saves; sticky so it's always reachable. */}
+        <div className="sticky bottom-4 z-10 flex items-center gap-3 rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)]/95 px-4 py-3 shadow-[var(--shadow-card)] backdrop-blur">
+          <Button onClick={save} disabled={saving || !dirty}>
+            {saving ? "Saving…" : "Save availability"}
+          </Button>
+          {dirty ? (
+            <span className="text-sm text-[var(--color-amber)]">Unsaved changes</span>
+          ) : saved ? (
+            <span className="inline-flex items-center gap-1.5 text-sm text-[var(--color-success)]">
+              <Check size={15} /> Saved
+            </span>
+          ) : (
+            <span className="text-sm text-[var(--color-muted)]">All changes saved</span>
+          )}
+          <FormError>{error}</FormError>
+        </div>
+      </div>
+
+      {/* SIDE PANEL (right): schedule switcher, timezone, and date overrides. */}
+      <aside className="space-y-6">
+        {sidebar}
+
+        <Card>
+          <CardHeader title="Timezone" description="The zone your weekly hours are set in." />
+          <CardBody>
             <label htmlFor="timezone" className="sr-only">
               Timezone
             </label>
@@ -202,236 +358,92 @@ export function AvailabilityEditor({
                 </option>
               ))}
             </Select>
-          </div>
-        </CardBody>
-      </Card>
+          </CardBody>
+        </Card>
 
-      <Card>
-        <CardHeader
-          title="Weekly hours"
-          description="The hours you're open for bookings each week. Toggle a day off to block it entirely."
-          action={
-            <div className="flex flex-wrap items-center justify-end gap-1.5">
-              <span className="mr-1 text-xs font-medium uppercase tracking-wide text-[var(--color-faint)]">
-                Quick set
-              </span>
-              {(
-                [
-                  { key: "weekdays", label: "Weekdays 9–5" },
-                  { key: "everyday", label: "Every day 9–5" },
-                  { key: "clear", label: "Clear all" },
-                ] as const
-              ).map((p) => (
-                <button
-                  key={p.key}
-                  type="button"
-                  onClick={() => applyPreset(p.key)}
-                  className="rounded-full border border-[var(--color-border-strong)] px-3 py-1 text-xs font-medium text-[var(--color-text)] transition-colors hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]"
-                >
-                  {p.label}
-                </button>
-              ))}
-            </div>
-          }
-        />
-        <div className="divide-y divide-[var(--color-border)]">
-          {DAY_ORDER.map((dow) => {
-            const ranges = days[dow] ?? [];
-            const on = ranges.length > 0;
-            return (
-              <div
-                key={dow}
-                className={cn(
-                  "flex flex-col gap-3 px-4 py-3 transition-colors sm:flex-row sm:items-center",
-                  on ? "bg-[var(--color-surface)]" : "bg-[var(--color-surface-2)]/40",
-                )}
-              >
-                <div className="flex w-36 shrink-0 items-center gap-3 sm:self-start sm:pt-1.5">
-                  <Toggle
-                    on={on}
-                    onClick={() => update(dow, on ? [] : [{ start: "09:00", end: "17:00" }])}
-                  />
-                  <span className={cn("text-sm font-medium", !on && "text-[var(--color-muted)]")}>
-                    {DAY_LABELS[dow]}
-                  </span>
-                </div>
-
-                <div className="min-w-0 flex-1">
-                  {!on ? (
-                    <span className="text-sm text-[var(--color-faint)] sm:leading-8">
-                      Unavailable
-                    </span>
-                  ) : (
-                    <div className="space-y-2">
-                      {ranges.map((r, i) => (
-                        <div key={i} className="flex items-center gap-2">
+        <Card>
+          <CardHeader
+            title="Date overrides"
+            description="Block out holidays or set different hours for specific dates."
+          />
+          {overrides.length > 0 ? (
+            <div className="divide-y divide-[var(--color-border)] border-b border-[var(--color-border)]">
+              {overrides.map((o) => {
+                const unavailable = o.start === null;
+                return (
+                  <div
+                    key={o.date}
+                    className="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center"
+                  >
+                    <span className="w-32 shrink-0 text-sm font-medium">{o.date}</span>
+                    <div className="flex flex-1 items-center gap-3">
+                      <Toggle
+                        on={!unavailable}
+                        onClick={() =>
+                          patchOverride(
+                            o.date,
+                            unavailable
+                              ? { start: "09:00", end: "17:00" }
+                              : { start: null, end: null },
+                          )
+                        }
+                      />
+                      {unavailable ? (
+                        <span className="text-sm text-[var(--color-faint)]">Unavailable</span>
+                      ) : (
+                        <div className="flex items-center gap-2">
                           <input
                             type="time"
                             step={900}
-                            value={r.start}
-                            onChange={(e) =>
-                              update(
-                                dow,
-                                ranges.map((x, j) =>
-                                  j === i ? { ...x, start: e.target.value } : x,
-                                ),
-                              )
-                            }
+                            value={o.start ?? "09:00"}
+                            onChange={(e) => patchOverride(o.date, { start: e.target.value })}
                             className={timeInputClass}
                           />
                           <span className="text-[var(--color-muted)]">–</span>
                           <input
                             type="time"
                             step={900}
-                            value={r.end}
-                            onChange={(e) =>
-                              update(
-                                dow,
-                                ranges.map((x, j) => (j === i ? { ...x, end: e.target.value } : x)),
-                              )
-                            }
+                            value={o.end ?? "17:00"}
+                            onChange={(e) => patchOverride(o.date, { end: e.target.value })}
                             className={timeInputClass}
                           />
-                          <button
-                            type="button"
-                            aria-label="Remove"
-                            onClick={() =>
-                              update(
-                                dow,
-                                ranges.filter((_, j) => j !== i),
-                              )
-                            }
-                            className="rounded-md p-1.5 text-[var(--color-faint)] hover:bg-[var(--color-surface-2)] hover:text-[var(--color-danger)]"
-                          >
-                            <X size={15} />
-                          </button>
                         </div>
-                      ))}
-                      <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
-                        <button
-                          type="button"
-                          onClick={() => update(dow, [...ranges, { start: "09:00", end: "17:00" }])}
-                          className="inline-flex items-center gap-1 text-sm text-[var(--color-accent)] hover:underline"
-                        >
-                          <Plus size={14} /> Add time
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => copyToAll(dow)}
-                          className="inline-flex items-center gap-1 text-sm text-[var(--color-muted)] hover:text-[var(--color-text)]"
-                        >
-                          <Copy size={13} /> Copy to all days
-                        </button>
-                      </div>
+                      )}
                     </div>
-                  )}
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      </Card>
-
-      <Card>
-        <CardHeader
-          title="Date overrides"
-          description="Block out holidays or set different hours for specific dates."
-        />
-        {overrides.length > 0 ? (
-          <div className="divide-y divide-[var(--color-border)] border-b border-[var(--color-border)]">
-            {overrides.map((o) => {
-              const unavailable = o.start === null;
-              return (
-                <div
-                  key={o.date}
-                  className="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center"
-                >
-                  <span className="w-32 shrink-0 text-sm font-medium">{o.date}</span>
-                  <div className="flex flex-1 items-center gap-3">
-                    <Toggle
-                      on={!unavailable}
-                      onClick={() =>
-                        patchOverride(
-                          o.date,
-                          unavailable
-                            ? { start: "09:00", end: "17:00" }
-                            : { start: null, end: null },
-                        )
-                      }
-                    />
-                    {unavailable ? (
-                      <span className="text-sm text-[var(--color-faint)]">Unavailable</span>
-                    ) : (
-                      <div className="flex items-center gap-2">
-                        <input
-                          type="time"
-                          step={900}
-                          value={o.start ?? "09:00"}
-                          onChange={(e) => patchOverride(o.date, { start: e.target.value })}
-                          className={timeInputClass}
-                        />
-                        <span className="text-[var(--color-muted)]">–</span>
-                        <input
-                          type="time"
-                          step={900}
-                          value={o.end ?? "17:00"}
-                          onChange={(e) => patchOverride(o.date, { end: e.target.value })}
-                          className={timeInputClass}
-                        />
-                      </div>
-                    )}
+                    <button
+                      type="button"
+                      aria-label="Remove override"
+                      onClick={() => removeOverride(o.date)}
+                      className="rounded-md p-1.5 text-[var(--color-faint)] hover:bg-[var(--color-surface-2)] hover:text-[var(--color-danger)]"
+                    >
+                      <X size={15} />
+                    </button>
                   </div>
-                  <button
-                    type="button"
-                    aria-label="Remove override"
-                    onClick={() => removeOverride(o.date)}
-                    className="rounded-md p-1.5 text-[var(--color-faint)] hover:bg-[var(--color-surface-2)] hover:text-[var(--color-danger)]"
-                  >
-                    <X size={15} />
-                  </button>
-                </div>
-              );
-            })}
-          </div>
-        ) : null}
+                );
+              })}
+            </div>
+          ) : null}
 
-        <CardBody>
-          <div className="flex items-center gap-2">
-            <input
-              type="date"
-              value={newDate}
-              onChange={(e) => setNewDate(e.target.value)}
-              className={timeInputClass}
-            />
-            <button
-              type="button"
-              onClick={addOverride}
-              disabled={!newDate}
-              className="inline-flex items-center gap-1 text-sm text-[var(--color-accent)] hover:underline disabled:opacity-50"
-            >
-              <Plus size={14} /> Add override
-            </button>
-          </div>
-        </CardBody>
-      </Card>
-
-      {/* Sticky action bar - Save stays reachable no matter how far you scroll
-          through the hours + overrides, instead of stranding at the bottom. */}
-      <div className="sticky bottom-4 z-10 mt-8 flex items-center gap-3 rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)]/95 px-4 py-3 shadow-[var(--shadow-card)] backdrop-blur">
-        <Button onClick={save} disabled={saving || !dirty}>
-          {saving ? "Saving…" : "Save availability"}
-        </Button>
-        {dirty ? (
-          <span className="text-sm text-[var(--color-amber)]">Unsaved changes</span>
-        ) : saved ? (
-          <span className="inline-flex items-center gap-1.5 text-sm text-[var(--color-success)]">
-            <Check size={15} /> Saved
-          </span>
-        ) : (
-          <span className="text-sm text-[var(--color-muted)]">All changes saved</span>
-        )}
-        <FormError>{error}</FormError>
-      </div>
+          <CardBody>
+            <div className="flex items-center gap-2">
+              <input
+                type="date"
+                value={newDate}
+                onChange={(e) => setNewDate(e.target.value)}
+                className={timeInputClass}
+              />
+              <button
+                type="button"
+                onClick={addOverride}
+                disabled={!newDate}
+                className="inline-flex items-center gap-1 text-sm text-[var(--color-accent)] hover:underline disabled:opacity-50"
+              >
+                <Plus size={14} /> Add override
+              </button>
+            </div>
+          </CardBody>
+        </Card>
+      </aside>
     </div>
   );
 }

--- a/apps/web/components/focus-defense.tsx
+++ b/apps/web/components/focus-defense.tsx
@@ -59,7 +59,9 @@ export function FocusDefense() {
   // Nothing to show until loaded, and hide entirely when there are no gaps.
   if (!suggestions || suggestions.length === 0) return null;
 
-  const visible = suggestions.filter((s) => !protectedKeys.has(s.startISO));
+  // Cap the list - one suggestion per day quickly becomes a wall. Show the two
+  // nearest unprotected blocks; the rest resurface as you protect these.
+  const visible = suggestions.filter((s) => !protectedKeys.has(s.startISO)).slice(0, 2);
 
   return (
     <Card className="mb-6">

--- a/apps/web/components/schedules-manager.tsx
+++ b/apps/web/components/schedules-manager.tsx
@@ -2,6 +2,7 @@
 
 import { AvailabilityEditor } from "@/components/availability-editor";
 import { Button } from "@/components/ui/button";
+import { Card, CardBody, CardHeader } from "@/components/ui/card";
 import { ConfirmDialog, Dialog } from "@/components/ui/dialog";
 import { FormError } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
@@ -168,86 +169,86 @@ export function SchedulesManager({
         </div>
       ) : null}
 
-      <div className="grid gap-6 lg:grid-cols-[240px_1fr]">
-        <aside className="space-y-2">
-          <ul className="space-y-1">
-            {schedules.map((s) => (
-              <li key={s.id}>
-                <button
-                  type="button"
-                  onClick={() => select(s.id)}
-                  className={cn(
-                    "flex w-full items-center justify-between gap-2 rounded-md border px-3 py-2 text-left text-sm transition-colors",
-                    s.id === selectedId
-                      ? "border-[var(--color-accent)] bg-[var(--color-surface-2)]"
-                      : "border-[var(--color-border)] bg-[var(--color-surface)] hover:bg-[var(--color-surface-2)]",
-                  )}
-                >
-                  <span className="min-w-0 flex-1 truncate font-medium">{s.name}</span>
-                  {s.isDefault ? (
-                    <span
-                      title="Default schedule"
-                      className="inline-flex items-center gap-1 text-[11px] text-[var(--color-accent)]"
-                    >
-                      <Star size={11} fill="currentColor" /> Default
-                    </span>
-                  ) : null}
-                </button>
-              </li>
-            ))}
-          </ul>
-          <Button
-            variant="outline"
-            size="sm"
-            className="w-full"
-            onClick={openCreate}
-            disabled={busy}
-          >
-            <Plus size={14} /> New schedule
-          </Button>
-        </aside>
-
-        <div>
-          {selected ? (
-            <div className="mb-4 flex flex-wrap items-center gap-2">
-              <h2 className="mr-auto text-lg font-semibold">{selected.name}</h2>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => openRename(selected.id, selected.name)}
-              >
-                Rename
-              </Button>
-              {!selected.isDefault ? (
-                <>
-                  <Button variant="ghost" size="sm" onClick={() => makeDefault(selected.id)}>
-                    <Star size={14} /> Make default
+      {loading || !detail ? (
+        <div className="py-6">
+          <SkeletonRows rows={6} />
+        </div>
+      ) : (
+        <AvailabilityEditor
+          key={selectedId}
+          scheduleId={selectedId}
+          initial={detail}
+          sidebar={
+            <Card>
+              <CardHeader
+                title="Schedules"
+                action={
+                  <Button variant="ghost" size="sm" onClick={openCreate} disabled={busy}>
+                    <Plus size={14} /> New
                   </Button>
+                }
+              />
+              <div className="p-2">
+                <ul className="space-y-1">
+                  {schedules.map((s) => (
+                    <li key={s.id}>
+                      <button
+                        type="button"
+                        onClick={() => select(s.id)}
+                        className={cn(
+                          "flex w-full items-center justify-between gap-2 rounded-md px-3 py-2 text-left text-sm transition-colors",
+                          s.id === selectedId
+                            ? "bg-[var(--color-accent-soft)] font-medium text-[var(--color-accent)]"
+                            : "text-[var(--color-muted)] hover:bg-[var(--color-surface-2)] hover:text-[var(--color-text)]",
+                        )}
+                      >
+                        <span className="min-w-0 flex-1 truncate">{s.name}</span>
+                        {s.isDefault ? (
+                          <span
+                            title="Default schedule"
+                            className="inline-flex shrink-0 items-center gap-1 text-[11px] text-[var(--color-accent)]"
+                          >
+                            <Star size={11} fill="currentColor" /> Default
+                          </span>
+                        ) : null}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              {selected ? (
+                <CardBody className="flex flex-wrap gap-1.5 border-t border-[var(--color-border)]">
                   <Button
                     variant="ghost"
                     size="sm"
-                    className="text-[var(--color-danger)]"
-                    onClick={() => {
-                      setDeleteError(null);
-                      setPendingDelete({ id: selected.id, name: selected.name });
-                    }}
+                    onClick={() => openRename(selected.id, selected.name)}
                   >
-                    <Trash2 size={14} /> Delete
+                    Rename
                   </Button>
-                </>
+                  {!selected.isDefault ? (
+                    <>
+                      <Button variant="ghost" size="sm" onClick={() => makeDefault(selected.id)}>
+                        <Star size={14} /> Make default
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="text-[var(--color-danger)]"
+                        onClick={() => {
+                          setDeleteError(null);
+                          setPendingDelete({ id: selected.id, name: selected.name });
+                        }}
+                      >
+                        <Trash2 size={14} /> Delete
+                      </Button>
+                    </>
+                  ) : null}
+                </CardBody>
               ) : null}
-            </div>
-          ) : null}
-
-          {loading || !detail ? (
-            <div className="py-6">
-              <SkeletonRows rows={5} />
-            </div>
-          ) : (
-            <AvailabilityEditor key={selectedId} scheduleId={selectedId} initial={detail} />
-          )}
-        </div>
-      </div>
+            </Card>
+          }
+        />
+      )}
 
       <Dialog
         open={promptOpen}


### PR DESCRIPTION
Availability page cleanup (from the screenshot feedback).

1. **Too many focus messages** — `FocusDefense` capped to the 2 nearest unprotected blocks (it was rendering one suggestion per day = a wall).
2. **Working-hours layout reshuffle** — now two columns:
   - **Left (main):** Weekly hours + one sticky Save.
   - **Right (side panel):** schedule switcher (list + New + rename/make-default/delete), then Timezone, then Date overrides.
   `AvailabilityEditor` gained a `sidebar` slot; `SchedulesManager` passes the switcher into it.

Verified: typecheck clean, 85 tests, biome clean (UI is auth-gated so not eyeballed live).