### PR TITLE
chore: prep for public repo (refs, trademark, gitignore, task list)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,10 +9,11 @@ out/
 build/
 *.tsbuildinfo
 
-# env
+# env - ignore every real env file; keep the committed *.example templates.
 .env
-.env.local
-.env.*.local
+.env.*
+!.env.example
+!.env.*.example
 
 # logs
 *.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,8 @@ kind, be constructive.
 - **Report a bug** or **request a feature** → [open an issue](../../issues/new/choose).
 - **Improve docs** - the fastest way to make a first contribution.
 - **Fix a bug** or **build a feature** - grab an issue labelled `good first issue`
-  or `help wanted`, or propose your own (see *Proposing a change* below).
+  or `help wanted`, pick something from the ready-to-start
+  [task list](./docs/TASKS.md), or propose your own (see *Proposing a change* below).
 - **Add to an extensible module** - the AI extractors, time-allocation metrics,
   voice knowledge sources, and reminder kinds are all registry-based; adding one
   is a great first PR. See each module's `README.md`.
@@ -29,7 +30,7 @@ see if it's already planned.
 Requirements: **Node 20+**, **pnpm 10+**, **Docker** (for Postgres + Redis).
 
 ```bash
-git clone https://github.com/nometria/dayotter && cd dayotter
+git clone https://github.com/Dayotter/dayotter && cd dayotter
 docker compose up -d            # Postgres + Redis
 cp .env.example .env            # fill in what you need (most features degrade gracefully without creds)
 pnpm install

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **The AI-native, open-source scheduling platform.**
 Say it once - Otter books the meeting, protects your focus, and clears the back-and-forth. Confirm-first, always.
 
-[Website](https://dayotter.com) · [Docs](./docs) · [Integration setup](./docs/INTEGRATIONS.md) · [Roadmap](./docs/ROADMAP.md) · [AI architecture](./docs/AI.md) · [Contributing](./CONTRIBUTING.md)
+[Website](https://dayotter.com) · [Docs](./docs) · [Integration setup](./docs/INTEGRATIONS.md) · [Roadmap](./docs/ROADMAP.md) · [Good first tasks](./docs/TASKS.md) · [AI architecture](./docs/AI.md) · [Contributing](./CONTRIBUTING.md)
 
 ![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)
 ![Self-hostable](https://img.shields.io/badge/self--hostable-yes-brightgreen)
@@ -106,4 +106,4 @@ We'd love your help - see [`CONTRIBUTING.md`](./CONTRIBUTING.md) for setup, conv
 - **Core:** [GNU AGPLv3](./LICENSE) - free to use, self-host, modify, and share.
 - **`ee/`:** [DayOtter Enterprise Edition License](./apps/web/lib/ee/LICENSE.md) - commercial, cloud-only.
 
-© DayOtter. "Otter" and "DayOtter" are trademarks; the AGPL covers the code, not the brand.
+© DayOtter. The AGPL covers the source code, not the DayOtter name or logo.

--- a/apps/web/app/api/webhooks/microsoft/route.ts
+++ b/apps/web/app/api/webhooks/microsoft/route.ts
@@ -43,8 +43,10 @@ export async function POST(request: Request) {
       continue;
     }
     const meta = sub.metadata as { clientState?: string } | null;
-    // spoof guard (constant-time)
-    if (meta?.clientState && !safeEqual(notif.clientState ?? "", meta.clientState)) {
+    // Spoof guard (constant-time). Fail CLOSED: reject when the stored clientState
+    // is missing too, so a subscription without one can't accept forged
+    // notifications (matches the Google webhook). We always store one at watch time.
+    if (!meta?.clientState || !safeEqual(notif.clientState ?? "", meta.clientState)) {
       logger.warn("ms webhook: clientState mismatch", {
         event: "webhook_rejected",
         reason: "clientState_mismatch",

--- a/apps/web/lib/marketing.ts
+++ b/apps/web/lib/marketing.ts
@@ -6,9 +6,9 @@ export const BRAND = {
   /** Canonical site origin - drives metadataBase, sitemap, canonical URLs, JSON-LD. */
   url: process.env.NEXT_PUBLIC_APP_URL ?? "https://dayotter.com",
   email: "hello@dayotter.com",
-  github: "https://github.com/nometria/dayotter",
-  githubLicense: "https://github.com/nometria/dayotter/blob/main/LICENSE",
-  githubContributing: "https://github.com/nometria/dayotter/blob/main/CONTRIBUTING.md",
+  github: "https://github.com/Dayotter/dayotter",
+  githubLicense: "https://github.com/Dayotter/dayotter/blob/main/LICENSE",
+  githubContributing: "https://github.com/Dayotter/dayotter/blob/main/CONTRIBUTING.md",
   x: "https://x.com/dayotter",
   copyrightYear: 2026,
 };

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -3,8 +3,8 @@
 Self-host the whole platform - web app, background worker, Postgres, Redis, and
 automatic HTTPS - on one server. Three ways in, easiest first.
 
-> Replace `OWNER/dayotter` below with your GitHub repo (or fork) before sharing
-> these links.
+> These links point at `Dayotter/dayotter`. If you're deploying from a fork,
+> swap in your own `OWNER/REPO` first.
 
 ---
 
@@ -12,7 +12,7 @@ automatic HTTPS - on one server. Three ways in, easiest first.
 
 Launches a single EC2 instance that boots the full stack automatically.
 
-[![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://raw.githubusercontent.com/OWNER/dayotter/main/deploy/aws/cloudformation.yaml&stackName=dayotter)
+[![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://raw.githubusercontent.com/Dayotter/dayotter/main/deploy/aws/cloudformation.yaml&stackName=dayotter)
 
 1. Click **Launch Stack** (defaults are fine).
 2. Optionally set **Domain** to a hostname you control for automatic HTTPS -
@@ -38,7 +38,7 @@ adds swap so the build survives on small instances.
 On a fresh box (a VPS, a home server, anything with Docker-able Linux):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/OWNER/dayotter/main/deploy/install.sh \
+curl -fsSL https://raw.githubusercontent.com/Dayotter/dayotter/main/deploy/install.sh \
   | sudo DAYOTTER_DOMAIN=cal.example.com bash
 ```
 

--- a/deploy/aws/cloudformation.yaml
+++ b/deploy/aws/cloudformation.yaml
@@ -26,7 +26,7 @@ Parameters:
       HTTPS. Leave blank to start on plain HTTP at the server's public IP.
   RepoUrl:
     Type: String
-    Default: "https://github.com/OWNER/dayotter.git"
+    Default: "https://github.com/Dayotter/dayotter.git"
     Description: Git repository to deploy (your fork, if you have one).
   InstanceType:
     Type: String

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # One-command dayotter self-host installer.
 #
-#   curl -fsSL https://raw.githubusercontent.com/OWNER/dayotter/main/deploy/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/Dayotter/dayotter/main/deploy/install.sh | bash
 #   - or, from a checkout -
 #   bash deploy/install.sh
 #
@@ -17,7 +17,7 @@
 set -euo pipefail
 
 DAYOTTER_DIR="${DAYOTTER_DIR:-/opt/dayotter}"
-DAYOTTER_REPO_URL="${DAYOTTER_REPO_URL:-https://github.com/OWNER/dayotter.git}"
+DAYOTTER_REPO_URL="${DAYOTTER_REPO_URL:-https://github.com/Dayotter/dayotter.git}"
 DAYOTTER_DOMAIN="${DAYOTTER_DOMAIN:-}"
 
 log() { printf '\033[1;36m==>\033[0m %s\n' "$*"; }

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -13,7 +13,7 @@ free, under AGPLv3. This is the setup guide.
 ## Quick start (local / evaluation)
 
 ```bash
-git clone https://github.com/nometria/dayotter && cd dayotter
+git clone https://github.com/Dayotter/dayotter && cd dayotter
 docker compose up -d            # Postgres + Redis
 cp .env.example .env            # see Configuration below
 pnpm install

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1,0 +1,108 @@
+# Open tasks — help wanted
+
+Concrete, scoped work that's ready to pick up. Each item says **where** to look and
+**what "done" means**, so you can go straight from reading to a PR.
+
+**How to claim one:** comment on (or open) the matching
+[issue](../../issues) so we don't double up, then open a PR that references it.
+For anything larger than a small fix, sketch the approach in the issue first — see
+[CONTRIBUTING](../CONTRIBUTING.md). Forward-looking product direction lives in the
+[Roadmap](./ROADMAP.md); this file is the near-term engineering backlog.
+
+Difficulty: 🟢 good first issue · 🟡 medium · 🔴 involved / needs a design call.
+
+---
+
+## Developer experience
+
+### 🟢 Silence the Redis `ECONNREFUSED` during `next build`
+`packages/jobs/src/index.ts` creates the ioredis client at module load, so `next
+build` (which imports server modules) tries to connect to Redis and logs
+`ECONNREFUSED 127.0.0.1:6379`. The build still succeeds — it's just noise.
+- **Do:** add `lazyConnect: true` to the `new IORedis(...)` options so it connects
+  on first command instead of at import.
+- **Done when:** a clean `pnpm --filter @dayotter/web build` shows no Redis errors,
+  and queues/heartbeat still work at runtime (worker enqueues/consumes).
+
+### 🟢 Add `CONTACT_EMAIL` to the deploy env example
+The contact form (`apps/web/app/api/contact/route.ts`) sends to `CONTACT_EMAIL`
+(default `hello@dayotter.com`), but that var isn't documented in
+`deploy/.env.prod.example` or `.env.example`.
+- **Done when:** both example files list `CONTACT_EMAIL` with a comment.
+
+---
+
+## Reliability / correctness
+
+### 🟡 Make the contact form not lose messages on a mail failure
+`apps/web/app/api/contact/route.ts` swallows send errors and still returns
+`{ ok: true }`, so a failed send is silently lost (only a log line).
+- **Do:** persist submissions to a small `contact_messages` table (new Drizzle
+  table + migration) before/independently of the email, and/or return a real error
+  to the client when the send fails.
+- **Done when:** a submission survives an email outage (row is stored) and the UI
+  reflects a genuine failure instead of a false "Thanks".
+
+### 🟡 Per-occurrence availability + cap checks for recurring series
+`apps/web/lib/booking/create-booking.ts` creates occurrences 2..N at a fixed
+cadence; they're skipped only on a same-host DB collision, and daily/weekly/focus
+caps aren't re-checked per occurrence. (Webhooks/CRM/workflows/overflow/scribe/
+travel now DO fire per occurrence.)
+- **Do:** decide + implement a policy — e.g. skip an occurrence that conflicts with
+  an external busy block or would exceed a cap, logging what was skipped, and
+  surface skipped dates to the booker/host.
+- **Done when:** a recurring booking that lands on a busy week no longer
+  double-books, and skipped occurrences are visible rather than silent.
+
+### 🔴 Whole-series *reschedule*
+Whole-series **cancel** exists (`cancelBookingSeries`), but reschedule only moves a
+single occurrence (`apps/web/lib/booking/reschedule-booking.ts`).
+- **Needs a design call first:** what does "reschedule the series" mean — shift
+  every future occurrence by the same delta, or move to a new weekday/time and
+  regenerate? Propose in an issue before coding.
+
+---
+
+## AI
+
+### 🟡 Wire up user-stated memory (`rememberUserFact`)
+`apps/web/lib/ai/memory/index.ts` exports `rememberUserFact` (source = "user") but
+nothing calls it — only *derived* memory is written today.
+- **Do:** add an intent/tool so when a user tells Otter "remember that I …", the
+  fact is stored via `rememberUserFact`. See `lib/ai/tools/registry.ts` for the
+  tool pattern.
+- **Done when:** a stated preference persists and shows up in later context.
+
+### 🟡 Cost ceiling for the public booking assistant
+`apps/web/app/api/public/booking-assistant/route.ts` rate-limits per IP only. Add a
+per-host and/or global daily ceiling on the LLM calls so an abusive booking page
+can't run up unbounded model spend.
+
+---
+
+## Payments
+
+### 🟢 Per-currency withdraw minimum (only matters for 0-decimal currencies)
+`WITHDRAW_MINIMUM` in `apps/web/lib/payments/stripe.ts` is `10_000` minor units,
+compared the same for every currency. Fine today (all six supported currencies are
+2-decimal → 100.00 each), but if a 0-decimal currency (e.g. JPY) is ever added, the
+minimum would be wrong.
+- **Do:** turn it into a per-currency map / helper and use it in the withdraw route
+  + payouts UI.
+
+---
+
+## Testing
+
+### 🟡 Cover the untested money + auth + sync paths
+No tests currently exercise: `lib/payments/stripe.ts`, the withdraw route, checkout
+/ credits, the Stripe webhook, auth/session, or the sync worker
+(`apps/worker/src/workers/sync.ts`) — and there are no API route-handler tests,
+including the `/api/book` double-book guard.
+- **Do:** add focused unit/integration tests for any one of these (each is its own
+  good PR). Follow the existing Vitest setup under `apps/web/lib/**/*.test.ts`.
+
+---
+
+Don't see your idea here? Open an [issue](../../issues/new/choose) — new proposals
+are welcome.


### PR DESCRIPTION
Prep for making the repo public.

## 1. Repo references → `Dayotter/dayotter`
Updated every GitHub reference: `apps/web/lib/marketing.ts`, `CONTRIBUTING.md`, `docs/SELF_HOSTING.md`, `deploy/README.md`, `deploy/install.sh`, `deploy/aws/cloudformation.yaml`. Also updated the local git remote.

## 2. Trademark claim removed
README license note no longer claims "Otter" as a trademark (we hold no registered mark). Kept the code-vs-brand line for the DayOtter name/logo. (The other "trademark" hits are AGPL license boilerplate — untouched.)

## 3. Secret / param audit — clean ✅
Before going public I scanned:
- **Committed `.env` files:** none (only `*.example`).
- **Working tree + full git history** (~5.6k objects) for Stripe/AWS/GitHub/Slack/Google/Anthropic/Resend/Twilio keys, JWTs, and private keys: **no matches**.
- **Example files:** no real values.
- **Hardening applied:** `.gitignore` now ignores every real `.env` (incl. `.env.production`/`.env.prod`) while keeping the committed `*.example` templates — previously `.env.production` would not have been ignored.

## 4. Contributor task list
New **[`docs/TASKS.md`](docs/TASKS.md)** — a ready-to-start "help wanted" backlog (Redis lazyConnect, contact-form persistence, recurring per-occurrence checks, whole-series reschedule, memory wiring, test coverage, …) with file pointers + acceptance criteria and difficulty tags. Linked from the README nav and CONTRIBUTING.

Typecheck + Biome clean.