### PR TITLE
feat(mobile): close web parity gaps + fix preferences data-loss bug

### DIFF
--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -42,6 +42,15 @@ export default function SettingsScreen() {
   const [adaptive, setAdaptive] = useState(false);
   const [maxPerDay, setMaxPerDay] = useState(5);
   const [travelBuffer, setTravelBuffer] = useState(0);
+  const [reclaim, setReclaim] = useState(false);
+  const [overflow, setOverflow] = useState(false);
+  const [scribe, setScribe] = useState(false);
+  const [briefing, setBriefing] = useState(false);
+  const [briefingHour, setBriefingHour] = useState(8);
+  const [lunch, setLunch] = useState(false);
+  const [lunchStart, setLunchStart] = useState(720);
+  const [lunchEnd, setLunchEnd] = useState(780);
+  const [bookingAssistant, setBookingAssistant] = useState(true);
   const [welcomeMessage, setWelcomeMessage] = useState("");
   const [brandColor, setBrandColor] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -65,6 +74,15 @@ export default function SettingsScreen() {
         setAdaptive(p.adaptiveAvailability ?? false);
         setMaxPerDay(p.maxMeetingsPerDay ?? 5);
         setTravelBuffer(p.travelBufferMinutes ?? 0);
+        setReclaim(p.reclaimCancelledTime ?? false);
+        setOverflow(p.overflowNotifyEnabled ?? false);
+        setScribe(p.scribeEnabled ?? false);
+        setBriefing(p.briefingEnabled ?? false);
+        setBriefingHour(p.briefingHour ?? 8);
+        setLunch(p.lunchEnabled ?? false);
+        setLunchStart(p.lunchStartMinute ?? 720);
+        setLunchEnd(p.lunchEndMinute ?? 780);
+        setBookingAssistant(p.bookingPageAssistant ?? true);
         setWelcomeMessage(me?.branding?.welcomeMessage ?? "");
         setBrandColor(me?.branding?.brandColor ?? null);
       })
@@ -92,14 +110,24 @@ export default function SettingsScreen() {
         brandColor,
         welcomeMessage: welcomeMessage.trim() || null,
       });
+      // Partial update - we intentionally omit `theme` (no dark mode on mobile
+      // yet) so a web-set theme is preserved by the server's merge.
       await api.patch("/api/settings/preferences", {
         timeFormat,
         weekStartsOn,
-        theme: "system",
         defaultReminderOffsets: reminders,
         adaptiveAvailability: adaptive,
         maxMeetingsPerDay: maxPerDay,
         travelBufferMinutes: travelBuffer,
+        reclaimCancelledTime: reclaim,
+        overflowNotifyEnabled: overflow,
+        scribeEnabled: scribe,
+        briefingEnabled: briefing,
+        briefingHour,
+        lunchEnabled: lunch,
+        lunchStartMinute: lunchStart,
+        lunchEndMinute: lunchEnd,
+        bookingPageAssistant: bookingAssistant,
       });
       setSaved(true);
     } catch (e) {
@@ -163,6 +191,16 @@ export default function SettingsScreen() {
             />
           ))}
         </View>
+
+        <ToggleRow
+          label="AI “find me a time” helper"
+          hint="Show the Otter assistant on your public booking page so visitors can describe when they're free."
+          value={bookingAssistant}
+          onChange={(v) => {
+            setBookingAssistant(v);
+            setSaved(false);
+          }}
+        />
 
         <Text style={styles.section}>Preferences</Text>
         <Text style={styles.label}>Time format</Text>
@@ -265,6 +303,95 @@ export default function SettingsScreen() {
           />
         </View>
 
+        <ToggleRow
+          label="Reclaim cancelled time"
+          hint="When a future meeting is cancelled, hold the freed time as focus instead of re-opening it."
+          value={reclaim}
+          onChange={(v) => {
+            setReclaim(v);
+            setSaved(false);
+          }}
+        />
+        <ToggleRow
+          label="Running-late alerts"
+          hint="Auto-notify your next meeting when one runs over."
+          value={overflow}
+          onChange={(v) => {
+            setOverflow(v);
+            setSaved(false);
+          }}
+        />
+        <ToggleRow
+          label="Post-meeting recap"
+          hint="Get a recap + next-step nudge just after each meeting ends."
+          value={scribe}
+          onChange={(v) => {
+            setScribe(v);
+            setSaved(false);
+          }}
+        />
+        <ToggleRow
+          label="Daily morning briefing"
+          hint="A “here's your day” summary each morning."
+          value={briefing}
+          onChange={(v) => {
+            setBriefing(v);
+            setSaved(false);
+          }}
+        />
+        {briefing ? (
+          <View style={styles.inlineField}>
+            <Text style={styles.label}>Briefing hour (0–23)</Text>
+            <TextInput
+              style={styles.numInput}
+              value={String(briefingHour)}
+              onChangeText={(v) => {
+                setBriefingHour(Math.max(0, Math.min(23, Number(v.replace(/[^0-9]/g, "")) || 0)));
+                setSaved(false);
+              }}
+              keyboardType="number-pad"
+            />
+          </View>
+        ) : null}
+        <ToggleRow
+          label="Lunch break"
+          hint="Block a daily lunch window so it's never bookable."
+          value={lunch}
+          onChange={(v) => {
+            setLunch(v);
+            setSaved(false);
+          }}
+        />
+        {lunch ? (
+          <View style={styles.inlineField}>
+            <Text style={styles.label}>Lunch (start–end hour)</Text>
+            <View style={{ flexDirection: "row", gap: 8 }}>
+              <TextInput
+                style={styles.numInput}
+                value={String(Math.floor(lunchStart / 60))}
+                onChangeText={(v) => {
+                  setLunchStart(
+                    Math.max(0, Math.min(23, Number(v.replace(/[^0-9]/g, "")) || 0)) * 60,
+                  );
+                  setSaved(false);
+                }}
+                keyboardType="number-pad"
+              />
+              <TextInput
+                style={styles.numInput}
+                value={String(Math.floor(lunchEnd / 60))}
+                onChangeText={(v) => {
+                  setLunchEnd(
+                    Math.max(1, Math.min(24, Number(v.replace(/[^0-9]/g, "")) || 1)) * 60,
+                  );
+                  setSaved(false);
+                }}
+                keyboardType="number-pad"
+              />
+            </View>
+          </View>
+        ) : null}
+
         {error ? <Text style={styles.error}>{error}</Text> : null}
 
         <Pressable style={styles.save} onPress={save} disabled={saving}>
@@ -331,6 +458,25 @@ export default function SettingsScreen() {
         </Pressable>
       </ScrollView>
     </SafeAreaView>
+  );
+}
+
+function ToggleRow(props: {
+  label: string;
+  hint?: string;
+  value: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <Pressable style={styles.toggleRow} onPress={() => props.onChange(!props.value)}>
+      <View style={{ flex: 1 }}>
+        <Text style={styles.label}>{props.label}</Text>
+        {props.hint ? <Text style={styles.hint}>{props.hint}</Text> : null}
+      </View>
+      <View style={[styles.switch, props.value && styles.switchOn]}>
+        <View style={[styles.knob, props.value && styles.knobOn]} />
+      </View>
+    </Pressable>
   );
 }
 

--- a/apps/mobile/app/booking/[uid].tsx
+++ b/apps/mobile/app/booking/[uid].tsx
@@ -32,16 +32,29 @@ export default function BookingDetailScreen() {
   const isPast = data ? new Date(data.endsAt).getTime() < Date.now() : false;
 
   function confirmCancel() {
+    // Recurring booking: let the host cancel just this one or the whole series.
+    if (data?.isRecurring) {
+      Alert.alert("Cancel recurring booking?", "This notifies everyone and frees the time.", [
+        { text: "Keep it", style: "cancel" },
+        { text: "This booking only", style: "destructive", onPress: () => doCancel("one") },
+        {
+          text: "This & all later",
+          style: "destructive",
+          onPress: () => doCancel("series"),
+        },
+      ]);
+      return;
+    }
     Alert.alert("Cancel booking?", "This notifies everyone and frees the time.", [
       { text: "Keep it", style: "cancel" },
-      { text: "Cancel booking", style: "destructive", onPress: doCancel },
+      { text: "Cancel booking", style: "destructive", onPress: () => doCancel("one") },
     ]);
   }
 
-  async function doCancel() {
+  async function doCancel(scope: "one" | "series") {
     setCancelling(true);
     try {
-      await api.post(`/api/bookings/${uid}/cancel`, {});
+      await api.post(`/api/bookings/${uid}/cancel`, { scope });
       reload();
     } catch {
       Alert.alert("Could not cancel", "Please try again.");

--- a/apps/mobile/src/models.ts
+++ b/apps/mobile/src/models.ts
@@ -106,6 +106,15 @@ export interface UserPreferences {
   adaptiveAvailability?: boolean;
   maxMeetingsPerDay?: number;
   travelBufferMinutes?: number;
+  reclaimCancelledTime?: boolean;
+  overflowNotifyEnabled?: boolean;
+  briefingEnabled?: boolean;
+  briefingHour?: number;
+  scribeEnabled?: boolean;
+  lunchEnabled?: boolean;
+  lunchStartMinute?: number;
+  lunchEndMinute?: number;
+  bookingPageAssistant?: boolean;
 }
 
 /** Automation rule (GET/POST /api/automations). */
@@ -261,6 +270,8 @@ export interface Team {
 export interface BookingDetail extends Booking {
   eventTypeId: string;
   hostName: string | null;
+  /** True when this booking is one occurrence of a recurring series. */
+  isRecurring?: boolean;
 }
 
 export interface Schedule {

--- a/apps/web/app/api/bookings/[uid]/route.ts
+++ b/apps/web/app/api/bookings/[uid]/route.ts
@@ -23,6 +23,8 @@ export async function GET(_request: Request, { params }: { params: Promise<{ uid
       status: booking.status,
       meetingUrl: booking.meetingUrl,
       hostName: booking.host?.name ?? null,
+      // Part of a recurring series - lets clients offer "cancel this and later".
+      isRecurring: Boolean(booking.recurrenceUid),
       // This endpoint is reachable by anyone holding the (unguessable) uid, so
       // don't disclose every co-attendee's email. Only the primary attendee's
       // email is returned (they're the confirmation recipient); guests get names.

--- a/apps/web/app/api/settings/preferences/route.ts
+++ b/apps/web/app/api/settings/preferences/route.ts
@@ -33,23 +33,27 @@ export const GET = withUser(async (u) => {
   });
 });
 
+// Every field is optional: this is a PARTIAL update. A client (e.g. the mobile
+// app) that sends only a subset must NOT reset the fields it omits - previously
+// zod `.default()` + a full write silently wiped any preference the caller
+// didn't include, so a mobile save reset lunch/scribe/briefing/theme/etc.
 const bodySchema = z.object({
-  timeFormat: z.enum(["12h", "24h"]),
-  weekStartsOn: z.number().int().min(0).max(6),
-  theme: z.enum(["system", "light", "dark"]),
-  defaultReminderOffsets: z.array(z.number().int().min(0).max(43_200)).max(5),
-  adaptiveAvailability: z.boolean().default(false),
-  maxMeetingsPerDay: z.number().int().min(1).max(20).default(5),
-  travelBufferMinutes: z.number().int().min(0).max(240).default(0),
-  reclaimCancelledTime: z.boolean().default(false),
-  overflowNotifyEnabled: z.boolean().default(false),
-  briefingEnabled: z.boolean().default(false),
-  briefingHour: z.number().int().min(0).max(23).default(8),
-  scribeEnabled: z.boolean().default(false),
-  lunchEnabled: z.boolean().default(false),
-  lunchStartMinute: z.number().int().min(0).max(1439).default(720),
-  lunchEndMinute: z.number().int().min(1).max(1440).default(780),
-  bookingPageAssistant: z.boolean().default(true),
+  timeFormat: z.enum(["12h", "24h"]).optional(),
+  weekStartsOn: z.number().int().min(0).max(6).optional(),
+  theme: z.enum(["system", "light", "dark"]).optional(),
+  defaultReminderOffsets: z.array(z.number().int().min(0).max(43_200)).max(5).optional(),
+  adaptiveAvailability: z.boolean().optional(),
+  maxMeetingsPerDay: z.number().int().min(1).max(20).optional(),
+  travelBufferMinutes: z.number().int().min(0).max(240).optional(),
+  reclaimCancelledTime: z.boolean().optional(),
+  overflowNotifyEnabled: z.boolean().optional(),
+  briefingEnabled: z.boolean().optional(),
+  briefingHour: z.number().int().min(0).max(23).optional(),
+  scribeEnabled: z.boolean().optional(),
+  lunchEnabled: z.boolean().optional(),
+  lunchStartMinute: z.number().int().min(0).max(1439).optional(),
+  lunchEndMinute: z.number().int().min(1).max(1440).optional(),
+  bookingPageAssistant: z.boolean().optional(),
 });
 
 export const PATCH = withUser(async (u, request) => {
@@ -57,29 +61,34 @@ export const PATCH = withUser(async (u, request) => {
   if (!parsed.success) return jsonError("Invalid preferences", 400);
   const d = parsed.data;
 
-  // De-duplicate + sort reminder offsets (largest lead time first).
-  const offsets = [...new Set(d.defaultReminderOffsets)].sort((a, b) => b - a);
-  // Guard against an inverted lunch window (end must be after start).
-  const lunchEnabled = d.lunchEnabled && d.lunchEndMinute > d.lunchStartMinute;
+  // Build the update from ONLY the keys the client actually sent.
+  const fields: Partial<typeof schema.userPreferences.$inferInsert> = {};
+  if (d.timeFormat !== undefined) fields.timeFormat = d.timeFormat;
+  if (d.weekStartsOn !== undefined) fields.weekStartsOn = d.weekStartsOn;
+  if (d.theme !== undefined) fields.theme = d.theme;
+  if (d.defaultReminderOffsets !== undefined) {
+    // De-duplicate + sort reminder offsets (largest lead time first).
+    fields.defaultReminderOffsets = [...new Set(d.defaultReminderOffsets)].sort((a, b) => b - a);
+  }
+  if (d.adaptiveAvailability !== undefined) fields.adaptiveAvailability = d.adaptiveAvailability;
+  if (d.maxMeetingsPerDay !== undefined) fields.maxMeetingsPerDay = d.maxMeetingsPerDay;
+  if (d.travelBufferMinutes !== undefined) fields.travelBufferMinutes = d.travelBufferMinutes;
+  if (d.reclaimCancelledTime !== undefined) fields.reclaimCancelledTime = d.reclaimCancelledTime;
+  if (d.overflowNotifyEnabled !== undefined) fields.overflowNotifyEnabled = d.overflowNotifyEnabled;
+  if (d.briefingEnabled !== undefined) fields.briefingEnabled = d.briefingEnabled;
+  if (d.briefingHour !== undefined) fields.briefingHour = d.briefingHour;
+  if (d.scribeEnabled !== undefined) fields.scribeEnabled = d.scribeEnabled;
+  if (d.lunchStartMinute !== undefined) fields.lunchStartMinute = d.lunchStartMinute;
+  if (d.lunchEndMinute !== undefined) fields.lunchEndMinute = d.lunchEndMinute;
+  if (d.bookingPageAssistant !== undefined) fields.bookingPageAssistant = d.bookingPageAssistant;
+  // Guard against an inverted lunch window (end must be after start) when enabling.
+  if (d.lunchEnabled !== undefined) {
+    const start = d.lunchStartMinute ?? 720;
+    const end = d.lunchEndMinute ?? 780;
+    fields.lunchEnabled = d.lunchEnabled && end > start;
+  }
 
-  const fields = {
-    timeFormat: d.timeFormat,
-    weekStartsOn: d.weekStartsOn,
-    theme: d.theme,
-    defaultReminderOffsets: offsets,
-    adaptiveAvailability: d.adaptiveAvailability,
-    maxMeetingsPerDay: d.maxMeetingsPerDay,
-    travelBufferMinutes: d.travelBufferMinutes,
-    reclaimCancelledTime: d.reclaimCancelledTime,
-    overflowNotifyEnabled: d.overflowNotifyEnabled,
-    briefingEnabled: d.briefingEnabled,
-    briefingHour: d.briefingHour,
-    scribeEnabled: d.scribeEnabled,
-    lunchEnabled,
-    lunchStartMinute: d.lunchStartMinute,
-    lunchEndMinute: d.lunchEndMinute,
-    bookingPageAssistant: d.bookingPageAssistant,
-  };
+  if (Object.keys(fields).length === 0) return NextResponse.json({ ok: true });
 
   await getDb()
     .insert(schema.userPreferences)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -104,5 +104,54 @@ including the `/api/book` double-book guard.
 
 ---
 
+## Mobile (Expo) — parity with the web app
+
+The mobile app (`apps/mobile`) covers most host-facing features, but several web
+surfaces have **no mobile screen yet**. Each is a self-contained new screen; the
+web version is the reference. Add a route under `apps/mobile/app/` and follow the
+patterns in the existing screens (e.g. `settings.tsx`, `developer.tsx`).
+
+### 🟡 Android push notifications (Firebase/FCM)
+`expo-notifications` needs FCM on Android, but there's no `google-services.json`,
+so `FirebaseInitProvider` fails and remote reminders don't deliver (push is
+guarded, so it doesn't crash — it just no-ops). Create a Firebase project, add
+`google-services.json`, and wire it via `android.googleServicesFile` in
+`app.json`. Needs a Google/Firebase account (maintainer task).
+
+### 🟡 Stripe Connect payouts screen
+No mobile equivalent of `apps/web/app/(app)/settings/payouts/page.tsx` +
+`apps/web/components/payouts-panel.tsx`. Show per-currency available/pending
+balances and a withdraw action (`/api/payments/withdraw`, connect status).
+
+### 🟡 Session packages / credits
+No mobile equivalent of `apps/web/app/(app)/settings/packages/page.tsx` +
+`apps/web/components/packages-manager.tsx`. Create/manage prepaid session bundles
+per event type.
+
+### 🟡 Group polls (find-a-time)
+No mobile screen for `apps/web/app/(app)/polls/*`. List/create polls and finalize a time.
+
+### 🟡 Routing forms
+No mobile screen for `apps/web/app/(app)/routing/*`. Build/list qualify-and-route forms.
+
+### 🟢 CRM connections
+No mobile screen for `apps/web/app/(app)/settings/crm/page.tsx`. Connect/disconnect
+Salesforce/HubSpot (OAuth start + status).
+
+### 🟢 Billing / edition
+No mobile screen for `apps/web/app/(app)/settings/billing/page.tsx`. Show plan/edition
+and a link to manage the subscription.
+
+### 🟢 Team detail / edit
+Mobile `teams.tsx` is a read-only list; the web has `teams/[id]` for members and
+settings. Add a mobile team detail screen.
+
+### 🟢 Cancel/reschedule reason on mobile
+Whole-series cancel now works on mobile, but the optional **reason** isn't captured
+(Android has no `Alert.prompt`). Add a small text-input modal and pass `reason`
+through to `/api/bookings/[uid]/{cancel,reschedule}`.
+
+---
+
 Don't see your idea here? Open an [issue](../../issues/new/choose) — new proposals
 are welcome.


### PR DESCRIPTION
Brings the mobile app up to par with recent web changes. **Stacked on #56** (the crash fix).

## 🔴 Data-loss bug fixed
A parity audit found that **every preferences save from mobile silently reset 9 settings.** The web `PATCH /api/settings/preferences` applied a zod `.default()` to each omitted field and wrote the whole object, but mobile only sends a subset — so lunch break, post-meeting recap, morning briefing, running-late alerts, reclaim-cancelled-time, the booking-page assistant, and the user's light/dark theme all got wiped to defaults on every mobile save.

**Fix:** `PATCH /api/settings/preferences` is now a true **partial merge** — only the keys actually sent are updated. Protects any client, not just mobile.

## Parity added on mobile
- **Preferences screen** now exposes the fields the recent web changes added: reclaim cancelled time, running-late alerts, post-meeting recap, morning briefing (+ hour), lunch break (+ start/end), and the **booking-page AI "find me a time" assistant** toggle. It no longer sends a hardcoded `theme`, so a web-set theme is preserved (there's no dark mode on mobile yet).
- **Whole-series cancel** for recurring bookings: the web GET now returns `isRecurring`, and the mobile cancel dialog offers **"This booking only"** vs **"This & all later"** (`scope=one|series`), matching the web.

## Deliberately NOT in this PR (larger, separate work)
The audit also flagged host-facing web surfaces with **no mobile screen yet**: Stripe Connect **payouts**, session **packages/credits**, group **polls**, **routing forms**, **CRM** connect, **billing/edition**, and team **detail/edit** (mobile teams is read-only). These are each a new screen, not a recent-change gap — happy to build them next if you want, but they're scoped out here to keep this reviewable. Cancel/reschedule **reason** capture is also skipped on mobile (Android has no `Alert.prompt`; needs a small modal).

Both apps typecheck; Biome clean.