### PR TITLE
feat(ai): vendor-agnostic streaming command bar (OpenAI function-calling)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,8 +98,8 @@ NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 # Otter runs on Claude by default. Switch providers with AI_PROVIDER:
 #   anthropic (default) | openai
 # "openai" also covers any OpenAI-COMPATIBLE endpoint (Groq, OpenRouter, Together,
-# Azure OpenAI, a local Ollama / LM Studio) via OPENAI_BASE_URL. Every AI feature
-# works on either; the streaming conversational command bar is Anthropic-only for now.
+# Azure OpenAI, a local Ollama / LM Studio) via OPENAI_BASE_URL. Every AI feature -
+# including the streaming conversational command bar - works on either provider.
 AI_PROVIDER=anthropic
 
 # Anthropic (used when AI_PROVIDER=anthropic). AI is hidden unless a key is set.

--- a/apps/web/app/api/ai/chat/route.ts
+++ b/apps/web/app/api/ai/chat/route.ts
@@ -32,12 +32,12 @@ const body = z.object({
  */
 export const POST = withUser(async (u, request) => {
   if (!aiEnabled) return jsonError("AI scheduling isn't enabled on this server.", 503);
-  // The streaming, multi-turn command bar uses provider-native tool-use, which is
-  // Anthropic-only today. Other providers still power the quick command bar and
-  // every other AI feature (they go through the vendor-agnostic `extract`).
+  // The streaming, multi-turn command bar uses provider-native tool-use. Both the
+  // Anthropic and OpenAI-compatible providers support it; only a hypothetical
+  // tool-less provider would trip this guard (the quick command bar still works).
   if (!supportsAgentTools) {
     return jsonError(
-      "The conversational assistant needs the Anthropic provider. Use the quick command instead.",
+      "The conversational assistant isn't available with the configured AI provider. Use the quick command instead.",
       503,
     );
   }

--- a/apps/web/lib/ai/agent.ts
+++ b/apps/web/lib/ai/agent.ts
@@ -1,4 +1,3 @@
-import type Anthropic from "@anthropic-ai/sdk";
 import { logger } from "@dayotter/core";
 import { DateTime } from "luxon";
 import { hostSlots } from "../booking/availability";
@@ -11,7 +10,7 @@ import {
   commandInputSchema,
   commandSystem,
 } from "./command-parse";
-import { MODELS, getAnthropicClient } from "./llm";
+import { type AgentToolResult, type AgentToolSpec, type AgentTurn, agentStep } from "./llm";
 
 /**
  * Read-only agentic loop for scheduling requests that need real availability
@@ -22,11 +21,11 @@ import { MODELS, getAnthropicClient } from "./llm";
  * single-shot parser produces. It NEVER writes - the only tool is a read.
  */
 
-export const FREE_SLOTS_TOOL: Anthropic.Tool = {
+export const FREE_SLOTS_TOOL: AgentToolSpec = {
   name: "find_free_slots",
   description:
     "Look up times the host is genuinely free for a meeting of a given length, within a date range. Call this to ground a proposed time in real availability before proposing it. Returns up to 8 open slots.",
-  input_schema: {
+  schema: {
     type: "object",
     additionalProperties: false,
     properties: {
@@ -35,13 +34,13 @@ export const FREE_SLOTS_TOOL: Anthropic.Tool = {
       toISO: { type: "string", description: "Search window end (ISO-8601 instant)." },
     },
     required: ["durationMinutes", "fromISO", "toISO"],
-  } as unknown as Anthropic.Tool.InputSchema,
+  },
 };
 
-const OUTPUT_TOOL: Anthropic.Tool = {
+const OUTPUT_TOOL: AgentToolSpec = {
   name: "propose_command",
   description: "Return the final structured command draft for the user to review and confirm.",
-  input_schema: commandInputSchema as unknown as Anthropic.Tool.InputSchema,
+  schema: commandInputSchema as Record<string, unknown>,
 };
 
 /** Execute the read-only tool: the host's real free slots in a bounded window. */
@@ -98,51 +97,40 @@ export async function runSchedulingAgent(params: {
   eventTypes?: EventTypeContext[];
   memory?: string;
 }): Promise<CommandDraft> {
-  const client = getAnthropicClient();
   const system = `${commandSystem}
 
 You also have a read-only tool, find_free_slots, that returns times the host is actually free. When the request depends on when the host is available (e.g. "find a free slot", "my next open afternoon", "sometime next week"), call find_free_slots FIRST, then choose a real returned slot for startISO/newStartISO. Never invent availability. When you have everything you need, call propose_command with the final draft.`;
 
-  const messages: Anthropic.MessageParam[] = [{ role: "user", content: buildCommandUser(params) }];
+  const history: AgentTurn[] = [{ role: "user", text: buildCommandUser(params) }];
 
   for (let step = 0; step < MAX_STEPS; step++) {
-    const response = await client.messages.create({
-      model: MODELS.deep,
-      max_tokens: 3000,
-      system: [{ type: "text", text: system, cache_control: { type: "ephemeral" } }],
+    // Adaptive thinking / high effort (on providers that support it) so the model
+    // reasons across the availability it looks up before proposing a time.
+    const res = await agentStep({
+      system: [{ text: system, cache: true }],
+      history,
       tools: [FREE_SLOTS_TOOL, OUTPUT_TOOL],
-      tool_choice: { type: "auto" },
-      // Adaptive thinking (compatible with auto tool-choice) so the model reasons
-      // across the availability it looks up before proposing a time. Assistant
-      // content - including thinking blocks - is echoed back below, as required.
-      output_config: { effort: "high" },
-      thinking: { type: "adaptive" },
-      messages,
+      tier: "deep",
+      effort: "high",
     });
 
-    const output = response.content.find(
-      (b) => b.type === "tool_use" && b.name === "propose_command",
-    );
-    if (output && output.type === "tool_use") {
-      return commandDraftSchema.parse(output.input);
-    }
+    const output = res.toolCalls.find((c) => c.name === "propose_command");
+    if (output) return commandDraftSchema.parse(output.input);
 
-    const reads = response.content.filter(
-      (b): b is Anthropic.ToolUseBlock => b.type === "tool_use" && b.name === "find_free_slots",
-    );
+    const reads = res.toolCalls.filter((c) => c.name === "find_free_slots");
     if (reads.length === 0) break; // no tool call and no proposal → give up to the fallback
 
-    messages.push({ role: "assistant", content: response.content });
-    const results: Anthropic.ToolResultBlockParam[] = [];
+    history.push({ role: "assistant_raw", raw: res.assistant });
+    const results: AgentToolResult[] = [];
     for (const call of reads) {
       const text = await findFreeSlots(
         params.userId,
         call.input as { durationMinutes: number; fromISO: string; toISO: string },
         params.timezone,
       ).catch(() => "Could not look up availability.");
-      results.push({ type: "tool_result", tool_use_id: call.id, content: text });
+      results.push({ id: call.id, content: text });
     }
-    messages.push({ role: "user", content: results });
+    history.push({ role: "tool_results", results });
   }
 
   logger.warn("scheduling agent did not converge", {

--- a/apps/web/lib/ai/chat.ts
+++ b/apps/web/lib/ai/chat.ts
@@ -1,4 +1,3 @@
-import type Anthropic from "@anthropic-ai/sdk";
 import { logger } from "@dayotter/core";
 import { getPluginTool, pluginTools, runPluginTool } from "@dayotter/plugin-host";
 import { DateTime } from "luxon";
@@ -10,10 +9,16 @@ import {
   commandInputSchema,
 } from "./command-parse";
 import { GUARDRAIL_PREAMBLE } from "./guardrails";
-import { MODELS, getAnthropicClient } from "./llm";
+import {
+  type AgentToolResult,
+  type AgentToolSpec,
+  type AgentTurn,
+  type SystemBlock,
+  agentStep,
+} from "./llm";
 import { retrieveCalendarContext } from "./retrieval";
 import { executeReadTool } from "./tools/exec";
-import { anthropicToolDefs, getTool } from "./tools/registry";
+import { getTool, toolSpecs } from "./tools/registry";
 
 /** One turn of the chat, as the client stores it (plain text, not Anthropic blocks). */
 export interface ChatTurn {
@@ -65,11 +70,11 @@ BEYOND BOOKINGS - you can also read and control the rest of the host's setup wit
 PROTECTING TIME (act like a great EA - do the work, don't just advise): when the host wants focus / deep-work / heads-down time, or time set aside for a task ("block 6 hours of focus this week", "I need 4 hours for the deck by Friday", "protect my mornings"), call find_focus_time FIRST (pass hoursNeeded, an optional byDate deadline, and chunkMinutes if they hint at block length). Briefly tell them the specific times you found, then propose protect_focus_time with those exact blocks. For a single quick hold you may still use create_focus_block. Never invent times - only protect blocks that find_focus_time returned.
 Rules for these: propose exactly ONE action at a time. NEVER say you've done, created, changed, or deleted something - you have only proposed it; the host confirms. Deleting always requires the host's explicit confirmation. For set_weekly_hours and update_preferences, call the matching read tool first and carry over the values the host wants to keep (both replace/merge against current state). Use propose_action ONLY for bookings (create/reschedule/cancel a meeting); use these tools for booking types, availability, preferences, and focus blocks.`;
 
-const PROPOSE_ACTION_TOOL: Anthropic.Tool = {
+const PROPOSE_ACTION_TOOL: AgentToolSpec = {
   name: "propose_action",
   description:
     "Propose a confirm-first scheduling action (create / reschedule / cancel) for the host to review and confirm. Only call this when the host wants to change their calendar - not to answer a question.",
-  input_schema: commandInputSchema as unknown as Anthropic.Tool.InputSchema,
+  schema: commandInputSchema as Record<string, unknown>,
 };
 
 const MAX_STEPS = 4;
@@ -138,55 +143,43 @@ export async function streamAssistant(params: {
   const latestUser = [...turns].reverse().find((t) => t.role === "user");
   const { ctx, tz, block } = await buildContext(userId, latestUser?.content ?? "");
 
-  const client = getAnthropicClient();
-  const system: Anthropic.TextBlockParam[] = [
-    { type: "text", text: GUARDRAIL_PREAMBLE, cache_control: { type: "ephemeral" } },
-    { type: "text", text: CHAT_SYSTEM, cache_control: { type: "ephemeral" } },
-    { type: "text", text: block },
+  const system: SystemBlock[] = [
+    { text: GUARDRAIL_PREAMBLE, cache: true },
+    { text: CHAT_SYSTEM, cache: true },
+    { text: block },
   ];
-  const messages: Anthropic.MessageParam[] = turns.map((t) => ({
-    role: t.role,
-    content: t.content,
-  }));
+  const tools: AgentToolSpec[] = [
+    FREE_SLOTS_TOOL,
+    PROPOSE_ACTION_TOOL,
+    ...toolSpecs(),
+    ...pluginTools().map(
+      (p): AgentToolSpec => ({
+        name: p.name,
+        description: p.tool.description,
+        schema: p.tool.schema as Record<string, unknown>,
+      }),
+    ),
+  ];
+  const history: AgentTurn[] = turns.map((t) => ({ role: t.role, text: t.content }));
 
   let fullText = "";
   for (let step = 0; step < MAX_STEPS; step++) {
-    const stream = client.messages.stream({
-      model: MODELS.deep,
-      max_tokens: 3000,
+    const res = await agentStep({
       system,
-      tools: [
-        FREE_SLOTS_TOOL,
-        PROPOSE_ACTION_TOOL,
-        ...(anthropicToolDefs() as Anthropic.Tool[]),
-        ...pluginTools().map(
-          (p): Anthropic.Tool => ({
-            name: p.name,
-            description: p.tool.description,
-            input_schema: p.tool.schema as Anthropic.Tool.InputSchema,
-          }),
-        ),
-      ],
-      tool_choice: { type: "auto" },
-      output_config: { effort: "medium" },
-      thinking: { type: "adaptive" },
-      messages,
+      history,
+      tools,
+      tier: "deep",
+      effort: "medium",
+      maxTokens: 3000,
+      onToken: (text) => {
+        fullText += text;
+        emit({ type: "token", text });
+      },
     });
-
-    for await (const ev of stream) {
-      if (ev.type === "content_block_delta" && ev.delta.type === "text_delta" && ev.delta.text) {
-        fullText += ev.delta.text;
-        emit({ type: "token", text: ev.delta.text });
-      }
-    }
-
-    const final = await stream.finalMessage();
-    const toolUses = final.content.filter(
-      (b): b is Anthropic.ToolUseBlock => b.type === "tool_use",
-    );
+    const toolCalls = res.toolCalls;
 
     // 1. Booking create/reschedule/cancel → the rich editable card.
-    const proposal = toolUses.find((b) => b.name === "propose_action");
+    const proposal = toolCalls.find((c) => c.name === "propose_action");
     if (proposal) {
       try {
         const draft = commandDraftSchema.parse(proposal.input);
@@ -201,13 +194,13 @@ export async function streamAssistant(params: {
 
     // 2. Registry write/destructive tool → generic confirm card. NOT executed here;
     //    the client runs it via /api/ai/act only after the host confirms.
-    const actionCall = toolUses.find((b) => {
-      const t = getTool(b.name);
+    const actionCall = toolCalls.find((c) => {
+      const t = getTool(c.name);
       if (t && t.kind !== "read") return true;
-      return getPluginTool(b.name)?.tool.kind === "action";
+      return getPluginTool(c.name)?.tool.kind === "action";
     });
     if (actionCall) {
-      const inp = (actionCall.input ?? {}) as Record<string, unknown>;
+      const inp = actionCall.input;
       const core = getTool(actionCall.name);
       if (core) {
         emit({
@@ -237,18 +230,18 @@ export async function streamAssistant(params: {
     }
 
     // 3. Reads (registry reads + find_free_slots) → run inline, feed back, loop.
-    const reads = toolUses.filter(
-      (b) =>
-        b.name === "find_free_slots" ||
-        getTool(b.name)?.kind === "read" ||
-        getPluginTool(b.name)?.tool.kind === "read",
+    const reads = toolCalls.filter(
+      (c) =>
+        c.name === "find_free_slots" ||
+        getTool(c.name)?.kind === "read" ||
+        getPluginTool(c.name)?.tool.kind === "read",
     );
     if (reads.length === 0) break; // plain conversational answer-done
 
-    messages.push({ role: "assistant", content: final.content });
-    const results: Anthropic.ToolResultBlockParam[] = [];
+    history.push({ role: "assistant_raw", raw: res.assistant });
+    const results: AgentToolResult[] = [];
     for (const call of reads) {
-      const input = (call.input ?? {}) as Record<string, unknown>;
+      const input = call.input;
       let content: string;
       if (call.name === "find_free_slots") {
         content = await findFreeSlots(
@@ -263,9 +256,9 @@ export async function streamAssistant(params: {
       } else {
         content = await runPluginTool(call.name, userId, input).catch(() => "Could not run that.");
       }
-      results.push({ type: "tool_result", tool_use_id: call.id, content });
+      results.push({ id: call.id, content });
     }
-    messages.push({ role: "user", content: results });
+    history.push({ role: "tool_results", results });
   }
 
   emit({ type: "done", text: fullText.trim() });

--- a/apps/web/lib/ai/llm.ts
+++ b/apps/web/lib/ai/llm.ts
@@ -1,7 +1,5 @@
-import type Anthropic from "@anthropic-ai/sdk";
-import { MODELS, anthropicClient } from "./providers/anthropic";
 import { aiEnabled, provider, supportsAgentTools } from "./providers/index";
-import type { Effort, ModelTier } from "./providers/types";
+import type { AgentStepRequest, AgentStepResult, Effort, ModelTier } from "./providers/types";
 
 /**
  * The single LLM layer for the whole platform. Every AI feature goes through
@@ -11,8 +9,17 @@ import type { Effort, ModelTier } from "./providers/types";
  * or any OpenAI-compatible endpoint without any feature module changing.
  */
 
-export { aiEnabled, supportsAgentTools, MODELS };
+export { aiEnabled, supportsAgentTools };
 export type { ModelTier, Effort };
+export type {
+  AgentStepRequest,
+  AgentStepResult,
+  AgentToolCall,
+  AgentToolResult,
+  AgentToolSpec,
+  AgentTurn,
+  SystemBlock,
+} from "./providers/types";
 
 export interface ExtractOptions<T> {
   /** System prompt - set the assistant's scope and rules here. Keep it static so it caches. */
@@ -57,15 +64,11 @@ export async function extract<T>(opts: ExtractOptions<T>): Promise<T> {
 }
 
 /**
- * Raw Anthropic client for the streaming agentic tool-use loop (the command bar).
- * That loop is Anthropic-specific; throws a clear error if a different provider
- * is active so the caller can degrade to the vendor-agnostic command path.
+ * The platform's vendor-neutral agentic tool-use primitive: one step of a
+ * streaming, multi-turn tool loop. The caller runs the returned tool calls and
+ * loops (see `lib/ai/chat.ts` and `lib/ai/agent.ts`). Backed by Anthropic tool
+ * use or OpenAI-compatible function-calling, depending on `AI_PROVIDER`.
  */
-export function getAnthropicClient(): Anthropic {
-  if (provider.name !== "anthropic") {
-    throw new Error(
-      "The conversational command bar requires the Anthropic provider (set AI_PROVIDER=anthropic).",
-    );
-  }
-  return anthropicClient();
+export function agentStep(req: AgentStepRequest): Promise<AgentStepResult> {
+  return provider.streamAgentStep(req);
 }

--- a/apps/web/lib/ai/providers/anthropic.ts
+++ b/apps/web/lib/ai/providers/anthropic.ts
@@ -1,19 +1,25 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { logger } from "@dayotter/core";
 import { managedAnthropicKey } from "../../ee/managed-ai";
-import type { ExtractRequest, LlmProvider, ModelTier } from "./types";
+import type {
+  AgentStepRequest,
+  AgentStepResult,
+  AgentTurn,
+  ExtractRequest,
+  LlmProvider,
+  ModelTier,
+} from "./types";
 
 /**
  * Anthropic (Claude) provider - the default. Structured extraction uses the
  * native structured-outputs `output_config` plus adaptive thinking on the deep
- * tier. This is also the only provider that backs the streaming agentic tool-use
- * loop (the command bar) today, so it exposes its raw client.
+ * tier; `streamAgentStep` backs the streaming agentic tool-use loop (the command
+ * bar) with native tool use + prompt caching. It also exposes its raw client.
  */
 
 const KEY = process.env.ANTHROPIC_API_KEY || managedAnthropicKey;
 
-/** Anthropic models per tier. Also used by the agentic tool-use loop, which is
- *  Anthropic-only, so it reads these directly. */
+/** Anthropic models per tier, keyed by the neutral `ModelTier`. */
 export const MODELS: Record<ModelTier, string> = {
   deep: process.env.ANTHROPIC_MODEL_DEEP || "claude-opus-4-8",
   fast: process.env.ANTHROPIC_MODEL_FAST || "claude-haiku-4-5",
@@ -33,6 +39,33 @@ export function anthropicClient(): Anthropic {
 function buildSystem(system: string, cache: boolean): string | Anthropic.TextBlockParam[] {
   if (!cache) return system;
   return [{ type: "text", text: system, cache_control: { type: "ephemeral" } }];
+}
+
+/** Map the neutral agent history into Anthropic message params. */
+function toAnthropicMessages(history: AgentTurn[]): Anthropic.MessageParam[] {
+  return history.map((turn): Anthropic.MessageParam => {
+    switch (turn.role) {
+      case "user":
+        return { role: "user", content: turn.text };
+      case "assistant":
+        return { role: "assistant", content: turn.text };
+      case "assistant_raw":
+        // The exact content blocks from a prior tool-use step (incl. thinking),
+        // echoed back verbatim as required for multi-turn tool use.
+        return { role: "assistant", content: turn.raw as Anthropic.ContentBlockParam[] };
+      case "tool_results":
+        return {
+          role: "user",
+          content: turn.results.map(
+            (r): Anthropic.ToolResultBlockParam => ({
+              type: "tool_result",
+              tool_use_id: r.id,
+              content: r.content,
+            }),
+          ),
+        };
+    }
+  });
 }
 
 export const anthropicProvider: LlmProvider = {
@@ -81,5 +114,52 @@ export const anthropicProvider: LlmProvider = {
       outputTokens: response.usage.output_tokens,
     });
     return JSON.parse(text.text) as unknown;
+  },
+
+  async streamAgentStep(req: AgentStepRequest): Promise<AgentStepResult> {
+    const deep = req.tier === "deep";
+    const system: Anthropic.TextBlockParam[] = req.system.map((b) =>
+      b.cache
+        ? { type: "text", text: b.text, cache_control: { type: "ephemeral" } }
+        : { type: "text", text: b.text },
+    );
+
+    const stream = getClient().messages.stream({
+      model: MODELS[req.tier],
+      max_tokens: req.maxTokens ?? 3000,
+      system,
+      tools: req.tools.map(
+        (t): Anthropic.Tool => ({
+          name: t.name,
+          description: t.description,
+          input_schema: t.schema as Anthropic.Tool.InputSchema,
+        }),
+      ),
+      tool_choice: { type: "auto" },
+      // Adaptive thinking + effort on the deep tier so the model reasons across
+      // tool results before answering; the fast tier omits both (unsupported).
+      ...(deep
+        ? {
+            output_config: { effort: req.effort ?? "medium" },
+            thinking: { type: "adaptive" as const },
+          }
+        : {}),
+      messages: toAnthropicMessages(req.history),
+    });
+
+    let text = "";
+    for await (const ev of stream) {
+      if (ev.type === "content_block_delta" && ev.delta.type === "text_delta" && ev.delta.text) {
+        text += ev.delta.text;
+        req.onToken?.(ev.delta.text);
+      }
+    }
+
+    const final = await stream.finalMessage();
+    const toolCalls = final.content
+      .filter((b): b is Anthropic.ToolUseBlock => b.type === "tool_use")
+      .map((b) => ({ id: b.id, name: b.name, input: (b.input ?? {}) as Record<string, unknown> }));
+
+    return { text, toolCalls, assistant: final.content };
   },
 };

--- a/apps/web/lib/ai/providers/index.ts
+++ b/apps/web/lib/ai/providers/index.ts
@@ -6,8 +6,8 @@ import type { LlmProvider } from "./types";
  * Selects the active LLM provider from `AI_PROVIDER` (default `anthropic`).
  * Set `AI_PROVIDER=openai` (with `OPENAI_API_KEY`, optionally `OPENAI_BASE_URL`
  * + `OPENAI_MODEL_DEEP/FAST`) to run Otter on OpenAI or any OpenAI-compatible
- * endpoint. Every `extract`-based feature works on either; the streaming command
- * bar is Anthropic-only for now (see `supportsAgentTools`).
+ * endpoint. Every `extract`-based feature AND the streaming agentic command bar
+ * work on either provider (see `supportsAgentTools`).
  */
 const SELECTED = (process.env.AI_PROVIDER || "anthropic").toLowerCase();
 
@@ -20,4 +20,16 @@ export const aiEnabled = provider.configured;
 export const supportsAgentTools = provider.configured && provider.supportsAgentTools;
 
 export { anthropicClient };
-export type { Effort, ExtractRequest, LlmProvider, ModelTier } from "./types";
+export type {
+  AgentStepRequest,
+  AgentStepResult,
+  AgentToolCall,
+  AgentToolResult,
+  AgentToolSpec,
+  AgentTurn,
+  Effort,
+  ExtractRequest,
+  LlmProvider,
+  ModelTier,
+  SystemBlock,
+} from "./types";

--- a/apps/web/lib/ai/providers/openai.test.ts
+++ b/apps/web/lib/ai/providers/openai.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the OpenAI SDK: every instance shares one `create` spy we drive per test.
+const create = vi.fn();
+vi.mock("openai", () => ({
+  default: class {
+    chat = { completions: { create } };
+  },
+}));
+
+import { openaiProvider } from "./openai";
+import type { AgentStepRequest } from "./types";
+
+/** Wrap a list of streamed chunks as the async-iterable the SDK returns. */
+function streamOf(chunks: unknown[]) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const c of chunks) yield c;
+    },
+  };
+}
+
+const baseReq: AgentStepRequest = {
+  system: [{ text: "You are Otter." }],
+  history: [{ role: "user", text: "find me a free 30 min" }],
+  tools: [{ name: "find_free_slots", description: "…", schema: { type: "object" } }],
+  tier: "deep",
+};
+
+describe("openaiProvider.streamAgentStep", () => {
+  beforeEach(() => create.mockReset());
+
+  it("streams text tokens and accumulates split tool-call argument deltas", async () => {
+    create.mockResolvedValue(
+      streamOf([
+        { choices: [{ delta: { content: "Let me " } }] },
+        { choices: [{ delta: { content: "check." } }] },
+        // A single tool call whose id/name arrive once and args arrive in fragments.
+        {
+          choices: [
+            {
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: "call_1",
+                    function: { name: "find_free_slots", arguments: '{"dur' },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        {
+          choices: [
+            { delta: { tool_calls: [{ index: 0, function: { arguments: 'ationMinutes":30}' } }] } },
+          ],
+        },
+      ]),
+    );
+
+    const tokens: string[] = [];
+    const res = await openaiProvider.streamAgentStep({
+      ...baseReq,
+      onToken: (t) => tokens.push(t),
+    });
+
+    expect(tokens).toEqual(["Let me ", "check."]);
+    expect(res.text).toBe("Let me check.");
+    expect(res.toolCalls).toEqual([
+      { id: "call_1", name: "find_free_slots", input: { durationMinutes: 30 } },
+    ]);
+    // The echoed assistant turn carries the reassembled arguments verbatim.
+    const assistant = res.assistant as {
+      role: string;
+      tool_calls?: { id: string; function: { name: string; arguments: string } }[];
+    };
+    expect(assistant.role).toBe("assistant");
+    expect(assistant.tool_calls?.[0]).toMatchObject({
+      id: "call_1",
+      function: { name: "find_free_slots", arguments: '{"durationMinutes":30}' },
+    });
+  });
+
+  it("prepends a system message and maps tool results to role:tool messages", async () => {
+    create.mockResolvedValue(streamOf([{ choices: [{ delta: { content: "ok" } }] }]));
+
+    await openaiProvider.streamAgentStep({
+      ...baseReq,
+      history: [
+        { role: "user", text: "hi" },
+        { role: "assistant_raw", raw: { role: "assistant", content: null, tool_calls: [] } },
+        { role: "tool_results", results: [{ id: "call_1", content: "no slots" }] },
+      ],
+    });
+
+    const sent = create.mock.calls[0]![0] as { messages: { role: string; content?: unknown }[] };
+    expect(sent.messages[0]).toEqual({ role: "system", content: "You are Otter." });
+    expect(sent.messages.at(-1)).toEqual({
+      role: "tool",
+      tool_call_id: "call_1",
+      content: "no slots",
+    });
+  });
+
+  it("tolerates non-JSON tool arguments without throwing (input falls back to {})", async () => {
+    create.mockResolvedValue(
+      streamOf([
+        {
+          choices: [
+            {
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: "c",
+                    function: { name: "get_preferences", arguments: "not json" },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ]),
+    );
+
+    const res = await openaiProvider.streamAgentStep(baseReq);
+    expect(res.toolCalls).toEqual([{ id: "c", name: "get_preferences", input: {} }]);
+  });
+});

--- a/apps/web/lib/ai/providers/openai.ts
+++ b/apps/web/lib/ai/providers/openai.ts
@@ -1,6 +1,13 @@
 import { logger } from "@dayotter/core";
 import OpenAI from "openai";
-import type { ExtractRequest, LlmProvider, ModelTier } from "./types";
+import type {
+  AgentStepRequest,
+  AgentStepResult,
+  AgentTurn,
+  ExtractRequest,
+  LlmProvider,
+  ModelTier,
+} from "./types";
 
 /**
  * OpenAI-compatible provider. Works with OpenAI itself and with any endpoint
@@ -12,6 +19,12 @@ import type { ExtractRequest, LlmProvider, ModelTier } from "./types";
  * JSON Schema in the system prompt, then JSON-parse the reply. (`json_object` is
  * supported almost everywhere; `json_schema` is OpenAI-specific.) The caller
  * still validates the object with its Zod schema, so a stray field is caught.
+ *
+ * The streaming agentic loop (`streamAgentStep`) uses the equally portable Chat
+ * Completions function-calling: stream `delta.content` as tokens and accumulate
+ * `delta.tool_calls` deltas by index, then hand the parsed calls back to the
+ * caller (which runs them and loops). The prompt-caching / adaptive-thinking
+ * knobs the Anthropic provider uses don't apply here, so they're ignored.
  */
 
 const KEY = process.env.OPENAI_API_KEY || "";
@@ -34,10 +47,41 @@ function unwrapJson(raw: string): string {
   return (m?.[1] ?? raw).trim();
 }
 
+/** Map the neutral agent history into OpenAI chat messages. */
+function toOpenAiMessages(
+  system: AgentStepRequest["system"],
+  history: AgentTurn[],
+): OpenAI.Chat.ChatCompletionMessageParam[] {
+  const messages: OpenAI.Chat.ChatCompletionMessageParam[] = [
+    { role: "system", content: system.map((b) => b.text).join("\n\n") },
+  ];
+  for (const turn of history) {
+    switch (turn.role) {
+      case "user":
+        messages.push({ role: "user", content: turn.text });
+        break;
+      case "assistant":
+        messages.push({ role: "assistant", content: turn.text });
+        break;
+      case "assistant_raw":
+        // The stored assistant message (may carry tool_calls) from a prior step.
+        messages.push(turn.raw as OpenAI.Chat.ChatCompletionAssistantMessageParam);
+        break;
+      case "tool_results":
+        // Each result is its own `role: "tool"` message keyed by the call id.
+        for (const r of turn.results) {
+          messages.push({ role: "tool", tool_call_id: r.id, content: r.content });
+        }
+        break;
+    }
+  }
+  return messages;
+}
+
 export const openaiProvider: LlmProvider = {
   name: "openai",
   configured: Boolean(KEY),
-  supportsAgentTools: false,
+  supportsAgentTools: true,
 
   async extract(req: ExtractRequest): Promise<unknown> {
     const model = MODELS[req.tier];
@@ -90,5 +134,77 @@ ${JSON.stringify(req.inputSchema)}`;
       outputTokens: usage?.completion_tokens ?? 0,
     });
     return JSON.parse(unwrapJson(content)) as unknown;
+  },
+
+  async streamAgentStep(req: AgentStepRequest): Promise<AgentStepResult> {
+    const model = MODELS[req.tier];
+    const stream = await getClient().chat.completions.create({
+      model,
+      messages: toOpenAiMessages(req.system, req.history),
+      tools: req.tools.map(
+        (t): OpenAI.Chat.ChatCompletionTool => ({
+          type: "function",
+          function: { name: t.name, description: t.description, parameters: t.schema },
+        }),
+      ),
+      tool_choice: "auto",
+      max_tokens: req.maxTokens ?? 3000,
+      stream: true,
+    });
+
+    let text = "";
+    // Accumulate streamed tool-call deltas by their `index` - id and name arrive
+    // once, arguments arrive as a stream of string fragments to be concatenated.
+    const partial: { id: string; name: string; args: string }[] = [];
+    for await (const chunk of stream) {
+      const delta = chunk.choices[0]?.delta;
+      if (delta?.content) {
+        text += delta.content;
+        req.onToken?.(delta.content);
+      }
+      for (const tc of delta?.tool_calls ?? []) {
+        let slot = partial[tc.index];
+        if (!slot) {
+          slot = { id: "", name: "", args: "" };
+          partial[tc.index] = slot;
+        }
+        if (tc.id) slot.id = tc.id;
+        if (tc.function?.name) slot.name += tc.function.name;
+        if (tc.function?.arguments) slot.args += tc.function.arguments;
+      }
+    }
+
+    const calls = partial.filter((c) => c?.name);
+    const toolCalls = calls.map((c) => {
+      let input: Record<string, unknown> = {};
+      try {
+        input = c.args ? (JSON.parse(c.args) as Record<string, unknown>) : {};
+      } catch {
+        logger.warn("openai tool-call args not valid JSON", {
+          event: "ai_openai_toolargs_parse_failed",
+          tool: c.name,
+        });
+      }
+      return { id: c.id, name: c.name, input };
+    });
+
+    // The assistant turn to echo back next step, in OpenAI's own shape.
+    const assistant: OpenAI.Chat.ChatCompletionAssistantMessageParam = {
+      role: "assistant",
+      content: text || null,
+      ...(calls.length
+        ? {
+            tool_calls: calls.map(
+              (c): OpenAI.Chat.ChatCompletionMessageToolCall => ({
+                id: c.id,
+                type: "function",
+                function: { name: c.name, arguments: c.args || "{}" },
+              }),
+            ),
+          }
+        : {}),
+    };
+
+    return { text, toolCalls, assistant };
   },
 };

--- a/apps/web/lib/ai/providers/types.ts
+++ b/apps/web/lib/ai/providers/types.ts
@@ -27,6 +27,70 @@ export interface ExtractRequest {
   effort?: Effort;
 }
 
+/**
+ * A system-prompt block. `cache` asks the provider to cache this (static) block
+ * where it can (Anthropic prompt caching); providers that can't just concatenate.
+ */
+export interface SystemBlock {
+  text: string;
+  cache?: boolean;
+}
+
+/** A tool the model may call, in vendor-neutral form. */
+export interface AgentToolSpec {
+  name: string;
+  description: string;
+  /** JSON Schema for the tool's input. */
+  schema: Record<string, unknown>;
+}
+
+/** A tool call the model emitted (arguments already parsed from JSON). */
+export interface AgentToolCall {
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
+/** The result of running one tool call, fed back to the model. */
+export interface AgentToolResult {
+  /** Must match the {@link AgentToolCall.id} it answers. */
+  id: string;
+  content: string;
+}
+
+/**
+ * Vendor-neutral conversation history for the agentic loop. The caller owns this
+ * list: it seeds `user`/`assistant` turns, then after each step pushes the
+ * returned opaque `assistant` item (as `assistant_raw`) followed by a
+ * `tool_results` item, and calls {@link LlmProvider.streamAgentStep} again.
+ */
+export type AgentTurn =
+  | { role: "user"; text: string }
+  | { role: "assistant"; text: string }
+  /** The provider-specific assistant message from a prior tool-use step, echoed back verbatim. */
+  | { role: "assistant_raw"; raw: unknown }
+  | { role: "tool_results"; results: AgentToolResult[] };
+
+export interface AgentStepRequest {
+  system: SystemBlock[];
+  history: AgentTurn[];
+  tools: AgentToolSpec[];
+  tier: ModelTier;
+  effort?: Effort;
+  maxTokens?: number;
+  /** Streamed assistant text deltas. Omit for a non-streaming (single-shot) call. */
+  onToken?: (text: string) => void;
+}
+
+export interface AgentStepResult {
+  /** The assistant's visible text this step. */
+  text: string;
+  /** Tool calls to run (empty ⇒ this is the final answer). */
+  toolCalls: AgentToolCall[];
+  /** Opaque assistant turn to echo back next step (push as `{ role: "assistant_raw", raw }`). */
+  assistant: unknown;
+}
+
 export interface LlmProvider {
   /** Stable id, e.g. "anthropic" | "openai". */
   readonly name: string;
@@ -34,8 +98,8 @@ export interface LlmProvider {
   readonly configured: boolean;
   /**
    * Whether this provider backs the streaming, multi-turn agentic tool-use loop
-   * (the Otter command bar / `lib/ai/chat.ts`). Structured `extract` works on
-   * every provider; the live agent loop is currently Anthropic-only.
+   * (the Otter command bar / `lib/ai/chat.ts`). Both the Anthropic and the
+   * OpenAI-compatible providers do; a hypothetical tool-less provider would not.
    */
   readonly supportsAgentTools: boolean;
   /**
@@ -43,4 +107,11 @@ export interface LlmProvider {
    * and return the raw parsed JSON object (the caller validates/narrows it).
    */
   extract(req: ExtractRequest): Promise<unknown>;
+  /**
+   * One step of a streaming, multi-turn tool-use loop: stream assistant text via
+   * `onToken`, and return any tool calls plus the opaque assistant turn to echo
+   * back. The caller runs the tools and loops. Providers where
+   * `supportsAgentTools` is false throw.
+   */
+  streamAgentStep(req: AgentStepRequest): Promise<AgentStepResult>;
 }

--- a/apps/web/lib/ai/tools/registry.ts
+++ b/apps/web/lib/ai/tools/registry.ts
@@ -784,11 +784,11 @@ const BY_NAME = new Map(TOOLS.map((t) => [t.name, t]));
 export function getTool(name: string): AiToolDef | undefined {
   return BY_NAME.get(name);
 }
-/** Anthropic tool definitions for every registry tool. */
-export function anthropicToolDefs() {
+/** Vendor-neutral tool specs for every registry tool (for the agentic loop). */
+export function toolSpecs() {
   return TOOLS.map((t) => ({
     name: t.name,
     description: t.description,
-    input_schema: t.schema,
+    schema: t.schema,
   }));
 }

--- a/docs/AI.md
+++ b/docs/AI.md
@@ -48,14 +48,17 @@ going**: the advancements and improvements we want the community to help build.
                           execute (reuses the app's own write paths)
 ```
 
-### The LLM layer - `lib/ai/llm.ts`
-The single Anthropic choke point. `aiEnabled` is just "is a key present." Model
-tiers live in one place - `deep: claude-opus-4-8`, `fast: claude-haiku-4-5` -
-swap models without touching features. `extract()` is the shared structured-output
-primitive (forced tool-use → Zod-validated object, with a chain-of-thought
-field), plus prompt caching and streaming. **No feature instantiates its own
-client**, which is what makes the model layer swappable (including to a
-self-hosted or alternative provider).
+### The LLM layer - `lib/ai/llm.ts` + `lib/ai/providers/`
+The single vendor-agnostic choke point. `AI_PROVIDER` selects a provider
+(`anthropic` default, or `openai` for OpenAI / any OpenAI-compatible endpoint);
+each implements one `LlmProvider` contract. `aiEnabled` is just "is a key
+present." Model tiers live in one place per provider - `deep` / `fast` - so you
+swap models without touching features. The facade exposes two primitives, both
+provider-neutral: `extract()` (structured output → Zod-validated object, with a
+chain-of-thought field, prompt caching where supported) and `agentStep()` (one
+streaming, multi-turn tool-use step - native tool use on Claude, function-calling
+on OpenAI - powering the conversational command bar). **No feature instantiates
+its own client**, which is what makes the model layer swappable.
 
 ### The interpret core - `lib/ai/interpret.ts`
 `interpretOtterCommand(userId, text)` is the shared brain for every non-chat


### PR DESCRIPTION
Closes #84 — the last piece of the multi-vendor AI work (follow-up to #83).

## Problem
`extract`-based AI features already ran on any provider, but the two agentic
tool-use loops used the Anthropic SDK directly and were gated to Anthropic:
- `lib/ai/chat.ts` — the streaming, multi-turn conversational command bar
- `lib/ai/agent.ts` — the read-only availability agent (`find_free_slots` → draft)

So with `AI_PROVIDER=openai` the conversational Otter returned a 503.

## Approach
Add one vendor-neutral primitive to the `LlmProvider` contract:

```ts
streamAgentStep(req): Promise<{ text, toolCalls, assistant }>
```

One step of a streaming tool-use loop — it streams assistant text via `onToken`,
returns the parsed tool calls, and hands back an **opaque** assistant turn the
caller echoes into the next step. The caller owns tool execution and the loop; it
never sees vendor types.

- **Anthropic** implements it with native tool use + adaptive thinking + prompt
  caching (unchanged behavior).
- **OpenAI** implements it with streaming Chat Completions function-calling,
  accumulating `tool_calls` deltas by `index` (id/name arrive once, arguments
  stream in fragments). Portable to any OpenAI-compatible endpoint (Groq,
  OpenRouter, Azure, Ollama, …) via `OPENAI_BASE_URL`.

`chat.ts` and `agent.ts` were rewritten to drive the loop through neutral
`AgentTurn`/`AgentToolSpec` values, so both the streaming command bar **and** the
single-shot availability agent now work on either provider.

## Notes
- Confirm-first semantics are unchanged — the loop still only executes *read*
  tools inline; writes/destructive actions and booking proposals surface as
  confirm cards the user taps.
- `supportsAgentTools` stays as a capability flag (now true for both providers);
  the chat route keeps a generic guard for any hypothetical tool-less provider.

## Testing
- `pnpm turbo typecheck` — 15/15 packages
- New unit test: OpenAI `streamAgentStep` delta-accumulation (split argument
  fragments), system-message prepend + tool-result mapping, and non-JSON-args
  tolerance. Web suite: 94 passing.
- Biome clean on all touched files.