### PR TITLE
feat(seo): GEO readiness — llms.txt, AI-crawler robots, per-page keywords, AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,83 @@
+# AGENTS.md
+
+Guidance for AI coding agents (and humans) working in this repo. Keep changes
+consistent with the conventions below; when in doubt, match the surrounding code.
+
+## What this is
+
+DayOtter — an AI-native, open-source scheduling platform (a Calendly / Cal.com
+alternative). Turborepo + pnpm monorepo. TypeScript everywhere, strict mode.
+
+## Layout
+
+- `apps/web` — Next.js 15 (App Router). Marketing site, booking pages, dashboard, API routes.
+- `apps/worker` — BullMQ worker: reminders, calendar sync, webhooks, CRM sync.
+- `apps/mobile` — Expo / React Native app.
+- `packages/core` — pure logic: the availability engine, round-robin, crypto, SSRF guards. No I/O.
+- `packages/db` — Drizzle schema + migrations (`drizzle/`).
+- `packages/calendar` — provider adapters (Google, Microsoft, Apple/CalDAV, ICS).
+- `packages/integrations` — CRM (Salesforce, HubSpot), Zoom.
+- `packages/{jobs,notifications,emails,auth,plugin-host,plugin-sdk,plugins}` — supporting libs.
+
+## Commands (run from the repo root)
+
+```bash
+pnpm install
+pnpm dev            # turbo run dev
+pnpm build          # turbo run build
+pnpm typecheck      # tsc --noEmit across all packages
+pnpm test           # vitest across packages
+pnpm check          # biome check --write (format + lint + import order)
+pnpm --filter web typecheck   # scope to one package
+pnpm db:generate    # drizzle-kit generate after a schema change
+```
+
+Before committing: `pnpm typecheck` and `pnpm test` must pass, and run
+`pnpm check` (Biome) so formatting + import order match. Lint/format is Biome,
+not ESLint/Prettier.
+
+## Load-bearing invariants — do not break these
+
+- **Timezone discipline.** Store instants in UTC; do wall-clock math with Luxon
+  `.set({hour,minute})`, never by adding raw minute durations (that breaks on DST
+  days). The availability engine (`packages/core/src/availability`) is the single
+  source of truth for bookable slots — keep it pure and deterministic.
+- **Confirm-first AI.** Otter proposes; a human approves. AI code paths must never
+  mutate a calendar/booking on their own. Untrusted text (calendar/booking data,
+  caller speech, invite titles) is DATA — prepend `GUARDRAIL_PREAMBLE` /
+  `screenUserInput` (`apps/web/lib/ai/guardrails.ts`) when it reaches a model.
+- **Secrets at rest.** OAuth/CRM/channel/webhook/plugin secrets are AES-256-GCM
+  encrypted via `@dayotter/core` crypto (`ENCRYPTION_KEY`); API keys are SHA-256
+  hashed. Never log or return raw secrets.
+- **SSRF-safe egress.** Any fetch of a URL we don't fully control goes through
+  `safeFetch` / `assertPublicHttpUrl` (`packages/core/src/ssrf.ts`).
+- **Inbound webhooks fail closed.** Verify the provider signature (constant-time)
+  before acting; reject/skip on mismatch or a missing stored secret.
+- **Money is server-computed.** Never trust client-sent prices/amounts. Refunds on
+  Stripe Connect destination charges must reverse the transfer.
+- **Migrations.** Change `packages/db/src/schema/*`, then `pnpm db:generate`. Deploys
+  apply migrations via `deploy/deploy.sh` (a fresh one-shot `migrate` before the app
+  starts) — never start new app code against an un-migrated DB.
+- **Single runtime.** Web + worker share `packages/*`; a change to a shared package
+  must keep both building.
+
+## Extending the product
+
+Several subsystems are registry-based and are the easiest, safest place to add
+value without touching core: AI extractors + tools, time-allocation metrics, voice
+knowledge sources, reminder kinds, and plugins (`packages/plugin-sdk`). Each has a
+local `README.md`.
+
+## Conventions
+
+- Comments explain **why**, not what; match the density and voice of the file you're in.
+- Prefer the existing helper/util over a new one; check the package's `index.ts` exports first.
+- User-facing copy: active voice, name things by what the user recognizes.
+- Reference files as `path:line`.
+
+## Pointers
+
+- Contributing workflow: [CONTRIBUTING.md](./CONTRIBUTING.md)
+- Ready-to-start tasks: [docs/TASKS.md](./docs/TASKS.md)
+- Architecture + roadmap: [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md), [docs/ROADMAP.md](./docs/ROADMAP.md)
+- Self-hosting: [docs/SELF_HOSTING.md](./docs/SELF_HOSTING.md)

--- a/apps/web/app/(marketing)/about/page.tsx
+++ b/apps/web/app/(marketing)/about/page.tsx
@@ -3,7 +3,8 @@ import { BRAND } from "@/lib/marketing";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "About - DayOtter",
+  title: "About",
+  alternates: { canonical: "/about" },
   description:
     "Why we built DayOtter - every calendar, your booking links, reminders, and an assistant in one calm place.",
 };

--- a/apps/web/app/(marketing)/blog/[slug]/page.tsx
+++ b/apps/web/app/(marketing)/blog/[slug]/page.tsx
@@ -1,5 +1,7 @@
 import { Prose } from "@/components/marketing/page-shell";
+import { ArticleJsonLd, BreadcrumbJsonLd } from "@/components/seo/json-ld";
 import { POSTS, formatDate, getPost } from "@/lib/blog";
+import { slugMetadata } from "@/lib/marketing-page";
 import { ArrowLeft } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
@@ -15,8 +17,12 @@ export async function generateMetadata({
   params: Promise<{ slug: string }>;
 }): Promise<Metadata> {
   const post = getPost((await params).slug);
-  if (!post) return { title: "Blog - DayOtter" };
-  return { title: `${post.title} - DayOtter`, description: post.excerpt };
+  if (!post) return { title: "Blog" };
+  return slugMetadata({
+    title: post.title,
+    description: post.excerpt,
+    path: `/blog/${post.slug}`,
+  });
 }
 
 export default async function BlogPostPage({ params }: { params: Promise<{ slug: string }> }) {
@@ -25,6 +31,18 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
 
   return (
     <article>
+      <ArticleJsonLd
+        title={post.title}
+        description={post.excerpt}
+        path={`/blog/${post.slug}`}
+        datePublished={post.date}
+      />
+      <BreadcrumbJsonLd
+        items={[
+          { name: "Blog", path: "/blog" },
+          { name: post.title, path: `/blog/${post.slug}` },
+        ]}
+      />
       <header className="relative overflow-hidden border-b border-[var(--color-border)]">
         <div
           aria-hidden

--- a/apps/web/app/(marketing)/blog/page.tsx
+++ b/apps/web/app/(marketing)/blog/page.tsx
@@ -4,7 +4,8 @@ import type { Metadata } from "next";
 import Link from "next/link";
 
 export const metadata: Metadata = {
-  title: "Blog - DayOtter",
+  title: "Blog",
+  alternates: { canonical: "/blog" },
   description: "Notes on calendars, focus, and getting your time back.",
 };
 

--- a/apps/web/app/(marketing)/changelog/page.tsx
+++ b/apps/web/app/(marketing)/changelog/page.tsx
@@ -2,7 +2,8 @@ import { MarketingHeader } from "@/components/marketing/page-shell";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Changelog - DayOtter",
+  title: "Changelog",
+  alternates: { canonical: "/changelog" },
   description: "What's new in DayOtter.",
 };
 

--- a/apps/web/app/(marketing)/contact/page.tsx
+++ b/apps/web/app/(marketing)/contact/page.tsx
@@ -5,7 +5,8 @@ import { Github, Mail, MessageSquare } from "lucide-react";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Contact - DayOtter",
+  title: "Contact",
+  alternates: { canonical: "/contact" },
   description: "Get in touch with the DayOtter team.",
 };
 

--- a/apps/web/app/(marketing)/docs/[slug]/page.tsx
+++ b/apps/web/app/(marketing)/docs/[slug]/page.tsx
@@ -19,10 +19,10 @@ export async function generateMetadata({
   if (!g) return { title: "Docs" };
   const path = `/docs/${g.slug}`;
   return {
-    title: `${g.title} - DayOtter Docs`,
+    title: `${g.title} - Docs`,
     description: g.summary,
     alternates: { canonical: path },
-    openGraph: { title: `${g.title} - DayOtter Docs`, description: g.summary, url: path },
+    openGraph: { title: `${g.title} - Docs`, description: g.summary, url: path },
   };
 }
 

--- a/apps/web/app/(marketing)/features/[slug]/page.tsx
+++ b/apps/web/app/(marketing)/features/[slug]/page.tsx
@@ -13,7 +13,18 @@ export function generateStaticParams() {
 
 export const generateMetadata = makeSlugMetadata(
   getFeature,
-  (f) => ({ title: f.title, description: f.subtitle, path: `/features/${f.slug}` }),
+  (f) => ({
+    title: f.title,
+    description: f.subtitle,
+    path: `/features/${f.slug}`,
+    keywords: [
+      f.title.toLowerCase(),
+      `${f.title.toLowerCase()} software`,
+      "AI scheduling",
+      "open source scheduling",
+      "DayOtter",
+    ],
+  }),
   "Features",
 );
 

--- a/apps/web/app/(marketing)/for/[slug]/page.tsx
+++ b/apps/web/app/(marketing)/for/[slug]/page.tsx
@@ -13,7 +13,19 @@ export function generateStaticParams() {
 
 export const generateMetadata = makeSlugMetadata(
   getPersona,
-  (p) => ({ title: p.title, description: p.subtitle, path: `/for/${p.slug}` }),
+  (p) => ({
+    title: p.title,
+    description: p.subtitle,
+    path: `/for/${p.slug}`,
+    keywords: [
+      `scheduling for ${p.label.toLowerCase()}`,
+      `${p.label.toLowerCase()} scheduling software`,
+      `${p.label.toLowerCase()} booking tool`,
+      "AI scheduling",
+      "Calendly alternative",
+      "DayOtter",
+    ],
+  }),
   "DayOtter",
 );
 

--- a/apps/web/app/(marketing)/glossary/[slug]/page.tsx
+++ b/apps/web/app/(marketing)/glossary/[slug]/page.tsx
@@ -17,6 +17,13 @@ export const generateMetadata = makeSlugMetadata(
     title: `${t.term} - scheduling glossary`,
     description: t.short,
     path: `/glossary/${t.slug}`,
+    keywords: [
+      t.term.toLowerCase(),
+      `what is ${t.term.toLowerCase()}`,
+      `${t.term.toLowerCase()} scheduling`,
+      "scheduling glossary",
+      "DayOtter",
+    ],
   }),
   "Glossary",
 );

--- a/apps/web/app/(marketing)/integrations/[slug]/page.tsx
+++ b/apps/web/app/(marketing)/integrations/[slug]/page.tsx
@@ -17,6 +17,14 @@ export const generateMetadata = makeSlugMetadata(
     title: `${it.name} scheduling - DayOtter integration`,
     description: it.subtitle,
     path: `/integrations/${it.slug}`,
+    keywords: [
+      `${it.name} scheduling`,
+      `${it.name} integration`,
+      `${it.name} calendar sync`,
+      `book meetings with ${it.name}`,
+      "AI scheduling",
+      "DayOtter",
+    ],
   }),
   "Integrations",
 );

--- a/apps/web/app/(marketing)/privacy/page.tsx
+++ b/apps/web/app/(marketing)/privacy/page.tsx
@@ -3,7 +3,8 @@ import { BRAND } from "@/lib/marketing";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Privacy Policy - DayOtter",
+  title: "Privacy Policy",
+  alternates: { canonical: "/privacy" },
   description: "How DayOtter collects, uses, and protects your data.",
 };
 

--- a/apps/web/app/(marketing)/security/page.tsx
+++ b/apps/web/app/(marketing)/security/page.tsx
@@ -3,7 +3,8 @@ import { BRAND } from "@/lib/marketing";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Security - DayOtter",
+  title: "Security",
+  alternates: { canonical: "/security" },
   description: "How DayOtter protects your data.",
 };
 

--- a/apps/web/app/(marketing)/self-hosting/page.tsx
+++ b/apps/web/app/(marketing)/self-hosting/page.tsx
@@ -3,7 +3,8 @@ import { BRAND } from "@/lib/marketing";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Self-hosting - DayOtter",
+  title: "Self-hosting",
+  alternates: { canonical: "/self-hosting" },
   description: "Run DayOtter on your own infrastructure. Every feature, free forever.",
 };
 

--- a/apps/web/app/(marketing)/status/page.tsx
+++ b/apps/web/app/(marketing)/status/page.tsx
@@ -3,7 +3,8 @@ import { CheckCircle2 } from "lucide-react";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Status - DayOtter",
+  title: "Status",
+  alternates: { canonical: "/status" },
   description: "DayOtter system status.",
 };
 

--- a/apps/web/app/(marketing)/terms/page.tsx
+++ b/apps/web/app/(marketing)/terms/page.tsx
@@ -3,7 +3,8 @@ import { BRAND } from "@/lib/marketing";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Terms of Service - DayOtter",
+  title: "Terms of Service",
+  alternates: { canonical: "/terms" },
   description: "The terms that govern your use of DayOtter.",
 };
 

--- a/apps/web/app/(marketing)/vs/[slug]/page.tsx
+++ b/apps/web/app/(marketing)/vs/[slug]/page.tsx
@@ -17,6 +17,14 @@ export const generateMetadata = makeSlugMetadata(
     title: `${c.title} (2026) - how they compare`,
     description: c.subtitle,
     path: `/vs/${c.slug}`,
+    keywords: [
+      `${c.name} alternative`,
+      `DayOtter vs ${c.name}`,
+      `${c.name} vs DayOtter`,
+      `open source ${c.name} alternative`,
+      "AI scheduling",
+      "DayOtter",
+    ],
   }),
   "Compare - DayOtter",
 );

--- a/apps/web/app/llms.txt/route.ts
+++ b/apps/web/app/llms.txt/route.ts
@@ -1,0 +1,85 @@
+import { POSTS } from "@/lib/blog";
+import { COMPARISONS } from "@/lib/comparisons";
+import { GUIDES } from "@/lib/docs";
+import { FEATURES } from "@/lib/features";
+import { GLOSSARY } from "@/lib/glossary";
+import { INTEGRATIONS } from "@/lib/integrations-content";
+import { BRAND } from "@/lib/marketing";
+import { PERSONAS } from "@/lib/personas";
+
+export const dynamic = "force-static";
+
+/**
+ * `/llms.txt` - the llmstxt.org convention: a single, link-rich Markdown file
+ * that gives AI/answer engines a clean map of the site's public content, built
+ * from the same content collections as the sitemap so it never drifts.
+ */
+function line(path: string, label: string, desc?: string): string {
+  return `- [${label}](${BRAND.url}${path})${desc ? `: ${desc}` : ""}`;
+}
+
+function section(title: string, lines: string[]): string {
+  return `## ${title}\n${lines.join("\n")}\n`;
+}
+
+export function GET(): Response {
+  const body = [
+    `# ${BRAND.name}`,
+    "",
+    "> DayOtter is the AI-native, open-source scheduling platform. Its assistant, Otter, books meetings, protects focus, and clears the scheduling back-and-forth - always confirm-first (it drafts, a human approves). Sync every calendar, run team round-robin and collective scheduling, accept payments, and self-host the whole thing under AGPLv3.",
+    "",
+    "Key facts:",
+    "- Open-source (AGPLv3); self-hostable in one command; managed cloud at dayotter.com.",
+    "- A privacy-respecting alternative to Calendly, Cal.com, Motion, and Reclaim, and to manual Google Calendar back-and-forth.",
+    "- Otter (the AI) is confirm-first: it never changes a calendar on its own, it proposes an action the user approves.",
+    "- Free tier plus a $9/seat/month Pro plan on the cloud edition; all features are unlocked when self-hosted.",
+    "",
+    section("Start here", [
+      line("/", "Home", "What DayOtter is and who it's for."),
+      line("/features", "Features", "Everything DayOtter does, by capability."),
+      line("/pricing", "Pricing", "Free tier and $9/seat/mo Pro; self-hosting is free."),
+      line("/integrations", "Integrations", "Calendars, video, payments, CRM, and messaging."),
+      line("/self-hosting", "Self-hosting", "Run the whole platform on your own server."),
+      line("/security", "Security", "Encryption at rest, signed webhooks, SSRF-safe egress."),
+      line("/docs", "Documentation", "Guides from first booking to advanced setup."),
+    ]),
+    section(
+      "Features",
+      FEATURES.map((f) => line(`/features/${f.slug}`, f.title, f.blurb)),
+    ),
+    section(
+      "Comparisons",
+      COMPARISONS.map((c) => line(`/vs/${c.slug}`, c.title, c.blurb)),
+    ),
+    section(
+      "For teams & roles",
+      PERSONAS.map((p) => line(`/for/${p.slug}`, p.title, p.subtitle)),
+    ),
+    section(
+      "Integrations",
+      INTEGRATIONS.map((i) => line(`/integrations/${i.slug}`, i.name, i.blurb)),
+    ),
+    section(
+      "Documentation",
+      GUIDES.map((g) => line(`/docs/${g.slug}`, g.title, g.summary)),
+    ),
+    section(
+      "Glossary",
+      GLOSSARY.map((t) => line(`/glossary/${t.slug}`, t.term, t.short)),
+    ),
+    section(
+      "Blog",
+      POSTS.map((p) => line(`/blog/${p.slug}`, p.title, p.excerpt)),
+    ),
+    section("More", [
+      `- [Source code](${BRAND.github}): GitHub repository (issues + contributions welcome).`,
+      line("/changelog", "Changelog", "What shipped, including security fixes."),
+      line("/about", "About", "Why DayOtter exists."),
+      line("/contact", "Contact", "Get in touch."),
+    ]),
+  ].join("\n");
+
+  return new Response(body, {
+    headers: { "content-type": "text/plain; charset=utf-8" },
+  });
+}

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -1,15 +1,35 @@
 import { BRAND } from "@/lib/marketing";
 import type { MetadataRoute } from "next";
 
+// Private/app + auth surfaces stay out of every crawler's index.
+const DISALLOW = ["/api/", "/dashboard", "/settings", "/sign-in", "/sign-up", "/onboarding"];
+
+// GEO: explicitly welcome the major AI/answer-engine crawlers to the public
+// content (they inherit "*" anyway, but naming them signals intent and future-
+// proofs against a default-deny stance). They still can't reach the app/auth
+// surfaces above. The public content is also summarized at /llms.txt.
+const AI_CRAWLERS = [
+  "GPTBot",
+  "OAI-SearchBot",
+  "ChatGPT-User",
+  "ClaudeBot",
+  "Claude-Web",
+  "anthropic-ai",
+  "PerplexityBot",
+  "Perplexity-User",
+  "Google-Extended",
+  "Applebot-Extended",
+  "CCBot",
+  "Amazonbot",
+  "cohere-ai",
+  "Meta-ExternalAgent",
+];
+
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: [
-      {
-        userAgent: "*",
-        allow: "/",
-        // Keep private/app + auth surfaces out of the index.
-        disallow: ["/api/", "/dashboard", "/settings", "/sign-in", "/sign-up", "/onboarding"],
-      },
+      { userAgent: "*", allow: "/", disallow: DISALLOW },
+      { userAgent: AI_CRAWLERS, allow: "/", disallow: DISALLOW },
     ],
     sitemap: `${BRAND.url}/sitemap.xml`,
     host: BRAND.url,

--- a/apps/web/lib/marketing-page.ts
+++ b/apps/web/lib/marketing-page.ts
@@ -7,15 +7,19 @@ import type { Metadata } from "next";
  * it so the SEO tags stay consistent and there's one place to change them.
  */
 
-/** Build a Metadata object with matching canonical + OpenGraph from one source. */
+/** Build a Metadata object with matching canonical + OpenGraph from one source.
+ *  `keywords` are page-specific (major engines mostly ignore the tag now, but
+ *  it's cheap and some secondary/AI crawlers still read it). */
 export function slugMetadata(opts: {
   title: string;
   description: string;
   path: string;
+  keywords?: string[];
 }): Metadata {
   return {
     title: opts.title,
     description: opts.description,
+    ...(opts.keywords?.length ? { keywords: opts.keywords } : {}),
     alternates: { canonical: opts.path },
     openGraph: { title: opts.title, description: opts.description, url: opts.path },
   };
@@ -24,11 +28,11 @@ export function slugMetadata(opts: {
 /**
  * Make a Next.js `generateMetadata` for a `[slug]` page: look the entity up,
  * fall back to a title when it's missing, otherwise map it to title/description/
- * path and return consistent metadata.
+ * path (and optional keywords) and return consistent metadata.
  */
 export function makeSlugMetadata<T>(
   get: (slug: string) => T | undefined,
-  build: (item: T) => { title: string; description: string; path: string },
+  build: (item: T) => { title: string; description: string; path: string; keywords?: string[] },
   fallbackTitle: string,
 ) {
   return async ({


### PR DESCRIPTION
Makes the marketing site SEO + GEO (AI/answer-engine) ready. **Stacked on #53** (base `chore/public-repo-prep`) so it inherits the `Dayotter/dayotter` refs; merge #53 first.

## Already in place (verified, no change needed)
- **Sitemap** — `app/sitemap.ts` dynamically enumerates every public route (features/vs/for/integrations/docs/glossary/blog + static pages).
- **robots** — `app/robots.ts` (extended below).
- **SSR** — all marketing pages are Server Components with static/generated metadata (none are client pages).
- **Root metadata** — title template, description, keywords, canonical, OpenGraph, Twitter, robots directives, icons, authors/publisher.
- **Open Graph** — dynamic per-slug `opengraph-image.tsx` for vs/for/features/integrations/glossary + a static `app/opengraph-image.png` default Next auto-applies elsewhere.
- **JSON-LD** — Organization, SoftwareApplication, FAQ, Breadcrumb, Article, DefinedTerm.

## New in this PR
1. **`/llms.txt`** (GEO) — dynamic route in [llmstxt.org](https://llmstxt.org) format, built from the same content collections as the sitemap so it never drifts. Product summary + key facts + links to every feature/comparison/persona/integration/doc/glossary/blog page.
2. **AI-crawler welcome in robots** — explicit allow groups for GPTBot, OAI-SearchBot, ChatGPT-User, ClaudeBot, Claude-Web, anthropic-ai, PerplexityBot, Google-Extended, Applebot-Extended, CCBot, Amazonbot, cohere-ai, Meta-ExternalAgent — while keeping `/api`, `/dashboard`, `/settings`, auth out of the index.
3. **Per-page keywords** — tailored keywords threaded through `slugMetadata` for the programmatic `[slug]` pages (e.g. `/vs/calendly` → "Calendly alternative, DayOtter vs Calendly, …").
4. **`AGENTS.md`** (repo root) — project map, commands, and load-bearing invariants for AI coding agents.

## Verification
Ran the dev server and fetched: `/llms.txt` (200, text/plain, llmstxt format), `/robots.txt` (200, both `*` and AI-crawler groups + sitemap), `/sitemap.xml` (200, application/xml). `/vs/calendly` HTML carries page-specific title, keywords, canonical, OG + Twitter tags, and its dynamic OG image. Typecheck + Biome clean.

## To submit to search indexes after merge/deploy
Google Search Console + Bing Webmaster Tools → verify domain → submit `https://dayotter.com/sitemap.xml`. `/llms.txt` is auto-discoverable by AI crawlers.