### PR TITLE
chore(community): enable GitHub Discussions as the community hub

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,0 +1,32 @@
+title: "[Question]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for asking! A couple of quick checks make answers faster:
+        - Search [existing discussions](https://github.com/Dayotter/dayotter/discussions) and [issues](https://github.com/Dayotter/dayotter/issues) first.
+        - Self-hosting? Skim [SELF_HOSTING.md](https://github.com/Dayotter/dayotter/blob/main/docs/SELF_HOSTING.md) and [INTEGRATIONS.md](https://github.com/Dayotter/dayotter/blob/main/docs/INTEGRATIONS.md).
+        - Found a bug (not a question)? Open an [issue](https://github.com/Dayotter/dayotter/issues/new/choose) instead.
+  - type: textarea
+    id: question
+    attributes:
+      label: What do you need help with?
+      description: What are you trying to do, and what's blocking you?
+    validations:
+      required: true
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: How are you running DayOtter?
+      options:
+        - Cloud (dayotter.com)
+        - Self-hosted (Docker)
+        - Local development
+        - Not sure
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Relevant context
+      description: Logs, error messages, screenshots, browser/OS, or anything that helps reproduce it.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Say it once - Otter books the meeting, protects your focus, and clears the back-
 ![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)
 ![Self-hostable](https://img.shields.io/badge/self--hostable-yes-brightgreen)
 ![Made with TypeScript](https://img.shields.io/badge/TypeScript-strict-3178c6)
+[![GitHub Discussions](https://img.shields.io/github/discussions/Dayotter/dayotter?logo=github&label=discussions)](https://github.com/Dayotter/dayotter/discussions)
+[![GitHub stars](https://img.shields.io/github/stars/Dayotter/dayotter?style=flat&logo=github)](https://github.com/Dayotter/dayotter/stargazers)
 
 </div>
 
@@ -94,12 +96,18 @@ Docker Compose brings up Postgres, Redis, migrations, web, worker, and a reverse
 
 **Connecting integrations** (Google, Microsoft, Apple, Salesforce, HubSpot, Zoom, Stripe, Twilio, Resend) — where to get each client ID / API key and which redirect URI & webhook to register: [`docs/INTEGRATIONS.md`](./docs/INTEGRATIONS.md), mirrored on the site at `/docs/integration-setup`.
 
+## Community
+
+- 💬 **[Discussions](https://github.com/Dayotter/dayotter/discussions)** - ask a question (Q&A), propose an idea, or show what you built. This is the best place to start.
+- 🐛 **[Issues](../../issues/new/choose)** - report a bug or request a feature.
+- 🔒 **[Security policy](./SECURITY.md)** - report a vulnerability privately (don't open a public issue).
+- 🤝 **[Code of conduct](./CODE_OF_CONDUCT.md)** · **[How to get help](./SUPPORT.md)**
+
+Real-time chat (Discord) is coming as the community grows - for now, Discussions is the hub so answers stay searchable for the next person.
+
 ## Contributing
 
-We'd love your help - see [`CONTRIBUTING.md`](./CONTRIBUTING.md) for setup, conventions, and the PR flow, and [`docs/ROADMAP.md`](./docs/ROADMAP.md) for where we're headed. Good first issues are labelled on the tracker. By contributing, you agree your changes are licensed under AGPLv3 (or the EE license for `ee/`).
-
-- [Report a bug or request a feature](../../issues/new/choose)
-- [Security policy](./SECURITY.md) · [Code of conduct](./CODE_OF_CONDUCT.md)
+We'd love your help - see [`CONTRIBUTING.md`](./CONTRIBUTING.md) for setup, conventions, and the PR flow, [`docs/TASKS.md`](./docs/TASKS.md) for ready-to-start work, and [`docs/ROADMAP.md`](./docs/ROADMAP.md) for where we're headed. Good first issues are labelled on the tracker. By contributing, you agree your changes are licensed under AGPLv3 (or the EE license for `ee/`).
 
 ## License
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,20 @@
+# Getting help
+
+Thanks for using DayOtter. Here's the fastest route for each kind of question.
+
+| I want to… | Go here |
+|---|---|
+| **Ask a question / get help** | [GitHub Discussions → Q&A](https://github.com/Dayotter/dayotter/discussions/categories/q-a) |
+| **Report a bug** | [Open an issue](https://github.com/Dayotter/dayotter/issues/new/choose) |
+| **Request a feature / share an idea** | [Discussions → Ideas](https://github.com/Dayotter/dayotter/discussions/categories/ideas) |
+| **Show what you built** | [Discussions → Show and tell](https://github.com/Dayotter/dayotter/discussions/categories/show-and-tell) |
+| **Report a security vulnerability** | **Do not open a public issue** — follow [SECURITY.md](./SECURITY.md) |
+| **Something private / commercial** | Email [hello@dayotter.com](mailto:hello@dayotter.com) |
+
+## Before you post
+
+- **Search first** — [Discussions](https://github.com/Dayotter/dayotter/discussions) and [Issues](https://github.com/Dayotter/dayotter/issues) often already have your answer.
+- **Self-hosting?** Check [docs/SELF_HOSTING.md](./docs/SELF_HOSTING.md) and [docs/INTEGRATIONS.md](./docs/INTEGRATIONS.md) first, and include your deploy method + relevant logs.
+- **Bug reports** are easiest to fix with steps to reproduce, what you expected, what happened, and your environment (self-hosted vs cloud, browser/OS).
+
+We keep durable answers in Discussions and docs so they're searchable for the next person — please post questions there rather than in commit or PR comments.

--- a/apps/web/lib/marketing.ts
+++ b/apps/web/lib/marketing.ts
@@ -9,6 +9,10 @@ export const BRAND = {
   github: "https://github.com/Dayotter/dayotter",
   githubLicense: "https://github.com/Dayotter/dayotter/blob/main/LICENSE",
   githubContributing: "https://github.com/Dayotter/dayotter/blob/main/CONTRIBUTING.md",
+  /** GitHub Discussions - the durable, searchable community home. */
+  discussions: "https://github.com/Dayotter/dayotter/discussions",
+  /** Real-time chat. Empty until the server is live; footer hides it when unset. */
+  discord: "",
   x: "https://x.com/dayotter",
   copyrightYear: 2026,
 };
@@ -63,6 +67,15 @@ export const FOOTER_COLUMNS: { title: string; links: FooterLink[] }[] = [
       { label: "Blog", href: "/blog" },
       { label: "About", href: "/about" },
       { label: "Contact", href: "/contact" },
+    ],
+  },
+  {
+    title: "Community",
+    links: [
+      { label: "Discussions", href: BRAND.discussions, external: true },
+      { label: "GitHub", href: BRAND.github, external: true },
+      { label: "Contribute", href: BRAND.githubContributing, external: true },
+      ...(BRAND.discord ? [{ label: "Discord", href: BRAND.discord, external: true }] : []),
     ],
   },
   {


### PR DESCRIPTION
Sets up the community layer, per the recommendation to make **GitHub Discussions** the durable, searchable hub now and keep Discord as a ready-to-flip placeholder for later. **Stacked on #54.**

## Done
- **Enabled GitHub Discussions** on the repo (`has_discussions: true`). It was already linked from `ROADMAP.md` and `CONTRIBUTING.md`, but was off — those links were dead until now.
- **`SUPPORT.md`** — routes each need to the right place: questions → Discussions Q&A, bugs → Issues, vulnerabilities → SECURITY.md, private/commercial → email. GitHub surfaces this in the 'new issue' flow.
- **Q&A discussion form** (`.github/DISCUSSION_TEMPLATE/q-a.yml`) — nudges askers to search first, pick their deployment, and include context.
- **README** — Discussions + stars badges, a **Community** section, and a link to `docs/TASKS.md`.
- **Marketing footer** — a **Community** column (Discussions, GitHub, Contribute). A Discord link auto-appears once `BRAND.discord` is set; it's empty for now so nothing renders.

## Deliberately not done
- **No Discord server yet** — an empty server reads as a dead project, and it's unindexed (no SEO value). Everything is wired so turning it on later is a one-line change (`BRAND.discord = "<invite>"`), plus a badge/section if you want.
- Custom Discussion **categories** beyond GitHub's defaults (Announcements/General/Ideas/Q&A/Show and tell/Polls) are created in the repo's Discussions UI — the defaults are a fine start.

## Verified
Typecheck + Biome clean. Footer renders the Community column with Discord correctly hidden while its URL is empty.

## Your one manual step
In the repo's **Discussions** tab, optionally pin a short 'Welcome / start here' post and tidy categories. Everything else is live on merge.