### PR TITLE
docs(readme): expand product story + quick start + mobile app; add Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@
 **The AI-native, open-source scheduling platform.**
 Say it once - Otter books the meeting, protects your focus, and clears the back-and-forth. Confirm-first, always.
 
-[Website](https://dayotter.com) · [Docs](./docs) · [Integration setup](./docs/INTEGRATIONS.md) · [Roadmap](./docs/ROADMAP.md) · [Good first tasks](./docs/TASKS.md) · [AI architecture](./docs/AI.md) · [Contributing](./CONTRIBUTING.md)
+[Website](https://dayotter.com) · [Docs](./docs) · [Discord](https://discord.gg/cxwETDsY85) · [Roadmap](./docs/ROADMAP.md) · [Good first tasks](./docs/TASKS.md) · [AI architecture](./docs/AI.md) · [Contributing](./CONTRIBUTING.md)
 
 ![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)
 ![Self-hostable](https://img.shields.io/badge/self--hostable-yes-brightgreen)
 ![Made with TypeScript](https://img.shields.io/badge/TypeScript-strict-3178c6)
+[![Discord](https://img.shields.io/badge/Discord-join%20the%20community-5865F2?logo=discord&logoColor=white)](https://discord.gg/cxwETDsY85)
 [![GitHub Discussions](https://img.shields.io/github/discussions/Dayotter/dayotter?logo=github&label=discussions)](https://github.com/Dayotter/dayotter/discussions)
 [![GitHub stars](https://img.shields.io/github/stars/Dayotter/dayotter?style=flat&logo=github)](https://github.com/Dayotter/dayotter/stargazers)
 
@@ -17,18 +18,25 @@ Say it once - Otter books the meeting, protects your focus, and clears the back-
 
 ---
 
-## Why DayOtter
+## What is DayOtter?
 
-Calendly is closed and cloud-only. **[Cal.com moved its core to a closed repo in April 2026](https://cal.com/blog/cal-diy-open-source-to-closed-source)** - citing AI - leaving only a stripped-down MIT fork with the commercial features removed. Motion and Reclaim were never open at all.
+DayOtter is a complete scheduling platform — booking pages, team round-robin, calendar sync, reminders, and payments — with an AI assistant, **Otter**, built into the core rather than bolted on.
 
-DayOtter is the alternative that stays genuinely open: **AGPLv3, self-host the _whole_ product** - including every AI feature - for free, forever. Not a demo, not a stripped fork.
+Most schedulers hand out a link and stop there. Otter actually does the work. You describe what you want in plain language — in the app, by voice, or over **WhatsApp / SMS** — and Otter drafts the action; you approve it. It **protects your focus time**, nudges your next meeting when you're **running late**, surfaces **proactive suggestions**, and **learns your patterns** over time. Crucially, it is **confirm-first**: it never changes your calendar without your OK.
 
-And it's built around **Otter**, a confirm-first AI executive assistant that actually does the scheduling work, not just shares a link:
+Think Calendly + Motion + a real assistant — except **open-source and self-hostable in one command**, with every AI feature included.
 
-- Talk to it - in the app, by voice, or over **WhatsApp / SMS**.
-- It **protects your focus time**, warns your next meeting when you're **running late**, and proactively **notices things worth doing**.
-- It **learns your patterns** over time.
-- It **never touches your calendar without your OK.**
+**Who it's for**
+
+- **Individuals** — a booking page and an assistant that clears the scheduling back-and-forth for you.
+- **Teams** — weighted round-robin, collective availability, routing forms, and shared analytics.
+- **Organisations & self-hosters** — run the entire product on your own infrastructure under AGPLv3, keep your calendar data on your servers, and roll the mobile app out to your whole team pointed at your own instance (see [Mobile app](#mobile-app-in-progress)).
+
+## Why we're building it
+
+Scheduling is where a lot of knowledge work quietly leaks time, and the good tools are closing up. Calendly is closed and cloud-only. **[Cal.com moved its core to a closed repo in April 2026](https://cal.com/blog/cal-diy-open-source-to-closed-source)** — citing AI — leaving only a stripped-down MIT fork with the commercial features removed. Motion and Reclaim were never open at all.
+
+We think the assistant that reads your calendar and acts on your time is exactly the thing that should be **open, inspectable, and self-hostable** — not a black box you rent. So DayOtter stays genuinely open: **AGPLv3, self-host the _whole_ product** — including all of Otter's AI — for free, forever. Not a demo, not a stripped fork.
 
 ## Features
 
@@ -41,6 +49,20 @@ And it's built around **Otter**, a confirm-first AI executive assistant that act
 **Insight** · booking analytics + "where your time goes" time-allocation · CSV export
 
 **Platform** · multi-channel reminders (email, Slack, WhatsApp, SMS, push) · automations & workflows · API keys & webhooks · mobile app (Expo, iOS + Android)
+
+## Mobile app (in progress)
+
+A native **iOS + Android** app (`apps/mobile`, built with Expo/React Native) is in active development. It already covers the day-to-day host workflow — dashboard, bookings, availability, event types, calendars, insights, reminders/channels, automations, workflows, and preferences — with voice input for Otter. Remaining screens (payouts, packages, polls, routing) are tracked in [`docs/TASKS.md`](./docs/TASKS.md).
+
+**Bring your own server — built for organisations.** The app isn't hard-wired to our cloud. It ships with a **Server** setting where anyone can point the same app at *their own* self-hosted DayOtter instance. So an organisation can:
+
+1. Self-host DayOtter once (Docker Compose — see below).
+2. Have their team install the **same** app from the store (or an internal/EAS build).
+3. Each person switches the server to the org's instance and signs in — their data never leaves the org's infrastructure.
+
+No forking, no per-org app build required. One app, any DayOtter server.
+
+> Note: the app is pre-1.0 and evolving quickly. Android push needs a Firebase `google-services.json` to deliver remote reminders — see [`docs/TASKS.md`](./docs/TASKS.md).
 
 ## Open-core
 
@@ -73,22 +95,33 @@ Full breakdown: [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md).
 
 ## Quick start (development)
 
+**Prerequisites:** Node 20+, [pnpm](https://pnpm.io) 9+, and Docker (for Postgres + Redis). Everything else installs with `pnpm install`.
+
 ```bash
-# 1. Datastores (Postgres + Redis)
+git clone https://github.com/Dayotter/dayotter && cd dayotter
+
+# 1. Datastores — starts Postgres + Redis in the background
 docker compose up -d
 
-# 2. Config - fill in OAuth creds + generate secrets
+# 2. Config — copy the example and fill in what you need. It runs with sane
+#    defaults; add OAuth creds + ANTHROPIC_API_KEY to enable calendar sync + Otter.
 cp .env.example .env
 
-# 3. Install & create the schema
+# 3. Install deps and create the database schema
 pnpm install
 pnpm db:push
 
-# 4. Run web (:3000) + worker
+# 4. Run the web app (:3000) + the background worker together
 pnpm dev
 ```
 
-**Stack:** TypeScript · Next.js 15 · Postgres + Drizzle · Redis + BullMQ · Luxon · Anthropic (Otter) · Better Auth · Stripe · Twilio.
+Open **http://localhost:3000**, create an account, and you have a working booking page. Integrations (Google/Microsoft calendar, Stripe, Twilio, AI) are all optional and off until you add their keys — see [`docs/INTEGRATIONS.md`](./docs/INTEGRATIONS.md).
+
+Run the mobile app against your local server with `pnpm --filter @dayotter/mobile start` (point its **Server** setting at your machine).
+
+**Common commands:** `pnpm dev` · `pnpm typecheck` · `pnpm test` · `pnpm check` (Biome format + lint). See [`AGENTS.md`](./AGENTS.md) for conventions.
+
+**Stack:** TypeScript · Next.js 15 · Expo (mobile) · Postgres + Drizzle · Redis + BullMQ · Luxon · Anthropic (Otter) · Better Auth · Stripe · Twilio.
 
 ## Self-hosting (production)
 
@@ -98,12 +131,11 @@ Docker Compose brings up Postgres, Redis, migrations, web, worker, and a reverse
 
 ## Community
 
-- 💬 **[Discussions](https://github.com/Dayotter/dayotter/discussions)** - ask a question (Q&A), propose an idea, or show what you built. This is the best place to start.
+- 💬 **[Discord](https://discord.gg/cxwETDsY85)** - real-time chat with the community and the team. Come say hi.
+- 🗣️ **[Discussions](https://github.com/Dayotter/dayotter/discussions)** - ask a question (Q&A), propose an idea, or show what you built. Durable, searchable answers live here.
 - 🐛 **[Issues](../../issues/new/choose)** - report a bug or request a feature.
 - 🔒 **[Security policy](./SECURITY.md)** - report a vulnerability privately (don't open a public issue).
 - 🤝 **[Code of conduct](./CODE_OF_CONDUCT.md)** · **[How to get help](./SUPPORT.md)**
-
-Real-time chat (Discord) is coming as the community grows - for now, Discussions is the hub so answers stay searchable for the next person.
 
 ## Contributing
 

--- a/apps/web/lib/marketing.ts
+++ b/apps/web/lib/marketing.ts
@@ -11,8 +11,8 @@ export const BRAND = {
   githubContributing: "https://github.com/Dayotter/dayotter/blob/main/CONTRIBUTING.md",
   /** GitHub Discussions - the durable, searchable community home. */
   discussions: "https://github.com/Dayotter/dayotter/discussions",
-  /** Real-time chat. Empty until the server is live; footer hides it when unset. */
-  discord: "",
+  /** Real-time community chat. Footer + README link to it. */
+  discord: "https://discord.gg/cxwETDsY85",
   x: "https://x.com/dayotter",
   copyrightYear: 2026,
 };


### PR DESCRIPTION
## README
- **What is DayOtter?** — a fuller product description (what it is, that Otter *does* the work confirm-first) plus a **Who it's for** breakdown (individuals / teams / organisations).
- **Why we're building it** — the case for an open, self-hostable scheduling assistant (the Calendly/Cal.com closing narrative, reframed around *why it matters*).
- **Quick start** — prerequisites, each step explained, first-run instructions, and common commands.
- **Mobile app (in progress)** — new section. Calls out that it's pre-1.0 and, importantly, **bring-your-own-server**: the same app has a Server setting so an organisation can self-host once and have their whole team point the app at their own instance (data stays on their infra, no per-org build).

## Discord (website + GitHub)
- README: nav link, a Discord badge, and the Community section now leads with the invite.
- Website: set `BRAND.discord = https://discord.gg/cxwETDsY85` so the marketing footer's Community column links to it (verified rendering in the preview).

Typecheck + Biome clean.