### PR TITLE
feat(ai): vendor-agnostic AI layer (Claude, OpenAI, or any compatible endpoint)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,8 +95,23 @@ NEXT_PUBLIC_POSTHOG_KEY=
 NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 
 # ---- AI scheduling (optional) ----
-# Anthropic API key. AI quick-add is hidden unless set. Confirm-first, scheduling-only.
+# Otter runs on Claude by default. Switch providers with AI_PROVIDER:
+#   anthropic (default) | openai
+# "openai" also covers any OpenAI-COMPATIBLE endpoint (Groq, OpenRouter, Together,
+# Azure OpenAI, a local Ollama / LM Studio) via OPENAI_BASE_URL. Every AI feature
+# works on either; the streaming conversational command bar is Anthropic-only for now.
+AI_PROVIDER=anthropic
+
+# Anthropic (used when AI_PROVIDER=anthropic). AI is hidden unless a key is set.
 ANTHROPIC_API_KEY=
+# ANTHROPIC_MODEL_DEEP=claude-opus-4-8
+# ANTHROPIC_MODEL_FAST=claude-haiku-4-5
+
+# OpenAI / OpenAI-compatible (used when AI_PROVIDER=openai)
+# OPENAI_API_KEY=
+# OPENAI_BASE_URL=            # e.g. https://openrouter.ai/api/v1 or http://localhost:11434/v1
+# OPENAI_MODEL_DEEP=gpt-4.1
+# OPENAI_MODEL_FAST=gpt-4.1-mini
 
 # ---- Reminder channels (optional) ----
 # Slack and mobile push need no server creds - the destination is stored per-user.

--- a/apps/web/app/api/ai/chat/route.ts
+++ b/apps/web/app/api/ai/chat/route.ts
@@ -1,6 +1,6 @@
 import { type ChatEvent, type ChatTurn, streamAssistant } from "@/lib/ai/chat";
 import { SCOPE_REFUSAL, latestUserText, screenUserInput } from "@/lib/ai/guardrails";
-import { aiEnabled } from "@/lib/ai/llm";
+import { aiEnabled, supportsAgentTools } from "@/lib/ai/llm";
 import { requireFeature } from "@/lib/billing/require-feature";
 import { jsonError, withUser } from "@/lib/server/http";
 import { enforceRateLimit } from "@/lib/server/rate-limit";
@@ -32,6 +32,15 @@ const body = z.object({
  */
 export const POST = withUser(async (u, request) => {
   if (!aiEnabled) return jsonError("AI scheduling isn't enabled on this server.", 503);
+  // The streaming, multi-turn command bar uses provider-native tool-use, which is
+  // Anthropic-only today. Other providers still power the quick command bar and
+  // every other AI feature (they go through the vendor-agnostic `extract`).
+  if (!supportsAgentTools) {
+    return jsonError(
+      "The conversational assistant needs the Anthropic provider. Use the quick command instead.",
+      503,
+    );
+  }
   const gate = await requireFeature(u.id, "ai");
   if (gate) return gate;
 

--- a/apps/web/lib/ai/llm.ts
+++ b/apps/web/lib/ai/llm.ts
@@ -1,69 +1,28 @@
-import Anthropic from "@anthropic-ai/sdk";
-import { logger } from "@dayotter/core";
-import { managedAnthropicKey } from "../ee/managed-ai";
+import type Anthropic from "@anthropic-ai/sdk";
+import { MODELS, anthropicClient } from "./providers/anthropic";
+import { aiEnabled, provider, supportsAgentTools } from "./providers/index";
+import type { Effort, ModelTier } from "./providers/types";
 
 /**
  * The single LLM layer for the whole platform. Every AI feature goes through
- * here - no feature instantiates its own client, picks its own model, or hand-
- * rolls its own request. This centralizes: model tiering, the API key gate,
- * structured-extraction mechanics (forced tool-use → validated object),
- * chain-of-thought, prompt caching, streaming, error handling, and logging.
- * Add a capability here; consume it from feature modules.
+ * here - no feature instantiates its own client or picks its own model. The
+ * actual vendor lives behind a provider abstraction (`./providers`) selected by
+ * `AI_PROVIDER`, so this facade is vendor-agnostic: Otter runs on Claude, OpenAI,
+ * or any OpenAI-compatible endpoint without any feature module changing.
  */
 
-/**
- * The key the platform uses. Self-host: the operator's own `ANTHROPIC_API_KEY`.
- * Cloud: falls back to DayOtter's managed key (the cloud-only "Managed AI"
- * feature) so Pro customers don't bring their own.
- */
-const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY || managedAnthropicKey;
-
-/** AI is optional platform-wide - nothing calls out unless a key is available. */
-export const aiEnabled = Boolean(ANTHROPIC_KEY);
-
-/**
- * Model tiers. Pick per task, not per feature:
- * - `deep` - highest quality, for genuine reasoning (planning a reschedule,
- *   resolving an ambiguous request, drafting a message).
- * - `fast` - low-latency + low-cost, for simple, well-bounded extraction or
- *   classification (parse a date, pick accept/decline). "Fast inference."
- * Change the actual model string in exactly one place.
- */
-export const MODELS = {
-  deep: "claude-opus-4-8",
-  fast: "claude-haiku-4-5",
-} as const;
-export type ModelTier = keyof typeof MODELS;
-
-let client: Anthropic | null = null;
-function getClient(): Anthropic {
-  if (!client) client = new Anthropic({ apiKey: ANTHROPIC_KEY });
-  return client;
-}
-
-/**
- * Build the `system` param. When cached, the (large, static) system prompt is
- * marked with `cache_control` so repeated calls with the same prompt read it
- * from cache - lower latency and ~10× cheaper on the cached prefix. Keep the
- * system prompt static (no per-request timestamps) for the cache to hit.
- */
-function buildSystem(system: string, cache: boolean): string | Anthropic.TextBlockParam[] {
-  if (!cache) return system;
-  return [{ type: "text", text: system, cache_control: { type: "ephemeral" } }];
-}
-
-/** Thinking depth for the deep tier. Higher = more reasoning, more tokens/latency. */
-export type Effort = "low" | "medium" | "high" | "xhigh" | "max";
+export { aiEnabled, supportsAgentTools, MODELS };
+export type { ModelTier, Effort };
 
 export interface ExtractOptions<T> {
   /** System prompt - set the assistant's scope and rules here. Keep it static so it caches. */
   system: string;
   /** The user's request / the content to interpret. */
   user: string;
-  /** Name of the output tool. Retained for back-compat / logging; not sent to the API. */
+  /** Retained for back-compat / logging; not sent to the API. */
   toolName?: string;
   toolDescription?: string;
-  /** JSON Schema for the output. Structured outputs constrains the reply to it. */
+  /** JSON Schema for the output. The reply is constrained to it. */
   inputSchema: Record<string, unknown>;
   /** Validate/narrow the raw output into `T` (e.g. a Zod `.parse`). */
   parse: (input: unknown) => T;
@@ -72,66 +31,41 @@ export interface ExtractOptions<T> {
   feature: string;
   /** Model tier (default `deep`). Use `fast` for simple, latency-sensitive tasks. */
   tier?: ModelTier;
-  /** Cache the system prompt (default true). Disable only for tiny/one-off prompts. */
+  /** Cache the system prompt where supported (default true). */
   cacheSystem?: boolean;
-  /** Reasoning effort on the deep tier (default `medium`). Ignored on the fast tier. */
+  /** Reasoning effort on the deep tier (default `medium`); providers ignore it if unsupported. */
   effort?: Effort;
 }
 
 /**
- * The platform's single structured-extraction primitive: prompt Claude,
- * constrain the reply to a JSON schema (structured outputs), and hand back a
- * validated object. Used by every AI feature that needs structured output.
- *
- * Chain-of-thought: on the deep tier this runs with adaptive thinking, so the
- * model reasons (internally) before producing the constrained JSON - better
- * results. Consumers may ALSO keep a leading `reasoning` field in the schema to
- * surface a short rationale (the raw thinking is not returned by default).
- * The fast tier (Haiku) omits thinking/effort - it doesn't support them.
+ * The platform's single structured-extraction primitive: prompt the model,
+ * constrain the reply to a JSON schema, hand back a validated object. Works on
+ * whichever provider is configured.
  */
 export async function extract<T>(opts: ExtractOptions<T>): Promise<T> {
-  const tier = opts.tier ?? "deep";
-  const model = MODELS[tier];
-  const deep = tier === "deep";
-  const started = Date.now();
-
-  const response = await getClient().messages.create({
-    model,
-    // Adaptive thinking shares the budget with the output, so give the deep tier
-    // generous headroom above the small JSON - otherwise heavy reasoning on a
-    // complex request could truncate the structured output (→ a parse failure).
-    max_tokens: opts.maxTokens ?? (deep ? 4096 : 1024),
-    system: buildSystem(opts.system, opts.cacheSystem !== false),
-    output_config: {
-      format: { type: "json_schema", schema: opts.inputSchema as Record<string, unknown> },
-      ...(deep ? { effort: opts.effort ?? "medium" } : {}),
-    },
-    ...(deep ? { thinking: { type: "adaptive" as const } } : {}),
-    messages: [{ role: "user", content: opts.user }],
-  });
-
-  const text = response.content.find((b) => b.type === "text");
-  if (!text || text.type !== "text") {
-    logger.error("llm returned no structured result", {
-      event: "llm_no_result",
-      feature: opts.feature,
-      model,
-      // Surface a truncation so it's diagnosable rather than a bare parse failure.
-      stopReason: response.stop_reason,
-    });
-    throw new Error("The assistant did not return a result");
-  }
-  logger.info("llm extract", {
-    event: "llm_extract",
+  const raw = await provider.extract({
+    system: opts.system,
+    user: opts.user,
+    inputSchema: opts.inputSchema,
     feature: opts.feature,
-    model,
-    ms: Date.now() - started,
-    inputTokens: response.usage.input_tokens,
-    cacheReadTokens: response.usage.cache_read_input_tokens ?? 0,
-    outputTokens: response.usage.output_tokens,
+    tier: opts.tier ?? "deep",
+    maxTokens: opts.maxTokens,
+    cacheSystem: opts.cacheSystem,
+    effort: opts.effort,
   });
-  return opts.parse(JSON.parse(text.text) as unknown);
+  return opts.parse(raw);
 }
 
-/** Re-exported so the agent loop can build tool-use requests against the shared client + tiers. */
-export { getClient as getAnthropicClient };
+/**
+ * Raw Anthropic client for the streaming agentic tool-use loop (the command bar).
+ * That loop is Anthropic-specific; throws a clear error if a different provider
+ * is active so the caller can degrade to the vendor-agnostic command path.
+ */
+export function getAnthropicClient(): Anthropic {
+  if (provider.name !== "anthropic") {
+    throw new Error(
+      "The conversational command bar requires the Anthropic provider (set AI_PROVIDER=anthropic).",
+    );
+  }
+  return anthropicClient();
+}

--- a/apps/web/lib/ai/providers/anthropic.ts
+++ b/apps/web/lib/ai/providers/anthropic.ts
@@ -1,0 +1,85 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { logger } from "@dayotter/core";
+import { managedAnthropicKey } from "../../ee/managed-ai";
+import type { ExtractRequest, LlmProvider, ModelTier } from "./types";
+
+/**
+ * Anthropic (Claude) provider - the default. Structured extraction uses the
+ * native structured-outputs `output_config` plus adaptive thinking on the deep
+ * tier. This is also the only provider that backs the streaming agentic tool-use
+ * loop (the command bar) today, so it exposes its raw client.
+ */
+
+const KEY = process.env.ANTHROPIC_API_KEY || managedAnthropicKey;
+
+/** Anthropic models per tier. Also used by the agentic tool-use loop, which is
+ *  Anthropic-only, so it reads these directly. */
+export const MODELS: Record<ModelTier, string> = {
+  deep: process.env.ANTHROPIC_MODEL_DEEP || "claude-opus-4-8",
+  fast: process.env.ANTHROPIC_MODEL_FAST || "claude-haiku-4-5",
+};
+
+let client: Anthropic | null = null;
+function getClient(): Anthropic {
+  if (!client) client = new Anthropic({ apiKey: KEY });
+  return client;
+}
+
+/** Raw client for the agentic tool-use loop (lib/ai/chat.ts, agent.ts). */
+export function anthropicClient(): Anthropic {
+  return getClient();
+}
+
+function buildSystem(system: string, cache: boolean): string | Anthropic.TextBlockParam[] {
+  if (!cache) return system;
+  return [{ type: "text", text: system, cache_control: { type: "ephemeral" } }];
+}
+
+export const anthropicProvider: LlmProvider = {
+  name: "anthropic",
+  configured: Boolean(KEY),
+  supportsAgentTools: true,
+
+  async extract(req: ExtractRequest): Promise<unknown> {
+    const deep = req.tier === "deep";
+    const model = MODELS[req.tier];
+    const started = Date.now();
+
+    const response = await getClient().messages.create({
+      model,
+      // Adaptive thinking shares the budget with the output; give the deep tier
+      // headroom above the small JSON so heavy reasoning can't truncate it.
+      max_tokens: req.maxTokens ?? (deep ? 4096 : 1024),
+      system: buildSystem(req.system, req.cacheSystem !== false),
+      output_config: {
+        format: { type: "json_schema", schema: req.inputSchema },
+        ...(deep ? { effort: req.effort ?? "medium" } : {}),
+      },
+      ...(deep ? { thinking: { type: "adaptive" as const } } : {}),
+      messages: [{ role: "user", content: req.user }],
+    });
+
+    const text = response.content.find((b) => b.type === "text");
+    if (!text || text.type !== "text") {
+      logger.error("llm returned no structured result", {
+        event: "llm_no_result",
+        provider: "anthropic",
+        feature: req.feature,
+        model,
+        stopReason: response.stop_reason,
+      });
+      throw new Error("The assistant did not return a result");
+    }
+    logger.info("llm extract", {
+      event: "llm_extract",
+      provider: "anthropic",
+      feature: req.feature,
+      model,
+      ms: Date.now() - started,
+      inputTokens: response.usage.input_tokens,
+      cacheReadTokens: response.usage.cache_read_input_tokens ?? 0,
+      outputTokens: response.usage.output_tokens,
+    });
+    return JSON.parse(text.text) as unknown;
+  },
+};

--- a/apps/web/lib/ai/providers/index.ts
+++ b/apps/web/lib/ai/providers/index.ts
@@ -1,0 +1,23 @@
+import { anthropicClient, anthropicProvider } from "./anthropic";
+import { openaiProvider } from "./openai";
+import type { LlmProvider } from "./types";
+
+/**
+ * Selects the active LLM provider from `AI_PROVIDER` (default `anthropic`).
+ * Set `AI_PROVIDER=openai` (with `OPENAI_API_KEY`, optionally `OPENAI_BASE_URL`
+ * + `OPENAI_MODEL_DEEP/FAST`) to run Otter on OpenAI or any OpenAI-compatible
+ * endpoint. Every `extract`-based feature works on either; the streaming command
+ * bar is Anthropic-only for now (see `supportsAgentTools`).
+ */
+const SELECTED = (process.env.AI_PROVIDER || "anthropic").toLowerCase();
+
+export const provider: LlmProvider = SELECTED === "openai" ? openaiProvider : anthropicProvider;
+
+/** AI is optional platform-wide - on only when the active provider is configured. */
+export const aiEnabled = provider.configured;
+
+/** Whether the active, configured provider backs the streaming agentic command bar. */
+export const supportsAgentTools = provider.configured && provider.supportsAgentTools;
+
+export { anthropicClient };
+export type { Effort, ExtractRequest, LlmProvider, ModelTier } from "./types";

--- a/apps/web/lib/ai/providers/openai.ts
+++ b/apps/web/lib/ai/providers/openai.ts
@@ -1,0 +1,94 @@
+import { logger } from "@dayotter/core";
+import OpenAI from "openai";
+import type { ExtractRequest, LlmProvider, ModelTier } from "./types";
+
+/**
+ * OpenAI-compatible provider. Works with OpenAI itself and with any endpoint
+ * that speaks the OpenAI Chat Completions API - Groq, OpenRouter, Together,
+ * Azure OpenAI, a local Ollama / LM Studio, etc. - by pointing `OPENAI_BASE_URL`
+ * at it. Models are env-configurable so you can name whatever the endpoint hosts.
+ *
+ * Structured output uses the portable path: request JSON-object mode and put the
+ * JSON Schema in the system prompt, then JSON-parse the reply. (`json_object` is
+ * supported almost everywhere; `json_schema` is OpenAI-specific.) The caller
+ * still validates the object with its Zod schema, so a stray field is caught.
+ */
+
+const KEY = process.env.OPENAI_API_KEY || "";
+const BASE_URL = process.env.OPENAI_BASE_URL || undefined;
+
+const MODELS: Record<ModelTier, string> = {
+  deep: process.env.OPENAI_MODEL_DEEP || "gpt-4.1",
+  fast: process.env.OPENAI_MODEL_FAST || "gpt-4.1-mini",
+};
+
+let client: OpenAI | null = null;
+function getClient(): OpenAI {
+  if (!client) client = new OpenAI({ apiKey: KEY, baseURL: BASE_URL });
+  return client;
+}
+
+/** Strip ```json … ``` fences some models wrap around JSON. */
+function unwrapJson(raw: string): string {
+  const m = raw.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  return (m?.[1] ?? raw).trim();
+}
+
+export const openaiProvider: LlmProvider = {
+  name: "openai",
+  configured: Boolean(KEY),
+  supportsAgentTools: false,
+
+  async extract(req: ExtractRequest): Promise<unknown> {
+    const model = MODELS[req.tier];
+    const started = Date.now();
+    const system = `${req.system}
+
+Respond with a SINGLE JSON object and nothing else (no prose, no code fences).
+It MUST conform to this JSON Schema:
+${JSON.stringify(req.inputSchema)}`;
+
+    const messages: OpenAI.Chat.ChatCompletionMessageParam[] = [
+      { role: "system", content: system },
+      { role: "user", content: req.user },
+    ];
+
+    // json_object mode isn't universal on OpenAI-compatible endpoints; if it's
+    // rejected, retry without it (the schema-in-prompt still constrains output).
+    let content: string | null = null;
+    let usage: OpenAI.CompletionUsage | undefined;
+    try {
+      const c = await getClient().chat.completions.create({
+        model,
+        messages,
+        response_format: { type: "json_object" },
+      });
+      content = c.choices[0]?.message?.content ?? null;
+      usage = c.usage;
+    } catch {
+      const c = await getClient().chat.completions.create({ model, messages });
+      content = c.choices[0]?.message?.content ?? null;
+      usage = c.usage;
+    }
+
+    if (!content) {
+      logger.error("llm returned no structured result", {
+        event: "llm_no_result",
+        provider: "openai",
+        feature: req.feature,
+        model,
+      });
+      throw new Error("The assistant did not return a result");
+    }
+    logger.info("llm extract", {
+      event: "llm_extract",
+      provider: "openai",
+      feature: req.feature,
+      model,
+      ms: Date.now() - started,
+      inputTokens: usage?.prompt_tokens ?? 0,
+      outputTokens: usage?.completion_tokens ?? 0,
+    });
+    return JSON.parse(unwrapJson(content)) as unknown;
+  },
+};

--- a/apps/web/lib/ai/providers/types.ts
+++ b/apps/web/lib/ai/providers/types.ts
@@ -1,0 +1,46 @@
+/**
+ * Vendor-agnostic LLM provider contract. The platform's single AI layer
+ * (`lib/ai/llm.ts`) talks to whichever provider is configured (`AI_PROVIDER`),
+ * so Otter can run on Claude, OpenAI, or any OpenAI-compatible endpoint
+ * (Groq, OpenRouter, Azure OpenAI, a local Ollama/LM Studio, ...) without any
+ * feature module knowing which vendor is behind it.
+ */
+
+/** Model tiers - pick per task, not per feature. `deep` = quality/reasoning,
+ *  `fast` = low-latency/low-cost classification+extraction. */
+export type ModelTier = "deep" | "fast";
+
+/** Reasoning effort on the deep tier (providers that don't support it ignore it). */
+export type Effort = "low" | "medium" | "high" | "xhigh" | "max";
+
+export interface ExtractRequest {
+  system: string;
+  user: string;
+  /** JSON Schema the output must conform to. */
+  inputSchema: Record<string, unknown>;
+  /** Short label for logs. */
+  feature: string;
+  tier: ModelTier;
+  maxTokens?: number;
+  /** Cache the (static) system prompt where the provider supports it. */
+  cacheSystem?: boolean;
+  effort?: Effort;
+}
+
+export interface LlmProvider {
+  /** Stable id, e.g. "anthropic" | "openai". */
+  readonly name: string;
+  /** Whether a usable API key/config is present for this provider. */
+  readonly configured: boolean;
+  /**
+   * Whether this provider backs the streaming, multi-turn agentic tool-use loop
+   * (the Otter command bar / `lib/ai/chat.ts`). Structured `extract` works on
+   * every provider; the live agent loop is currently Anthropic-only.
+   */
+  readonly supportsAgentTools: boolean;
+  /**
+   * Structured extraction: prompt the model, constrain the reply to `inputSchema`,
+   * and return the raw parsed JSON object (the caller validates/narrows it).
+   */
+  extract(req: ExtractRequest): Promise<unknown>;
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -31,6 +31,7 @@
     "mixpanel-browser": "^2.58.0",
     "next": "^15.1.3",
     "node-ical": "^0.20.1",
+    "openai": "^6.48.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "stripe": "^17.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,9 @@ importers:
       node-ical:
         specifier: ^0.20.1
         version: 0.20.1
+      openai:
+        specifier: ^6.48.0
+        version: 6.48.0(ws@8.21.0)(zod@3.25.76)
       react:
         specifier: ^19.0.0
         version: 19.2.7
@@ -4762,6 +4765,26 @@ packages:
   open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
+
+  openai@6.48.0:
+    resolution: {integrity: sha512-KhVp+FyV50QrXNextvL9hIU5l6ox5HYuKQjGVk7lIqprgJol90+dQXWONV6S1lRWsKA1bXjrow8RsUT14M1hNA==}
+    peerDependencies:
+      '@aws-sdk/credential-provider-node': '>=3.972.0 <4'
+      '@smithy/hash-node': '>=4.3.0 <5'
+      '@smithy/signature-v4': '>=5.4.0 <6'
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-node':
+        optional: true
+      '@smithy/hash-node':
+        optional: true
+      '@smithy/signature-v4':
+        optional: true
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   ora@3.4.0:
     resolution: {integrity: sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==}
@@ -10396,6 +10419,11 @@ snapshots:
       define-lazy-prop: 2.0.0
       is-docker: 2.2.1
       is-wsl: 2.2.0
+
+  openai@6.48.0(ws@8.21.0)(zod@3.25.76):
+    optionalDependencies:
+      ws: 8.21.0
+      zod: 3.25.76
 
   ora@3.4.0:
     dependencies:


### PR DESCRIPTION
Otter was hard-wired to Anthropic. This makes the AI layer **provider-agnostic**, selectable with `AI_PROVIDER` (default `anthropic` — no behavior change unless you opt in).

## What
- **`lib/ai/providers/`** — an `LlmProvider` interface + two implementations:
  - **anthropic** — the existing structured-outputs + adaptive-thinking path (default).
  - **openai** — OpenAI **and any OpenAI-compatible endpoint** (Groq, OpenRouter, Together, Azure OpenAI, local **Ollama / LM Studio**) via `OPENAI_BASE_URL`. Structured output uses the portable `json_object` mode + schema-in-prompt (falls back if json mode isn't supported); the caller still Zod-validates.
  - **index** — picks the provider from `AI_PROVIDER`; exposes `aiEnabled` + `supportsAgentTools`.
- **`lib/ai/llm.ts` is now a thin facade** over the active provider. `extract()` and every feature that uses it — invite triage, schedule/command parsing, long-term memory, the voice receptionist, the booking-page assistant, proactive nudges, meeting-reply drafts, the quick command bar — are vendor-agnostic with **zero feature-module changes**.
- Model tiers (`deep`/`fast`) are env-overridable per provider; documented in `.env.example`.

## Scope / what's intentionally not covered
The **streaming, multi-turn conversational command bar** (`lib/ai/chat.ts` + `agent.ts`) uses **provider-native tool-use** and stays **Anthropic-only** for now. The `/api/ai/chat` route gates on `supportsAgentTools` and returns a clear message on other providers (and `getAnthropicClient()` throws loudly rather than silently misbehaving). Every other AI feature — including the single-shot command path — works on any provider. Porting the streaming agent loop to OpenAI function-calling is a follow-up (issue linked below).

## Verified
Full monorepo typecheck (15/15) + AI tests pass; `pnpm install --frozen-lockfile` is consistent.