### PR TITLE
fix: recurring-series parity, whole-series cancel + cleanup

### DIFF
--- a/apps/web/app/api/bookings/[uid]/cancel/route.ts
+++ b/apps/web/app/api/bookings/[uid]/cancel/route.ts
@@ -1,4 +1,4 @@
-import { cancelBooking } from "@/lib/booking/cancel-booking";
+import { cancelBooking, cancelBookingSeries } from "@/lib/booking/cancel-booking";
 import { enforceRateLimit } from "@/lib/server/rate-limit";
 import { NextResponse } from "next/server";
 import { z } from "zod";
@@ -7,6 +7,8 @@ export const dynamic = "force-dynamic";
 
 const schema = z.object({
   reason: z.string().max(500).optional(),
+  /** "series" cancels this and every later occurrence of a recurring booking. */
+  scope: z.enum(["one", "series"]).default("one"),
 });
 
 export async function POST(request: Request, { params }: { params: Promise<{ uid: string }> }) {
@@ -23,9 +25,22 @@ export async function POST(request: Request, { params }: { params: Promise<{ uid
 
   const parsed = schema.safeParse(await request.json().catch(() => ({})));
   const reason = parsed.success ? parsed.data.reason?.trim() || undefined : undefined;
+  const scope = parsed.success ? parsed.data.scope : "one";
+
+  if (scope === "series") {
+    const count = await cancelBookingSeries(uid, reason);
+    if (count === 0) {
+      return NextResponse.json(
+        { error: "Booking not found or already cancelled" },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json({ ok: true, cancelled: count });
+  }
+
   const ok = await cancelBooking(uid, reason);
   if (!ok) {
     return NextResponse.json({ error: "Booking not found or already cancelled" }, { status: 404 });
   }
-  return NextResponse.json({ ok: true });
+  return NextResponse.json({ ok: true, cancelled: 1 });
 }

--- a/apps/web/app/booking/[uid]/cancel/page.tsx
+++ b/apps/web/app/booking/[uid]/cancel/page.tsx
@@ -20,6 +20,7 @@ export default async function CancelBookingPage({
   });
   if (!booking) notFound();
   if (booking.status === "cancelled") redirect(`/booking/${uid}`);
+  const isRecurring = Boolean(booking.recurrenceUid);
 
   const when = DateTime.fromJSDate(booking.startsAt)
     .setZone(booking.timezone)
@@ -42,7 +43,7 @@ export default async function CancelBookingPage({
           </div>
 
           <div className="mt-6 space-y-3">
-            <CancelButton uid={uid} />
+            <CancelButton uid={uid} isRecurring={isRecurring} />
             <Link
               href={`/booking/${uid}`}
               className={`${buttonVariants({ variant: "outline" })} w-full`}

--- a/apps/web/components/cancel-button.tsx
+++ b/apps/web/components/cancel-button.tsx
@@ -5,11 +5,12 @@ import { Button } from "@/components/ui/button";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
-export function CancelButton({ uid }: { uid: string }) {
+export function CancelButton({ uid, isRecurring = false }: { uid: string; isRecurring?: boolean }) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [reason, setReason] = useState("");
+  const [wholeSeries, setWholeSeries] = useState(false);
 
   async function cancel() {
     setLoading(true);
@@ -17,7 +18,10 @@ export function CancelButton({ uid }: { uid: string }) {
     const res = await fetch(`/api/bookings/${uid}/cancel`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ reason: reason.trim() || undefined }),
+      body: JSON.stringify({
+        reason: reason.trim() || undefined,
+        scope: isRecurring && wholeSeries ? "series" : "one",
+      }),
     });
     if (!res.ok) {
       setLoading(false);
@@ -44,8 +48,23 @@ export function CancelButton({ uid }: { uid: string }) {
           className="w-full rounded-md border border-[var(--color-border-strong)] bg-[var(--color-bg)] px-3 py-2 text-sm text-[var(--color-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
         />
       </div>
+      {isRecurring ? (
+        <label className="flex items-center gap-2 text-sm text-[var(--color-text)]">
+          <input
+            type="checkbox"
+            checked={wholeSeries}
+            onChange={(e) => setWholeSeries(e.target.checked)}
+            className="h-4 w-4 rounded border-[var(--color-border-strong)] text-[var(--color-accent)] focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+          />
+          Cancel this and all later occurrences
+        </label>
+      ) : null}
       <Button variant="danger" className="w-full" onClick={cancel} disabled={loading}>
-        {loading ? "Cancelling…" : "Yes, cancel this booking"}
+        {loading
+          ? "Cancelling…"
+          : isRecurring && wholeSeries
+            ? "Yes, cancel the whole series"
+            : "Yes, cancel this booking"}
       </Button>
       <FormError>{error}</FormError>
     </div>

--- a/apps/web/components/timezone-sync.tsx
+++ b/apps/web/components/timezone-sync.tsx
@@ -20,6 +20,17 @@ export function TimezoneSync() {
       return;
     }
     if (!tz || tz === "UTC") return;
+
+    // Only POST once per detected zone - the server short-circuits an already-set
+    // zone anyway, so hitting it on every page load is wasted. Re-syncs if the
+    // browser's zone later changes (e.g. the user travels).
+    const KEY = "dayotter:tzsynced";
+    try {
+      if (localStorage.getItem(KEY) === tz) return;
+    } catch {
+      /* storage blocked (private mode) - fall through and just POST. */
+    }
+
     fetch("/api/me/timezone", {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -27,6 +38,11 @@ export function TimezoneSync() {
     })
       .then((r) => r.json())
       .then((d) => {
+        try {
+          localStorage.setItem(KEY, tz);
+        } catch {
+          /* ignore */
+        }
         if (d?.updated) router.refresh();
       })
       .catch(() => {});

--- a/apps/web/lib/ai/llm.ts
+++ b/apps/web/lib/ai/llm.ts
@@ -133,35 +133,5 @@ export async function extract<T>(opts: ExtractOptions<T>): Promise<T> {
   return opts.parse(JSON.parse(text.text) as unknown);
 }
 
-export interface GenerateOptions {
-  system: string;
-  user: string;
-  maxTokens?: number;
-  feature: string;
-  tier?: ModelTier;
-  cacheSystem?: boolean;
-}
-
-/**
- * Generate free-form text. Streams under the hood (so long outputs never hit an
- * HTTP timeout) and returns the concatenated text. Use for drafting where the
- * output is prose rather than a fixed schema.
- */
-export async function generateText(opts: GenerateOptions): Promise<string> {
-  const model = MODELS[opts.tier ?? "deep"];
-  const stream = getClient().messages.stream({
-    model,
-    max_tokens: opts.maxTokens ?? 1024,
-    system: buildSystem(opts.system, opts.cacheSystem !== false),
-    messages: [{ role: "user", content: opts.user }],
-  });
-  const final = await stream.finalMessage();
-  return final.content
-    .filter((b): b is Anthropic.TextBlock => b.type === "text")
-    .map((b) => b.text)
-    .join("")
-    .trim();
-}
-
 /** Re-exported so the agent loop can build tool-use requests against the shared client + tiers. */
 export { getClient as getAnthropicClient };

--- a/apps/web/lib/ai/tools/registry.ts
+++ b/apps/web/lib/ai/tools/registry.ts
@@ -784,9 +784,6 @@ const BY_NAME = new Map(TOOLS.map((t) => [t.name, t]));
 export function getTool(name: string): AiToolDef | undefined {
   return BY_NAME.get(name);
 }
-export const READ_TOOLS = TOOLS.filter((t) => t.kind === "read");
-export const ACTION_TOOLS = TOOLS.filter((t) => t.kind !== "read");
-
 /** Anthropic tool definitions for every registry tool. */
 export function anthropicToolDefs() {
   return TOOLS.map((t) => ({

--- a/apps/web/lib/auth/session.ts
+++ b/apps/web/lib/auth/session.ts
@@ -5,10 +5,3 @@ import { headers } from "next/headers";
 export async function getSession() {
   return auth.api.getSession({ headers: await headers() });
 }
-
-/** Return the authenticated user id or throw - use to gate protected routes. */
-export async function requireUserId(): Promise<string> {
-  const session = await getSession();
-  if (!session?.user?.id) throw new Response("Unauthorized", { status: 401 });
-  return session.user.id;
-}

--- a/apps/web/lib/billing/edition.ts
+++ b/apps/web/lib/billing/edition.ts
@@ -10,7 +10,6 @@
  * runtime user setting - a self-hoster can never accidentally paywall themselves.
  */
 export const isCloud = process.env.DAYOTTER_CLOUD === "1";
-export const isSelfHosted = !isCloud;
 
 /** Monthly per-seat price shown in the UI (USD). Keep in sync with the Stripe price. */
 export const PRO_PRICE_USD = 9;

--- a/apps/web/lib/booking/cancel-booking.ts
+++ b/apps/web/lib/booking/cancel-booking.ts
@@ -1,5 +1,5 @@
 import { logger } from "@dayotter/core";
-import { and, eq, getDb, ne, schema } from "@dayotter/db";
+import { and, eq, getDb, gte, ne, schema } from "@dayotter/db";
 import { bookingCancellation, sendEmail } from "@dayotter/emails";
 import { deleteBookingFromCalendar } from "../calendar/host-calendar";
 import { restoreCredit } from "../packages/credits";
@@ -150,4 +150,39 @@ export async function cancelBooking(uid: string, reason?: string): Promise<boole
   }
 
   return true;
+}
+
+/**
+ * Cancel a booking AND every later occurrence in its recurring series ("this and
+ * following"). Falls back to a single cancel for a non-recurring booking. Each
+ * occurrence is cancelled through the normal path (refund, calendar, emails).
+ * Returns how many bookings were cancelled.
+ */
+export async function cancelBookingSeries(uid: string, reason?: string): Promise<number> {
+  const db = getDb();
+  const target = await db.query.bookings.findFirst({
+    where: eq(schema.bookings.uid, uid),
+    columns: { recurrenceUid: true, startsAt: true },
+  });
+  if (!target) return 0;
+
+  // One-off booking: just cancel it.
+  if (!target.recurrenceUid) return (await cancelBooking(uid, reason)) ? 1 : 0;
+
+  // The target and every later occurrence of the same series, still live.
+  const siblings = await db.query.bookings.findMany({
+    where: and(
+      eq(schema.bookings.recurrenceUid, target.recurrenceUid),
+      ne(schema.bookings.status, "cancelled"),
+      gte(schema.bookings.startsAt, target.startsAt),
+    ),
+    columns: { uid: true },
+    orderBy: schema.bookings.startsAt,
+  });
+
+  let cancelled = 0;
+  for (const s of siblings) {
+    if (await cancelBooking(s.uid, reason)) cancelled++;
+  }
+  return cancelled;
 }

--- a/apps/web/lib/booking/create-booking.ts
+++ b/apps/web/lib/booking/create-booking.ts
@@ -488,18 +488,24 @@ export async function createBooking(
     await db.update(schema.bookings).set({ meetingUrl }).where(eq(schema.bookings.id, booking.id));
   }
 
+  // Host opt-ins (computed once; reused for the recurring occurrences below).
+  const [wantsOverflow, wantsScribe] = await Promise.all([
+    hostWantsOverflowNotice(host.id),
+    hostWantsScribe(host.id),
+  ]);
+
   // Schedule reminders at the host's preferred lead times.
   await scheduleBookingReminders(booking.id, start, await reminderOffsetsForHost(host.id));
 
   // Proactive overflow: if the host opted in, schedule an end-of-meeting check
   // that auto-notifies a back-to-back next meeting when this one runs over.
-  if (await hostWantsOverflowNotice(host.id)) {
+  if (wantsOverflow) {
     await scheduleOverflowCheck(booking.id, end);
   }
 
   // Post-meeting recap ("Scribe"): if the host opted in, nudge them just after
   // the meeting ends to capture notes and line up the next step.
-  if (await hostWantsScribe(host.id)) {
+  if (wantsScribe) {
     await scheduleScribe(booking.id, end);
   }
 
@@ -643,6 +649,58 @@ export async function createBooking(
             externalEventId: written.externalEventId,
           });
         }
+
+        // Parity with the primary booking: each occurrence must also fan out to
+        // webhooks/CRM/plugins and get workflows, overflow, scribe, and travel/
+        // rule blocks - otherwise downstream systems only ever see meeting #1.
+        const occStartISO = occStart.toISOString();
+        const occEndISO = occEnd.toISOString();
+        await fanOutBookingLifecycle(
+          "created",
+          {
+            bookingId: occ.id,
+            uid: occ.uid,
+            hostId: host.id,
+            eventTypeId: eventType.id,
+            title: eventType.title,
+            startsAt: occStartISO,
+            endsAt: occEndISO,
+            attendees: [{ name: input.attendee.name, email: input.attendee.email }],
+          },
+          {
+            uid: occ.uid,
+            eventTypeId: eventType.id,
+            title: eventType.title,
+            startsAt: occStartISO,
+            endsAt: occEndISO,
+            status: occ.status,
+            attendee: { name: input.attendee.name, email: input.attendee.email },
+          },
+        ).catch(() => {});
+        await scheduleWorkflowMessages(
+          occ.id,
+          eventType.organizationId,
+          eventType.id,
+          occStart,
+          occEnd,
+        ).catch(() => {});
+        if (wantsOverflow) await scheduleOverflowCheck(occ.id, occEnd).catch(() => {});
+        if (wantsScribe) await scheduleScribe(occ.id, occEnd).catch(() => {});
+        await applyBookingRules({
+          bookingId: occ.id,
+          hostId: host.id,
+          title: eventType.title,
+          startsAt: occStart,
+          endsAt: occEnd,
+        }).catch(() => {});
+        await reserveTravelBlocks({
+          hostId: host.id,
+          bookingId: occ.id,
+          location: eventType.location,
+          startsAt: occStart,
+          endsAt: occEnd,
+          place: eventType.locationDetail,
+        }).catch(() => {});
       } catch (err) {
         logger.error("recurring occurrence skipped", {
           event: "recurrence_skipped",

--- a/apps/web/lib/integrations/zoom.ts
+++ b/apps/web/lib/integrations/zoom.ts
@@ -134,19 +134,6 @@ async function refreshCredentials(
   return next;
 }
 
-/** True when the user has an active Zoom connection. */
-export async function hasZoomConnection(userId: string): Promise<boolean> {
-  const row = await getDb().query.conferencingConnections.findFirst({
-    where: and(
-      eq(schema.conferencingConnections.userId, userId),
-      eq(schema.conferencingConnections.provider, "zoom"),
-      eq(schema.conferencingConnections.status, "active"),
-    ),
-    columns: { id: true },
-  });
-  return Boolean(row);
-}
-
 /**
  * Create a scheduled Zoom meeting for a booking and return its join URL, or null
  * if the user has no Zoom connection or the API call fails. Best-effort - the

--- a/apps/web/lib/routing/routing.ts
+++ b/apps/web/lib/routing/routing.ts
@@ -164,13 +164,3 @@ export async function submitAndRoute(
 
   return { url: `/${owner.handle}/${target.slug}` };
 }
-
-/** Resolve event-type ids → titles for the builder/results (labels for routes). */
-export async function eventTypeTitles(ids: string[]): Promise<Map<string, string>> {
-  if (ids.length === 0) return new Map();
-  const rows = await getDb().query.eventTypes.findMany({
-    where: inArray(schema.eventTypes.id, ids),
-    columns: { id: true, title: true },
-  });
-  return new Map(rows.map((r) => [r.id, r.title]));
-}

--- a/packages/jobs/src/index.ts
+++ b/packages/jobs/src/index.ts
@@ -41,18 +41,6 @@ export async function pingRedis(): Promise<boolean> {
   }
 }
 
-/** Pending/active/failed counts per queue, for health/metrics. */
-export async function queueDepths(): Promise<
-  Record<string, Awaited<ReturnType<Queue["getJobCounts"]>>>
-> {
-  const [reminders, sync, maintenance] = await Promise.all([
-    remindersQueue.getJobCounts(),
-    syncQueue.getJobCounts(),
-    maintenanceQueue.getJobCounts(),
-  ]);
-  return { reminders, sync, maintenance };
-}
-
 export interface ReminderJob {
   reminderId: string;
   bookingId: string;


### PR DESCRIPTION
Second batch from the audit — the items deferred out of #50. **Stacked on #50** (base is `fix/audit-findings`); merge #50 first. 15/15 packages typecheck; 88 web + 32 core tests pass; Biome clean.

## Recurring-series parity
Occurrences 2..N of a recurring booking previously skipped everything after the calendar write. They now match the primary booking:
- fan out to webhooks / CRM / plugins (`fanOutBookingLifecycle`)
- schedule workflow messages, overflow check, scribe, travel + rule blocks
- host overflow/scribe opt-ins are computed once and reused for all occurrences

## Whole-series cancel
- `cancelBookingSeries(uid, reason)` cancels the target occurrence and every later one in the series (each through the normal refund/calendar/email path).
- Cancel route accepts `scope: "one" | "series"` (default `one`).
- The cancel page shows a **"Cancel this and all later occurrences"** checkbox for recurring bookings.

## Polish
- **timezone-sync**: guarded with `localStorage` so it POSTs once per detected zone (re-syncs if the browser zone later changes) instead of on every page load.
- **Dead code**: removed 8 verified-unused exports — `generateText`/`GenerateOptions`, `hasZoomConnection`, `isSelfHosted`, `requireUserId`, `queueDepths`, `eventTypeTitles`, `READ_TOOLS`, `ACTION_TOOLS`. (`createExpressLoginLink` and `creditBalance` from the earlier list were wired up in #50.)

## Still deliberately deferred (product decisions, not bugs)
- **Whole-series *reschedule*** — semantics are genuinely ambiguous (shift all by the same delta? move to a new weekday/time?), so I left single-occurrence reschedule as-is rather than guess.
- **Per-occurrence availability/cap revalidation** — a recurring event type is expected to land on its fixed cadence; per-occurrence recompute (up to 52×) changes that policy and is a product call. Same-host collisions are still skipped via the DB constraints.
- **`rememberUserFact` wiring** — needs an explicit "remember that…" intent/tool in the AI flow; kept the clean export rather than bolt on a speculative trigger. Derived memory continues to work.
- **Per-currency `WITHDRAW_MINIMUM`** — all six supported currencies are 2-decimal, so `10_000` = 100.00 major units uniformly; the payouts panel now reads "per currency", so no code change was warranted.
