### PR TITLE
feat: focus protection - hard-decline bookings over the daily meeting cap

### DIFF
--- a/apps/web/components/preferences-form.tsx
+++ b/apps/web/components/preferences-form.tsx
@@ -250,10 +250,11 @@ export function PreferencesForm({
                 className="mt-0.5 accent-[var(--color-accent)]"
               />
               <span>
-                Adaptive availability
+                Focus protection (adaptive availability)
                 <span className="mt-0.5 block text-xs text-[var(--color-faint)]">
-                  On heavy days, stop offering booking slots once you hit your meeting cap - so a
-                  full day doesn't get fuller.
+                  On heavy days, stop offering slots once you hit your meeting cap - and
+                  hard-decline any booking that would push a day over it - so a full day doesn't get
+                  fuller and your focus time is protected.
                 </span>
               </span>
             </label>

--- a/apps/web/lib/booking/create-booking.ts
+++ b/apps/web/lib/booking/create-booking.ts
@@ -177,6 +177,13 @@ export async function createBooking(
 
   const { host, coHostEmails } = await resolveHost(eventType, start, hostIds, perHost);
 
+  // Focus protection: when the host caps their daily meetings, we hard-decline a
+  // booking that would push the day over the limit (see the guard in the tx below).
+  const focusPrefs = await db.query.userPreferences.findFirst({
+    where: eq(schema.userPreferences.userId, host.id),
+    columns: { adaptiveAvailability: true, maxMeetingsPerDay: true },
+  });
+
   const uid = randomUUID();
   const appUrl = process.env.APP_URL ?? "http://localhost:3000";
   const guests = [
@@ -217,6 +224,34 @@ export async function createBooking(
           );
         if (count >= eventType.dailyBookingLimit) {
           throw new BookingError("This day is fully booked. Please pick another day.", 409);
+        }
+      }
+
+      // Focus protection (host-wide cap across all event types). Backstops the
+      // availability-level slot hiding for group events / direct API / races, so
+      // an overloaded day can't be pushed past the host's daily meeting limit.
+      if (!isGroup && focusPrefs?.adaptiveAvailability) {
+        const cap = focusPrefs.maxMeetingsPerDay ?? 5;
+        const zone = host.timezone || "UTC";
+        const day = DateTime.fromJSDate(start).setZone(zone);
+        const dayStart = day.startOf("day").toJSDate();
+        const nextDay = day.startOf("day").plus({ days: 1 }).toJSDate();
+        const [{ count } = { count: 0 }] = await tx
+          .select({ count: sql<number>`count(*)::int` })
+          .from(schema.bookings)
+          .where(
+            and(
+              eq(schema.bookings.hostId, host.id),
+              eq(schema.bookings.status, "confirmed"),
+              gte(schema.bookings.startsAt, dayStart),
+              lt(schema.bookings.startsAt, nextDay),
+            ),
+          );
+        if (count >= cap) {
+          throw new BookingError(
+            "This day is protected for focus and has reached its meeting limit. Please pick another day.",
+            409,
+          );
         }
       }
 


### PR DESCRIPTION
Turns the existing adaptive daily cap into a real guarantee.

- **Availability** already hides slots on days at `maxMeetingsPerDay` (soft). This adds a **hard server-side guard** in `createBooking` (inside the booking transaction): if the host has focus protection on and the target host-local day already holds ≥ cap confirmed bookings across all event types, the booking is declined (409). Backstops group events, direct API calls, and concurrent races the slot-hiding can't catch. Group events (shared slot) are exempt.
- **Preferences**: the toggle is relabeled **'Focus protection (adaptive availability)'** and notes it hard-declines over-limit days — optional, per end user, as requested.

Auto-*reshuffling* existing confirmed meetings is intentionally left to a confirm-first Otter suggestion (silent calendar edits would violate the confirm-first principle).

Verified: typecheck clean, 88 tests, biome clean.