### PR TITLE
feat: meetings-first dashboard, poll/routing delete, booking links, cancel/reschedule reasons, calendar overlay

### DIFF
--- a/apps/web/app/(app)/dashboard/page.tsx
+++ b/apps/web/app/(app)/dashboard/page.tsx
@@ -155,6 +155,57 @@ export default async function DashboardPage() {
         description="Here's what's on your calendar."
       />
 
+      {/* Meetings first - the thing people open the dashboard to see. */}
+      {inProgress ? (
+        <Card className="mb-6 border-[var(--color-border-strong)] bg-gradient-to-br from-[var(--color-surface-2)] to-[var(--color-surface)]">
+          <div className="flex items-center justify-between gap-3 p-5">
+            <div className="min-w-0">
+              <p className="inline-flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-[var(--color-accent)]">
+                <Radio size={13} /> Happening now
+              </p>
+              <p className="mt-1 truncate text-lg font-semibold">{inProgress.title}</p>
+              <p className="mt-0.5 text-sm text-[var(--color-muted)]">
+                until {DateTime.fromJSDate(inProgress.endsAt).setZone(tz).toFormat("h:mm a")}
+                {nextAfterInProgress ? " · another meeting right after" : ""}
+              </p>
+            </div>
+            {nextAfterInProgress ? <OverflowButton uid={inProgress.uid} /> : null}
+          </div>
+        </Card>
+      ) : null}
+
+      {next ? (
+        <Card className="mb-6 border-[var(--color-border-strong)] bg-gradient-to-br from-[var(--color-surface-2)] to-[var(--color-surface)]">
+          <div className="flex items-center justify-between p-5">
+            <div>
+              <p className="text-xs font-medium uppercase tracking-wide text-[var(--color-mint)]">
+                Next up
+              </p>
+              <p className="mt-1 text-lg font-semibold">{next.title}</p>
+              <p className="mt-0.5 text-sm text-[var(--color-muted)]">
+                {DateTime.fromJSDate(next.startsAt).setZone(tz).toFormat("cccc, LLL d · h:mm a")} –{" "}
+                {DateTime.fromJSDate(next.endsAt).setZone(tz).toFormat("h:mm a")}
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              {nextIsImminent ? <RunningLateButton uid={next.uid} /> : null}
+              {next.meetingUrl ? (
+                <a
+                  href={next.meetingUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className={buttonVariants({ variant: "primary" })}
+                >
+                  <Video size={16} /> Join
+                </a>
+              ) : null}
+            </div>
+          </div>
+        </Card>
+      ) : null}
+
+      {aiEnabled && next ? <MeetingAssistant uid={next.uid} title={next.title} /> : null}
+
       <SetupChecklist hasCalendar={hasCalendar} hasHours={hasHours} hasEventType={hasEventType} />
       <DashboardTour />
 
@@ -233,56 +284,6 @@ export default async function DashboardPage() {
       </div>
 
       <PendingInvites aiEnabled={aiEnabled} />
-
-      {inProgress ? (
-        <Card className="mb-6 border-[var(--color-border-strong)] bg-gradient-to-br from-[var(--color-surface-2)] to-[var(--color-surface)]">
-          <div className="flex items-center justify-between gap-3 p-5">
-            <div className="min-w-0">
-              <p className="inline-flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-[var(--color-accent)]">
-                <Radio size={13} /> Happening now
-              </p>
-              <p className="mt-1 truncate text-lg font-semibold">{inProgress.title}</p>
-              <p className="mt-0.5 text-sm text-[var(--color-muted)]">
-                until {DateTime.fromJSDate(inProgress.endsAt).setZone(tz).toFormat("h:mm a")}
-                {nextAfterInProgress ? " · another meeting right after" : ""}
-              </p>
-            </div>
-            {nextAfterInProgress ? <OverflowButton uid={inProgress.uid} /> : null}
-          </div>
-        </Card>
-      ) : null}
-
-      {next ? (
-        <Card className="mb-6 border-[var(--color-border-strong)] bg-gradient-to-br from-[var(--color-surface-2)] to-[var(--color-surface)]">
-          <div className="flex items-center justify-between p-5">
-            <div>
-              <p className="text-xs font-medium uppercase tracking-wide text-[var(--color-mint)]">
-                Next up
-              </p>
-              <p className="mt-1 text-lg font-semibold">{next.title}</p>
-              <p className="mt-0.5 text-sm text-[var(--color-muted)]">
-                {DateTime.fromJSDate(next.startsAt).setZone(tz).toFormat("cccc, LLL d · h:mm a")} –{" "}
-                {DateTime.fromJSDate(next.endsAt).setZone(tz).toFormat("h:mm a")}
-              </p>
-            </div>
-            <div className="flex items-center gap-2">
-              {nextIsImminent ? <RunningLateButton uid={next.uid} /> : null}
-              {next.meetingUrl ? (
-                <a
-                  href={next.meetingUrl}
-                  target="_blank"
-                  rel="noreferrer"
-                  className={buttonVariants({ variant: "primary" })}
-                >
-                  <Video size={16} /> Join
-                </a>
-              ) : null}
-            </div>
-          </div>
-        </Card>
-      ) : null}
-
-      {aiEnabled && next ? <MeetingAssistant uid={next.uid} title={next.title} /> : null}
 
       <SectionHeading eyebrow="Agenda" title="Upcoming" />
       {upcoming.length === 0 ? (

--- a/apps/web/app/(app)/polls/page.tsx
+++ b/apps/web/app/(app)/polls/page.tsx
@@ -1,3 +1,4 @@
+import { DeleteRowButton } from "@/components/delete-row-button";
 import { EmptyState, PageHeader } from "@/components/page-header";
 import { buttonVariants } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -33,34 +34,37 @@ export default async function PollsPage() {
       ) : (
         <div className="space-y-3">
           {polls.map((p) => (
-            <Link key={p.id} href={`/polls/${p.id}`}>
-              <Card interactive className="flex items-center justify-between gap-4 p-4">
-                <div className="min-w-0">
-                  <p className="truncate font-medium">{p.title}</p>
-                  <p className="mt-0.5 flex items-center gap-3 text-xs text-[var(--color-muted)]">
-                    <span>{p.options.length} time options</span>
-                    <span className="inline-flex items-center gap-1">
-                      <Users size={12} /> {p.votes.length} votes
-                    </span>
-                  </p>
-                </div>
-                <span
-                  className={
-                    p.status === "finalized"
-                      ? "inline-flex items-center gap-1 rounded-full bg-[var(--color-success)]/15 px-2.5 py-1 text-xs font-medium text-[var(--color-success)]"
-                      : "rounded-full bg-[var(--color-surface-2)] px-2.5 py-1 text-xs font-medium text-[var(--color-muted)]"
-                  }
-                >
-                  {p.status === "finalized" ? (
-                    <>
-                      <CheckCircle2 size={12} /> Finalized
-                    </>
-                  ) : (
-                    "Open"
-                  )}
-                </span>
-              </Card>
-            </Link>
+            <div key={p.id} className="flex items-center gap-2">
+              <Link href={`/polls/${p.id}`} className="min-w-0 flex-1">
+                <Card interactive className="flex items-center justify-between gap-4 p-4">
+                  <div className="min-w-0">
+                    <p className="truncate font-medium">{p.title}</p>
+                    <p className="mt-0.5 flex items-center gap-3 text-xs text-[var(--color-muted)]">
+                      <span>{p.options.length} time options</span>
+                      <span className="inline-flex items-center gap-1">
+                        <Users size={12} /> {p.votes.length} votes
+                      </span>
+                    </p>
+                  </div>
+                  <span
+                    className={
+                      p.status === "finalized"
+                        ? "inline-flex items-center gap-1 rounded-full bg-[var(--color-success)]/15 px-2.5 py-1 text-xs font-medium text-[var(--color-success)]"
+                        : "rounded-full bg-[var(--color-surface-2)] px-2.5 py-1 text-xs font-medium text-[var(--color-muted)]"
+                    }
+                  >
+                    {p.status === "finalized" ? (
+                      <>
+                        <CheckCircle2 size={12} /> Finalized
+                      </>
+                    ) : (
+                      "Open"
+                    )}
+                  </span>
+                </Card>
+              </Link>
+              <DeleteRowButton endpoint={`/api/polls/${p.id}`} label="poll" />
+            </div>
           ))}
         </div>
       )}

--- a/apps/web/app/(app)/routing/page.tsx
+++ b/apps/web/app/(app)/routing/page.tsx
@@ -1,3 +1,4 @@
+import { DeleteRowButton } from "@/components/delete-row-button";
 import { EmptyState, PageHeader } from "@/components/page-header";
 import { buttonVariants } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -33,31 +34,34 @@ export default async function RoutingPage() {
       ) : (
         <div className="space-y-3">
           {forms.map((f) => (
-            <Link key={f.id} href={`/routing/${f.id}`}>
-              <Card interactive className="flex items-center justify-between gap-4 p-4">
-                <div className="min-w-0">
-                  <p className="flex items-center gap-2 truncate font-medium">
-                    <Split size={15} className="shrink-0 text-[var(--color-accent)]" />
-                    {f.title}
-                  </p>
-                  <p className="mt-0.5 flex items-center gap-3 text-xs text-[var(--color-muted)]">
-                    <span>{f.routes.length} rules</span>
-                    <span className="inline-flex items-center gap-1">
-                      <Users size={12} /> {f.responses.length} responses
-                    </span>
-                  </p>
-                </div>
-                <span
-                  className={
-                    f.isActive
-                      ? "rounded-full bg-[var(--color-success)]/15 px-2.5 py-1 text-xs font-medium text-[var(--color-success)]"
-                      : "rounded-full bg-[var(--color-surface-2)] px-2.5 py-1 text-xs font-medium text-[var(--color-muted)]"
-                  }
-                >
-                  {f.isActive ? "Live" : "Draft"}
-                </span>
-              </Card>
-            </Link>
+            <div key={f.id} className="flex items-center gap-2">
+              <Link href={`/routing/${f.id}`} className="min-w-0 flex-1">
+                <Card interactive className="flex items-center justify-between gap-4 p-4">
+                  <div className="min-w-0">
+                    <p className="flex items-center gap-2 truncate font-medium">
+                      <Split size={15} className="shrink-0 text-[var(--color-accent)]" />
+                      {f.title}
+                    </p>
+                    <p className="mt-0.5 flex items-center gap-3 text-xs text-[var(--color-muted)]">
+                      <span>{f.routes.length} rules</span>
+                      <span className="inline-flex items-center gap-1">
+                        <Users size={12} /> {f.responses.length} responses
+                      </span>
+                    </p>
+                  </div>
+                  <span
+                    className={
+                      f.isActive
+                        ? "rounded-full bg-[var(--color-success)]/15 px-2.5 py-1 text-xs font-medium text-[var(--color-success)]"
+                        : "rounded-full bg-[var(--color-surface-2)] px-2.5 py-1 text-xs font-medium text-[var(--color-muted)]"
+                    }
+                  >
+                    {f.isActive ? "Live" : "Draft"}
+                  </span>
+                </Card>
+              </Link>
+              <DeleteRowButton endpoint={`/api/routing/${f.id}`} label="form" />
+            </div>
           ))}
         </div>
       )}

--- a/apps/web/app/api/bookings/[uid]/reschedule/route.ts
+++ b/apps/web/app/api/bookings/[uid]/reschedule/route.ts
@@ -4,7 +4,10 @@ import { z } from "zod";
 
 export const dynamic = "force-dynamic";
 
-const schema = z.object({ start: z.string().datetime() });
+const schema = z.object({
+  start: z.string().datetime(),
+  reason: z.string().max(500).optional(),
+});
 
 export async function POST(request: Request, { params }: { params: Promise<{ uid: string }> }) {
   const { uid } = await params;
@@ -14,7 +17,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ uid
   }
 
   try {
-    await rescheduleBooking(uid, parsed.data.start);
+    await rescheduleBooking(uid, parsed.data.start, parsed.data.reason?.trim() || undefined);
     return NextResponse.json({ ok: true, url: `/booking/${uid}` });
   } catch (err) {
     if (err instanceof RescheduleError) {

--- a/apps/web/app/api/bookings/range/route.ts
+++ b/apps/web/app/api/bookings/range/route.ts
@@ -1,5 +1,5 @@
 import { jsonError, withUser } from "@/lib/server/http";
-import { and, asc, eq, getDb, gte, lt, ne, schema } from "@dayotter/db";
+import { and, asc, eq, getDb, gte, inArray, lt, ne, schema } from "@dayotter/db";
 import { NextResponse } from "next/server";
 
 export const dynamic = "force-dynamic";
@@ -36,6 +36,37 @@ export const GET = withUser(async (u, request) => {
     },
   });
 
+  // Also surface the host's real (synced) calendar events, so the calendar shows
+  // their whole schedule - not just DayOtter bookings. Busy, non-all-day only.
+  const conns = await getDb().query.calendarConnections.findMany({
+    where: eq(schema.calendarConnections.userId, u.id),
+    with: { calendars: { columns: { id: true, checkForConflicts: true } } },
+  });
+  const calIds = conns
+    .flatMap((c) => c.calendars)
+    .filter((c) => c.checkForConflicts)
+    .map((c) => c.id);
+
+  let events: { title: string; startsAt: string; endsAt: string }[] = [];
+  if (calIds.length > 0) {
+    const evRows = await getDb().query.calendarEvents.findMany({
+      where: and(
+        inArray(schema.calendarEvents.calendarId, calIds),
+        gte(schema.calendarEvents.endsAt, start),
+        lt(schema.calendarEvents.startsAt, end),
+        ne(schema.calendarEvents.transparency, "transparent"),
+        eq(schema.calendarEvents.allDay, false),
+      ),
+      columns: { title: true, startsAt: true, endsAt: true },
+      limit: 500,
+    });
+    events = evRows.map((e) => ({
+      title: e.title ?? "Busy",
+      startsAt: e.startsAt.toISOString(),
+      endsAt: e.endsAt.toISOString(),
+    }));
+  }
+
   return NextResponse.json({
     bookings: rows.map((b) => ({
       uid: b.uid,
@@ -46,5 +77,6 @@ export const GET = withUser(async (u, request) => {
       color: b.eventType?.color ?? null,
       attendees: b.attendees.map((a) => a.name ?? a.email),
     })),
+    events,
   });
 });

--- a/apps/web/app/api/polls/[id]/route.ts
+++ b/apps/web/app/api/polls/[id]/route.ts
@@ -1,0 +1,12 @@
+import { deletePoll } from "@/lib/polls/polls";
+import { jsonError, withUser } from "@/lib/server/http";
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export const DELETE = withUser(async (u, _request, ctx: { params: Promise<{ id: string }> }) => {
+  const { id } = await ctx.params;
+  const ok = await deletePoll(id, u.id);
+  if (!ok) return jsonError("Poll not found", 404);
+  return NextResponse.json({ ok: true });
+});

--- a/apps/web/app/api/routing/[id]/route.ts
+++ b/apps/web/app/api/routing/[id]/route.ts
@@ -1,4 +1,4 @@
-import { RoutingError, updateForm } from "@/lib/routing/routing";
+import { RoutingError, deleteForm, updateForm } from "@/lib/routing/routing";
 import { jsonError, withUser } from "@/lib/server/http";
 import { NextResponse } from "next/server";
 import { z } from "zod";
@@ -47,4 +47,11 @@ export const PUT = withUser(async (u, request, ctx: { params: Promise<{ id: stri
     if (err instanceof RoutingError) return jsonError(err.message, err.status);
     throw err;
   }
+});
+
+export const DELETE = withUser(async (u, _request, ctx: { params: Promise<{ id: string }> }) => {
+  const { id } = await ctx.params;
+  const ok = await deleteForm(id, u.id);
+  if (!ok) return jsonError("Form not found", 404);
+  return NextResponse.json({ ok: true });
 });

--- a/apps/web/components/bookings-calendar.tsx
+++ b/apps/web/components/bookings-calendar.tsx
@@ -21,6 +21,17 @@ interface CalBooking {
   attendees: string[];
 }
 
+interface CalEvent {
+  title: string;
+  startsAt: string;
+  endsAt: string;
+}
+
+/** A calendar cell item: a DayOtter booking, or a synced "busy" calendar event. */
+type CalItem =
+  | ({ kind: "booking"; id: string } & CalBooking)
+  | ({ kind: "busy"; id: string } & CalEvent);
+
 type View = "month" | "week" | "agenda";
 const VIEWS: { value: View; label: string }[] = [
   { value: "month", label: "Month" },
@@ -46,6 +57,7 @@ export function BookingsCalendar({ tz }: { tz: string }) {
   const [view, setView] = useState<View>("month");
   const [anchor, setAnchor] = useState<DateTime>(() => DateTime.now().setZone(tz).startOf("day"));
   const [bookings, setBookings] = useState<CalBooking[]>([]);
+  const [events, setEvents] = useState<CalEvent[]>([]);
   const [loading, setLoading] = useState(true);
 
   // The visible range for the current view.
@@ -75,25 +87,41 @@ export function BookingsCalendar({ tz }: { tz: string }) {
     });
     fetch(`/api/bookings/range?${qs}`)
       .then((r) => r.json())
-      .then((d) => active && setBookings(d.bookings ?? []))
-      .catch(() => active && setBookings([]))
+      .then((d) => {
+        if (!active) return;
+        setBookings(d.bookings ?? []);
+        setEvents(d.events ?? []);
+      })
+      .catch(() => {
+        if (!active) return;
+        setBookings([]);
+        setEvents([]);
+      })
       .finally(() => active && setLoading(false));
     return () => {
       active = false;
     };
   }, [rangeStart, rangeEnd]);
 
-  // Group bookings by local day for the grid views.
+  // Group bookings + synced calendar events by local day for the grid views.
   const byDay = useMemo(() => {
-    const map = new Map<string, CalBooking[]>();
-    for (const b of bookings) {
-      const key = localKey(b.startsAt, tz);
+    const map = new Map<string, CalItem[]>();
+    const add = (item: CalItem) => {
+      const key = localKey(item.startsAt, tz);
       const list = map.get(key);
-      if (list) list.push(b);
-      else map.set(key, [b]);
-    }
+      if (list) list.push(item);
+      else map.set(key, [item]);
+    };
+    const bookingStarts = new Set(bookings.map((b) => b.startsAt));
+    for (const b of bookings) add({ kind: "booking", id: b.uid, ...b });
+    events.forEach((e, i) => {
+      // Skip an event that's a DayOtter booking's own calendar mirror.
+      if (bookingStarts.has(e.startsAt)) return;
+      add({ kind: "busy", id: `busy:${i}`, ...e });
+    });
+    for (const list of map.values()) list.sort((a, b) => a.startsAt.localeCompare(b.startsAt));
     return map;
-  }, [bookings, tz]);
+  }, [bookings, events, tz]);
 
   function step(dir: 1 | -1) {
     if (view === "month") setAnchor((a) => a.plus({ months: dir }));
@@ -177,16 +205,69 @@ export function BookingsCalendar({ tz }: { tz: string }) {
   );
 }
 
-function EventChip({ b, tz }: { b: CalBooking; tz: string }) {
-  const time = DateTime.fromISO(b.startsAt).setZone(tz).toFormat("h:mm a");
+function EventChip({ item, tz }: { item: CalItem; tz: string }) {
+  const time = DateTime.fromISO(item.startsAt).setZone(tz).toFormat("h:mm a");
+  // Synced calendar event: greyed, non-clickable "busy" block for context.
+  if (item.kind === "busy") {
+    return (
+      <div
+        title="From a connected calendar"
+        className="flex items-center gap-1.5 rounded-sm border-l-[3px] border-[var(--color-border-strong)] bg-[var(--color-surface-2)]/60 px-1.5 py-0.5 text-xs text-[var(--color-muted)]"
+      >
+        <span className="shrink-0 text-[var(--color-faint)]">{time}</span>
+        <span className="truncate">{item.title}</span>
+      </div>
+    );
+  }
   return (
     <Link
-      href={`/booking/${b.uid}`}
+      href={`/booking/${item.uid}`}
       className="flex items-center gap-1.5 rounded-sm px-1.5 py-0.5 text-xs hover:bg-[var(--color-surface-2)]"
-      style={{ borderLeft: `3px solid ${eventColorVar(b.color)}` }}
+      style={{ borderLeft: `3px solid ${eventColorVar(item.color)}` }}
     >
       <span className="shrink-0 text-[var(--color-faint)]">{time}</span>
-      <span className={cn("truncate", b.status === "pending" && "italic")}>{b.title}</span>
+      <span className={cn("truncate", item.status === "pending" && "italic")}>{item.title}</span>
+    </Link>
+  );
+}
+
+function AgendaRow({ item, tz }: { item: CalItem; tz: string }) {
+  const time = DateTime.fromISO(item.startsAt).setZone(tz).toFormat("h:mm a");
+  if (item.kind === "busy") {
+    return (
+      <div
+        title="From a connected calendar"
+        className="flex items-center gap-3 rounded-md border border-dashed border-[var(--color-border)] bg-[var(--color-surface-2)]/50 px-3 py-2"
+      >
+        <span
+          aria-hidden
+          className="h-8 w-1 shrink-0 rounded-full bg-[var(--color-border-strong)]"
+        />
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium text-[var(--color-muted)]">{item.title}</p>
+          <p className="truncate text-xs text-[var(--color-faint)]">Busy · from your calendar</p>
+        </div>
+        <p className="shrink-0 text-xs text-[var(--color-muted)]">{time}</p>
+      </div>
+    );
+  }
+  return (
+    <Link
+      href={`/booking/${item.uid}`}
+      className="flex items-center gap-3 rounded-md border border-[var(--color-border)] px-3 py-2 hover:border-[var(--color-border-strong)]"
+    >
+      <span
+        aria-hidden
+        className="h-8 w-1 shrink-0 rounded-full"
+        style={{ backgroundColor: eventColorVar(item.color) }}
+      />
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium">{item.title}</p>
+        <p className="truncate text-xs text-[var(--color-muted)]">
+          {item.attendees.join(", ") || "No attendees"}
+        </p>
+      </div>
+      <p className="shrink-0 text-xs text-[var(--color-muted)]">{time}</p>
     </Link>
   );
 }
@@ -199,7 +280,7 @@ function MonthGrid({
 }: {
   rangeStart: DateTime;
   anchor: DateTime;
-  byDay: Map<string, CalBooking[]>;
+  byDay: Map<string, CalItem[]>;
   tz: string;
 }) {
   const today = DateTime.now().setZone(tz).toFormat("yyyy-LL-dd");
@@ -246,8 +327,8 @@ function MonthGrid({
                 {day.day}
               </div>
               <div className="space-y-0.5">
-                {evs.slice(0, 3).map((b) => (
-                  <EventChip key={b.uid} b={b} tz={tz} />
+                {evs.slice(0, 3).map((it) => (
+                  <EventChip key={it.id} item={it} tz={tz} />
                 ))}
                 {evs.length > 3 ? (
                   <p className="px-1.5 text-xs text-[var(--color-faint)]">+{evs.length - 3} more</p>
@@ -267,7 +348,7 @@ function WeekGrid({
   tz,
 }: {
   rangeStart: DateTime;
-  byDay: Map<string, CalBooking[]>;
+  byDay: Map<string, CalItem[]>;
   tz: string;
 }) {
   const today = DateTime.now().setZone(tz).toFormat("yyyy-LL-dd");
@@ -294,7 +375,7 @@ function WeekGrid({
               {evs.length === 0 ? (
                 <p className="text-xs text-[var(--color-faint)]">-</p>
               ) : (
-                evs.map((b) => <EventChip key={b.uid} b={b} tz={tz} />)
+                evs.map((it) => <EventChip key={it.id} item={it} tz={tz} />)
               )}
             </div>
           </div>
@@ -312,7 +393,7 @@ function Agenda({
 }: {
   rangeStart: DateTime;
   rangeEnd: DateTime;
-  byDay: Map<string, CalBooking[]>;
+  byDay: Map<string, CalItem[]>;
   tz: string;
 }) {
   const days: DateTime[] = [];
@@ -335,27 +416,8 @@ function Agenda({
             <p className="text-xs text-[var(--color-muted)]">{day.toFormat("LLL d")}</p>
           </div>
           <div className="flex-1 space-y-1.5">
-            {(byDay.get(day.toFormat("yyyy-LL-dd")) ?? []).map((b) => (
-              <Link
-                key={b.uid}
-                href={`/booking/${b.uid}`}
-                className="flex items-center gap-3 rounded-md border border-[var(--color-border)] px-3 py-2 hover:border-[var(--color-border-strong)]"
-              >
-                <span
-                  aria-hidden
-                  className="h-8 w-1 shrink-0 rounded-full"
-                  style={{ backgroundColor: eventColorVar(b.color) }}
-                />
-                <div className="min-w-0 flex-1">
-                  <p className="truncate text-sm font-medium">{b.title}</p>
-                  <p className="truncate text-xs text-[var(--color-muted)]">
-                    {b.attendees.join(", ") || "No attendees"}
-                  </p>
-                </div>
-                <p className="shrink-0 text-xs text-[var(--color-muted)]">
-                  {DateTime.fromISO(b.startsAt).setZone(tz).toFormat("h:mm a")}
-                </p>
-              </Link>
+            {(byDay.get(day.toFormat("yyyy-LL-dd")) ?? []).map((it) => (
+              <AgendaRow key={it.id} item={it} tz={tz} />
             ))}
           </div>
         </div>

--- a/apps/web/components/bookings-workspace.tsx
+++ b/apps/web/components/bookings-workspace.tsx
@@ -6,6 +6,7 @@ import { Card } from "@/components/ui/card";
 import { eventColorVar } from "@/lib/booking/event-type-input";
 import { cn } from "@/lib/cn";
 import { DateTime } from "luxon";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 export interface HistoryBooking {
@@ -125,7 +126,9 @@ export function BookingsWorkspace({ tz, history }: { tz: string; history: Histor
 }
 
 function HistoryRow({ b, tz }: { b: HistoryBooking; tz: string }) {
+  const router = useRouter();
   const [status, setStatus] = useState(b.status);
+  const open = () => router.push(`/booking/${b.uid}`);
   const isPast = new Date(b.endsAt).getTime() < Date.now();
   // Past meetings auto-complete, so the no-show toggle covers confirmed/completed/no_show.
   const canMark =
@@ -144,7 +147,19 @@ function HistoryRow({ b, tz }: { b: HistoryBooking; tz: string }) {
   }
 
   return (
-    <Card className="flex items-center gap-4 px-4 py-3">
+    <Card
+      interactive
+      role="link"
+      tabIndex={0}
+      onClick={open}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          open();
+        }
+      }}
+      className="flex cursor-pointer items-center gap-4 px-4 py-3"
+    >
       <span
         aria-hidden
         className="h-9 w-1 shrink-0 rounded-full"
@@ -165,7 +180,10 @@ function HistoryRow({ b, tz }: { b: HistoryBooking; tz: string }) {
       {canMark ? (
         <button
           type="button"
-          onClick={toggleNoShow}
+          onClick={(e) => {
+            e.stopPropagation();
+            toggleNoShow();
+          }}
           className="shrink-0 text-xs text-[var(--color-muted)] hover:text-[var(--color-text)]"
         >
           {status === "no_show" ? "Undo" : "No-show"}

--- a/apps/web/components/cancel-button.tsx
+++ b/apps/web/components/cancel-button.tsx
@@ -9,6 +9,7 @@ export function CancelButton({ uid }: { uid: string }) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [reason, setReason] = useState("");
 
   async function cancel() {
     setLoading(true);
@@ -16,7 +17,7 @@ export function CancelButton({ uid }: { uid: string }) {
     const res = await fetch(`/api/bookings/${uid}/cancel`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({}),
+      body: JSON.stringify({ reason: reason.trim() || undefined }),
     });
     if (!res.ok) {
       setLoading(false);
@@ -28,7 +29,21 @@ export function CancelButton({ uid }: { uid: string }) {
   }
 
   return (
-    <div>
+    <div className="space-y-3">
+      <div>
+        <label htmlFor="cancel-reason" className="mb-1.5 block text-sm font-medium">
+          Reason <span className="font-normal text-[var(--color-faint)]">(optional)</span>
+        </label>
+        <textarea
+          id="cancel-reason"
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          rows={3}
+          maxLength={500}
+          placeholder="Add a note - it's included in the cancellation email everyone gets."
+          className="w-full rounded-md border border-[var(--color-border-strong)] bg-[var(--color-bg)] px-3 py-2 text-sm text-[var(--color-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+        />
+      </div>
       <Button variant="danger" className="w-full" onClick={cancel} disabled={loading}>
         {loading ? "Cancelling…" : "Yes, cancel this booking"}
       </Button>

--- a/apps/web/components/delete-row-button.tsx
+++ b/apps/web/components/delete-row-button.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { ConfirmDialog } from "@/components/ui/dialog";
+import { Trash2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+/** Small trash button + confirm dialog that DELETEs `endpoint` and refreshes.
+ *  Rendered as a sibling of the row's Link (never nested inside an anchor). */
+export function DeleteRowButton({ endpoint, label }: { endpoint: string; label: string }) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  async function del() {
+    setBusy(true);
+    const res = await fetch(endpoint, { method: "DELETE" });
+    setBusy(false);
+    setOpen(false);
+    if (res.ok) router.refresh();
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label={`Delete ${label}`}
+        onClick={() => setOpen(true)}
+        className="shrink-0 rounded-md p-2 text-[var(--color-faint)] transition-colors hover:bg-[var(--color-surface-2)] hover:text-[var(--color-danger)]"
+      >
+        <Trash2 size={16} />
+      </button>
+      <ConfirmDialog
+        open={open}
+        onClose={() => setOpen(false)}
+        onConfirm={del}
+        title={`Delete ${label}?`}
+        description="This can't be undone."
+        confirmLabel="Delete"
+        danger
+        loading={busy}
+      />
+    </>
+  );
+}

--- a/apps/web/components/reschedule-widget.tsx
+++ b/apps/web/components/reschedule-widget.tsx
@@ -14,6 +14,7 @@ export function RescheduleWidget({ uid, eventTypeId }: { uid: string; eventTypeI
   const [selected, setSelected] = useState<Slot | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [reason, setReason] = useState("");
 
   async function confirm() {
     if (!selected) return;
@@ -22,7 +23,7 @@ export function RescheduleWidget({ uid, eventTypeId }: { uid: string; eventTypeI
     const res = await fetch(`/api/bookings/${uid}/reschedule`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ start: selected.start }),
+      body: JSON.stringify({ start: selected.start, reason: reason.trim() || undefined }),
     });
     if (!res.ok) {
       const data = await res.json().catch(() => ({}));
@@ -51,6 +52,20 @@ export function RescheduleWidget({ uid, eventTypeId }: { uid: string; eventTypeI
           {DateTime.fromISO(selected.start).setZone(zone).toFormat("cccc, LLLL d 'at' h:mm a")}
         </span>
         <span className="text-[var(--color-muted)]"> · {zone}</span>
+      </div>
+      <div className="mb-4">
+        <label htmlFor="reschedule-reason" className="mb-1.5 block text-sm font-medium">
+          Reason <span className="font-normal text-[var(--color-faint)]">(optional)</span>
+        </label>
+        <textarea
+          id="reschedule-reason"
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          rows={3}
+          maxLength={500}
+          placeholder="Add a note - it's included in the reschedule email everyone gets."
+          className="w-full rounded-md border border-[var(--color-border-strong)] bg-[var(--color-bg)] px-3 py-2 text-sm text-[var(--color-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+        />
       </div>
       <FormError>{error}</FormError>
       <Button className="w-full" onClick={confirm} disabled={submitting}>

--- a/apps/web/lib/booking/cancel-booking.ts
+++ b/apps/web/lib/booking/cancel-booking.ts
@@ -119,6 +119,7 @@ export async function cancelBooking(uid: string, reason?: string): Promise<boole
             hostName: booking.host?.name ?? "your host",
             attendeeName: a.name ?? a.email,
             manageUrl: `${process.env.APP_URL ?? "http://localhost:3000"}/booking/${uid}`,
+            reason: reason ?? null,
           }),
           to: a.email,
         }),

--- a/apps/web/lib/booking/reschedule-booking.ts
+++ b/apps/web/lib/booking/reschedule-booking.ts
@@ -25,7 +25,11 @@ export class RescheduleError extends Error {
 
 /** Move a booking to a new start time: validate, update, move the calendar event,
  * reschedule reminders, and notify attendees. */
-export async function rescheduleBooking(uid: string, newStartISO: string): Promise<void> {
+export async function rescheduleBooking(
+  uid: string,
+  newStartISO: string,
+  reason?: string,
+): Promise<void> {
   const db = getDb();
 
   const booking = await db.query.bookings.findFirst({
@@ -171,6 +175,7 @@ export async function rescheduleBooking(uid: string, newStartISO: string): Promi
             meetingUrl: meetingUrl ?? booking.meetingUrl ?? undefined,
             location: eventType.locationDetail ?? undefined,
             manageUrl: `${appUrl}/booking/${uid}`,
+            reason: reason ?? null,
           }),
           to: r.email,
         }),

--- a/apps/web/lib/polls/polls.ts
+++ b/apps/web/lib/polls/polls.ts
@@ -87,6 +87,15 @@ export async function getPollForHost(pollId: string, hostId: string) {
 }
 
 /** List a host's polls (newest first) with lightweight counts. */
+/** Delete a poll (ownership-checked). Options + votes cascade. */
+export async function deletePoll(pollId: string, hostId: string): Promise<boolean> {
+  const rows = await getDb()
+    .delete(schema.meetingPolls)
+    .where(and(eq(schema.meetingPolls.id, pollId), eq(schema.meetingPolls.hostId, hostId)))
+    .returning({ id: schema.meetingPolls.id });
+  return rows.length > 0;
+}
+
 export async function listPolls(hostId: string) {
   return getDb().query.meetingPolls.findMany({
     where: eq(schema.meetingPolls.hostId, hostId),

--- a/apps/web/lib/routing/routing.ts
+++ b/apps/web/lib/routing/routing.ts
@@ -100,6 +100,15 @@ export async function updateForm(
 }
 
 /** Public: the active form for the voting/booking page. */
+/** Delete a form (ownership-checked). Responses cascade. */
+export async function deleteForm(id: string, hostId: string): Promise<boolean> {
+  const rows = await getDb()
+    .delete(schema.routingForms)
+    .where(and(eq(schema.routingForms.id, id), eq(schema.routingForms.hostId, hostId)))
+    .returning({ id: schema.routingForms.id });
+  return rows.length > 0;
+}
+
 export async function getFormByToken(token: string) {
   const form = await getDb().query.routingForms.findFirst({
     where: eq(schema.routingForms.token, token),

--- a/packages/emails/src/templates.ts
+++ b/packages/emails/src/templates.ts
@@ -12,6 +12,8 @@ export interface BookingEmailData {
   meetingUrl?: string;
   /** Public link to view / cancel / reschedule the booking. */
   manageUrl: string;
+  /** Optional host-written note shown on cancel/reschedule emails. */
+  reason?: string | null;
 }
 
 interface Rendered {
@@ -127,15 +129,17 @@ export function bookingRescheduled(d: BookingEmailData): Rendered {
     : d.location
       ? `Location: ${d.location}`
       : "";
+  const note = d.reason ? `Reason: ${d.reason}` : "";
   return {
     subject: `Rescheduled: ${d.eventTitle} - ${DateTime.fromJSDate(d.start).setZone(d.timezone).toFormat("LLL d, h:mm a")}`,
-    text: `Your booking has been moved to a new time.\n\n${d.eventTitle} with ${d.hostName}\nNew time: ${when}\n${where}\n\nManage: ${d.manageUrl}`,
+    text: `Your booking has been moved to a new time.\n\n${d.eventTitle} with ${d.hostName}\nNew time: ${when}\n${where}${note ? `\n\n${note}` : ""}\n\nManage: ${d.manageUrl}`,
     html: shell(
       "Your booking was rescheduled",
       [
         `<strong>${esc(d.eventTitle)}</strong> with ${esc(d.hostName)} has a new time:`,
         `🗓 ${when}`,
         where ? `📍 ${esc(where)}` : "",
+        note ? `💬 ${esc(note)}` : "",
       ].filter(Boolean),
       { label: "View booking", url: d.manageUrl },
     ),
@@ -173,13 +177,18 @@ export function bookingMessage(d: BookingEmailData & { body: string }): Rendered
 }
 
 export function bookingCancellation(d: BookingEmailData): Rendered {
+  const note = d.reason ? `Reason: ${d.reason}` : "";
   return {
     subject: `Cancelled: ${d.eventTitle} - ${DateTime.fromJSDate(d.start).setZone(d.timezone).toFormat("LLL d, h:mm a")}`,
-    text: `This booking has been cancelled.\n\n${d.eventTitle} with ${d.hostName}\nWas: ${fmt(d.start, d.timezone)}`,
-    html: shell("Booking cancelled", [
-      `<strong>${esc(d.eventTitle)}</strong> with ${esc(d.hostName)} has been cancelled.`,
-      `Was: ${fmt(d.start, d.timezone)}`,
-    ]),
+    text: `This booking has been cancelled.\n\n${d.eventTitle} with ${d.hostName}\nWas: ${fmt(d.start, d.timezone)}${note ? `\n\n${note}` : ""}`,
+    html: shell(
+      "Booking cancelled",
+      [
+        `<strong>${esc(d.eventTitle)}</strong> with ${esc(d.hostName)} has been cancelled.`,
+        `Was: ${fmt(d.start, d.timezone)}`,
+        note ? `💬 ${esc(note)}` : "",
+      ].filter(Boolean),
+    ),
   };
 }
 


### PR DESCRIPTION
Five UX requests.

1. **Dashboard — meetings first.** 'Happening now', 'Next up', and the AI 'send a message' assistant now render at the top, right under the header, whenever there's a meeting.
2. **Delete group polls & routing forms.** New `DELETE /api/polls/[id]` and `DELETE /api/routing/[id]` (+ `deletePoll`/`deleteForm`, ownership-checked, cascade), surfaced via a reusable `DeleteRowButton` on both list pages. (Routing *edit* already exists via the builder page the row links to.)
3. **Booking rows → management page.** Clicking a booking in the Bookings tab now opens `/booking/[uid]`; the no-show button stops propagation.
4. **Cancel/reschedule reasons.** Optional reason on both flows, threaded through the API + lib and shown in the cancellation/reschedule emails everyone receives.
5. **Full-calendar overlay.** The Bookings calendar now also shows the host's real synced calendar events (busy, greyed, non-clickable) across month/week/agenda — the range API returns them, deduped against a booking's own calendar mirror.

Verified: typecheck clean, 85 tests, biome clean. (App is auth-gated so not clicked-through live.)