### PR TITLE
feat(calendar): generic CalDAV connect (Fastmail/Nextcloud/…) + SSRF hardening

### DIFF
--- a/apps/web/app/(app)/settings/calendars/page.tsx
+++ b/apps/web/app/(app)/settings/calendars/page.tsx
@@ -15,7 +15,7 @@ export const dynamic = "force-dynamic";
 const PROVIDERS = [
   { id: "google", name: "Google Calendar", color: "#4285F4", available: true },
   { id: "microsoft", name: "Microsoft 365 / Outlook", color: "#0078D4", available: true },
-  { id: "apple", name: "Apple iCloud", color: "#A2AAAD", available: true },
+  { id: "apple", name: "Apple iCloud / CalDAV", color: "#A2AAAD", available: true },
   { id: "ics", name: "Calendar feed (ICS)", color: "#6366F1", available: true },
 ] as const;
 

--- a/apps/web/app/api/calendars/apple/route.ts
+++ b/apps/web/app/api/calendars/apple/route.ts
@@ -6,8 +6,10 @@ import { z } from "zod";
 export const dynamic = "force-dynamic";
 
 const bodySchema = z.object({
-  username: z.string().email("Enter your Apple ID email"),
-  password: z.string().min(1, "Enter your app-specific password"),
+  // Apple IDs are emails, but generic CalDAV usernames (Nextcloud, Radicale) may
+  // not be - accept any non-empty string.
+  username: z.string().min(1, "Enter your username"),
+  password: z.string().min(1, "Enter your password"),
   serverUrl: z.string().url().optional(),
 });
 

--- a/apps/web/components/apple-connect-form.tsx
+++ b/apps/web/components/apple-connect-form.tsx
@@ -8,25 +8,44 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 /**
- * Apple iCloud connect - a form-based flow (app-specific password) rather than an
- * OAuth redirect. Verifies credentials server-side and shows inline feedback.
+ * CalDAV connect - a form-based flow (app-specific / account password) rather
+ * than an OAuth redirect. Works with Apple iCloud, Fastmail, mailbox.org, or any
+ * other CalDAV server (Nextcloud, Radicale, self-hosted). Credentials are
+ * verified server-side (which also SSRF-checks a custom server URL) with inline
+ * feedback.
  */
+
+/** Known CalDAV endpoints. `url: null` = the server default (Apple iCloud);
+ *  `url: "custom"` = prompt for the server URL. */
+const PRESETS = [
+  { id: "apple", label: "Apple iCloud", url: null as string | null, custom: false },
+  { id: "fastmail", label: "Fastmail", url: "https://caldav.fastmail.com/", custom: false },
+  { id: "mailbox", label: "mailbox.org", url: "https://dav.mailbox.org/", custom: false },
+  { id: "other", label: "Other CalDAV server", url: null, custom: true },
+] as const;
+
 export function AppleConnectForm({ name, color }: { name: string; color: string }) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
+  const [preset, setPreset] = useState<(typeof PRESETS)[number]["id"]>("apple");
+  const [customUrl, setCustomUrl] = useState("");
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const selected = PRESETS.find((p) => p.id === preset) ?? PRESETS[0];
+  const isApple = preset === "apple";
+
   async function connect(e: React.FormEvent) {
     e.preventDefault();
     setSubmitting(true);
     setError(null);
+    const serverUrl = selected.custom ? customUrl.trim() : (selected.url ?? undefined);
     const res = await fetch("/api/calendars/apple", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ username, password }),
+      body: JSON.stringify({ username, password, ...(serverUrl ? { serverUrl } : {}) }),
     });
     setSubmitting(false);
     if (!res.ok) {
@@ -37,6 +56,7 @@ export function AppleConnectForm({ name, color }: { name: string; color: string 
     setOpen(false);
     setUsername("");
     setPassword("");
+    setCustomUrl("");
     router.refresh();
   }
 
@@ -63,37 +83,78 @@ export function AppleConnectForm({ name, color }: { name: string; color: string 
           className="mt-4 space-y-3 border-t border-[var(--color-border)] pt-4"
         >
           <div>
-            <Label htmlFor="apple-id">Apple ID</Label>
+            <Label htmlFor="caldav-provider">Provider</Label>
+            <select
+              id="caldav-provider"
+              value={preset}
+              onChange={(e) => setPreset(e.target.value as (typeof PRESETS)[number]["id"])}
+              className="h-10 w-full rounded-md border border-[var(--color-border-strong)] bg-[var(--color-bg)] px-3 text-sm text-[var(--color-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+            >
+              {PRESETS.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {selected.custom ? (
+            <div>
+              <Label htmlFor="caldav-url">CalDAV server URL</Label>
+              <Input
+                id="caldav-url"
+                type="url"
+                required
+                value={customUrl}
+                onChange={(e) => setCustomUrl(e.target.value)}
+                placeholder="https://cloud.example.com/remote.php/dav"
+              />
+              <p className="mt-1 text-xs text-[var(--color-faint)]">
+                Must be a public HTTPS endpoint. For Nextcloud it's usually{" "}
+                <code>https://your-server/remote.php/dav</code>.
+              </p>
+            </div>
+          ) : null}
+
+          <div>
+            <Label htmlFor="caldav-user">{isApple ? "Apple ID" : "Email / username"}</Label>
             <Input
-              id="apple-id"
-              type="email"
+              id="caldav-user"
+              type={isApple ? "email" : "text"}
               required
               value={username}
               onChange={(e) => setUsername(e.target.value)}
-              placeholder="you@icloud.com"
+              placeholder={isApple ? "you@icloud.com" : "you@example.com"}
+              autoCapitalize="none"
             />
           </div>
           <div>
-            <Label htmlFor="apple-pw">App-specific password</Label>
+            <Label htmlFor="caldav-pw">{isApple ? "App-specific password" : "Password"}</Label>
             <Input
-              id="apple-pw"
+              id="caldav-pw"
               type="password"
               required
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              placeholder="xxxx-xxxx-xxxx-xxxx"
+              placeholder={isApple ? "xxxx-xxxx-xxxx-xxxx" : "app password"}
             />
             <p className="mt-1 text-xs text-[var(--color-faint)]">
-              Not your Apple password - generate one at{" "}
-              <a
-                href="https://account.apple.com/account/manage"
-                target="_blank"
-                rel="noreferrer"
-                className="text-[var(--color-accent)] hover:underline"
-              >
-                account.apple.com
-              </a>{" "}
-              → App-Specific Passwords.
+              {isApple ? (
+                <>
+                  Not your Apple password - generate one at{" "}
+                  <a
+                    href="https://account.apple.com/account/manage"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-[var(--color-accent)] hover:underline"
+                  >
+                    account.apple.com
+                  </a>{" "}
+                  → App-Specific Passwords.
+                </>
+              ) : (
+                "Use an app password if your provider offers one (recommended over your main password)."
+              )}
             </p>
           </div>
           <FormError>{error}</FormError>

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -71,13 +71,23 @@ provider rejects the callback.
    ```
 - Push sync uses `APP_URL/api/webhooks/microsoft` (auto).
 
-## Apple iCloud
+## Apple iCloud & CalDAV
 
-No developer setup or env vars - Apple calendars connect over **CalDAV** with a
-per-user **app-specific password**. Each user generates one at
-[appleid.apple.com](https://appleid.apple.com) (Sign-In & Security → App-Specific
-Passwords) and pastes it in **Settings → Calendars → Apple**. Never their real
-Apple ID password.
+No developer setup or env vars - these connect over **CalDAV** with a per-user
+username + password, verified server-side on connect.
+
+- **Apple iCloud:** generate an **app-specific password** at
+  [appleid.apple.com](https://appleid.apple.com) (Sign-In & Security → App-Specific
+  Passwords) and paste it in **Settings → Calendars → Apple iCloud / CalDAV**.
+  Never the real Apple ID password.
+- **Any other CalDAV server** (Fastmail, mailbox.org, Nextcloud, Radicale,
+  self-hosted): pick the provider (or "Other CalDAV server" and enter the server
+  URL, e.g. `https://cloud.example.com/remote.php/dav` for Nextcloud) in the same
+  dialog. The URL must be a public HTTPS endpoint - it's DNS-resolved and rejected
+  if it points at an internal/private address (SSRF-safe).
+
+CalDAV calendars have no push webhooks, so DayOtter polls them on an interval
+(CTag/ETag reconciled) rather than receiving live updates.
 
 ## Salesforce (CRM sync)
 

--- a/packages/calendar/src/providers/apple.ts
+++ b/packages/calendar/src/providers/apple.ts
@@ -1,3 +1,4 @@
+import { resolvePublicIp } from "@dayotter/core";
 import icalGenerator from "ical-generator";
 import ical from "node-ical";
 // tsdav is CommonJS; a named ESM import isn't statically resolvable at runtime,
@@ -17,19 +18,16 @@ const { createDAVClient } = tsdav;
 
 const ICLOUD_CALDAV = "https://caldav.icloud.com";
 
-/** Hostnames / IP-literal patterns that must never be used as a CalDAV target -
- * blocks SSRF to cloud metadata, loopback, and private ranges when a user
- * supplies a custom `serverUrl`. */
-const BLOCKED_HOST =
-  /^(localhost|.*\.local|0\.0\.0\.0|127\.|10\.|192\.168\.|169\.254\.|::1|\[?::1\]?|\[?fc00:|\[?fe80:)/i;
-const BLOCKED_172 = /^172\.(1[6-9]|2\d|3[01])\./;
-
 /**
  * Reject a user-supplied CalDAV server URL that isn't a public https endpoint.
- * Defends against SSRF (e.g. `http://169.254.169.254/…`, localhost, private
- * ranges) before we make any server-side request to it.
+ * We now invite arbitrary CalDAV URLs (Nextcloud, Fastmail, self-hosted, ...), so
+ * a hostname allow-list isn't enough: RESOLVE the host and reject any address in
+ * a private/loopback/link-local range (defeats `internal.corp` or a domain that
+ * points at 169.254.169.254 / 127.0.0.1). NB: tsdav re-resolves DNS when it
+ * connects, so this is check-then-use, not a hard IP pin - good enough here since
+ * the credentials are the user's own, but keep it in mind.
  */
-function assertPublicHttpsUrl(raw: string): void {
+async function assertPublicHttpsUrl(raw: string): Promise<void> {
   let url: URL;
   try {
     url = new URL(raw);
@@ -37,8 +35,9 @@ function assertPublicHttpsUrl(raw: string): void {
     throw new Error("Invalid CalDAV server URL");
   }
   if (url.protocol !== "https:") throw new Error("CalDAV server URL must use https");
-  const host = url.hostname.toLowerCase();
-  if (BLOCKED_HOST.test(host) || BLOCKED_172.test(host)) {
+  try {
+    await resolvePublicIp(url.hostname); // throws if it resolves to an internal IP
+  } catch {
     throw new Error("CalDAV server URL points at a disallowed (internal) host");
   }
 }
@@ -70,7 +69,7 @@ export class AppleCalendarAdapter implements CalendarAdapter {
 
   static async connect(creds: AppleCredentials): Promise<AppleCalendarAdapter> {
     const serverUrl = creds.serverUrl ?? ICLOUD_CALDAV;
-    if (creds.serverUrl) assertPublicHttpsUrl(creds.serverUrl);
+    if (creds.serverUrl) await assertPublicHttpsUrl(creds.serverUrl);
     const client = await createDAVClient({
       serverUrl,
       credentials: { username: creds.username, password: creds.password },


### PR DESCRIPTION
Makes CalDAV a first-class, self-serve integration — not just Apple iCloud.

## The gap
The CalDAV adapter (`packages/calendar/src/providers/apple.ts`) already accepted a custom `serverUrl`, and the API route already validated one — but the **connect UI only collected Apple iCloud credentials and never sent a server URL**, so no one could actually connect Fastmail, Nextcloud, Radicale, mailbox.org, or a self-hosted CalDAV server.

## Changes
- **Connect UI** (`apple-connect-form.tsx`): a provider picker — **Apple iCloud / Fastmail / mailbox.org / Other CalDAV server** — with a server-URL field for custom servers and provider-aware labels/help. Sends `serverUrl` for non-iCloud providers.
- **Route**: relax `username` from email-only to any non-empty string (Nextcloud/Radicale usernames aren't emails).
- **SSRF hardening** (the important one): now that we invite arbitrary user-supplied CalDAV URLs, the old hostname *regex* allow-list isn't enough — a domain that **resolves** to `169.254.169.254` / `127.0.0.1` / a private range would slip through. Replaced it with a **DNS-resolving** check (`resolvePublicIp` from `@dayotter/core`) that rejects any resolved internal address. (Documented the residual check-then-connect caveat, since tsdav re-resolves on connect.)
- Relabel the settings entry **Apple iCloud → Apple iCloud / CalDAV**; documented generic CalDAV in `docs/INTEGRATIONS.md`.

The adapter's sync (poll-based, CTag/ETag, busy projection, create/update/delete) was already complete and unchanged.

calendar + core + web typecheck; Biome clean.