### PR TITLE
feat(i18n): honor stored locale preference + language picker

### DIFF
--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -1,7 +1,7 @@
 import { ApiError, api } from "@/api";
 import { useAuth } from "@/auth";
 import { Loading } from "@/components/ui";
-import type { UserPreferences } from "@/models";
+import type { Locale, UserPreferences } from "@/models";
 import { serverHost } from "@/server";
 import { colors, radius } from "@/theme";
 import { Ionicons } from "@expo/vector-icons";
@@ -18,6 +18,14 @@ const WEEK_DAYS = [
   { value: 0, label: "Sunday" },
   { value: 1, label: "Monday" },
   { value: 6, label: "Saturday" },
+];
+// Native-language labels; booking page + Otter chrome are translated (see #81).
+const LOCALES: { value: Locale; label: string }[] = [
+  { value: "en", label: "English" },
+  { value: "es", label: "Español" },
+  { value: "fr", label: "Français" },
+  { value: "de", label: "Deutsch" },
+  { value: "pt", label: "Português" },
 ];
 const REMINDER_OPTIONS = [
   { value: 10080, label: "1 week" },
@@ -38,6 +46,7 @@ export default function SettingsScreen() {
   const [timezone, setTimezone] = useState(user?.timezone ?? "UTC");
   const [timeFormat, setTimeFormat] = useState<"12h" | "24h">("12h");
   const [weekStartsOn, setWeekStartsOn] = useState(0);
+  const [locale, setLocale] = useState<Locale>("en");
   const [reminders, setReminders] = useState<number[]>([1440, 60]);
   const [adaptive, setAdaptive] = useState(false);
   const [maxPerDay, setMaxPerDay] = useState(5);
@@ -70,6 +79,7 @@ export default function SettingsScreen() {
         if (!active) return;
         setTimeFormat(p.timeFormat);
         setWeekStartsOn(p.weekStartsOn);
+        setLocale(p.locale ?? "en");
         setReminders(p.defaultReminderOffsets);
         setAdaptive(p.adaptiveAvailability ?? false);
         setMaxPerDay(p.maxMeetingsPerDay ?? 5);
@@ -115,6 +125,7 @@ export default function SettingsScreen() {
       await api.patch("/api/settings/preferences", {
         timeFormat,
         weekStartsOn,
+        locale,
         defaultReminderOffsets: reminders,
         adaptiveAvailability: adaptive,
         maxMeetingsPerDay: maxPerDay,
@@ -238,6 +249,27 @@ export default function SettingsScreen() {
             </Pressable>
           ))}
         </View>
+
+        <Text style={styles.label}>Language</Text>
+        <View style={styles.wrapPills}>
+          {LOCALES.map((l) => (
+            <Pressable
+              key={l.value}
+              onPress={() => {
+                setLocale(l.value);
+                setSaved(false);
+              }}
+              style={[styles.chip, l.value === locale && styles.pillOn]}
+            >
+              <Text style={[styles.pillText, l.value === locale && styles.pillTextOn]}>
+                {l.label}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+        <Text style={styles.hint}>
+          Your booking page and Otter use this language. The rest of the app is English for now.
+        </Text>
 
         <Text style={styles.label}>Default reminders</Text>
         <View style={styles.wrapPills}>

--- a/apps/mobile/src/models.ts
+++ b/apps/mobile/src/models.ts
@@ -98,10 +98,13 @@ export interface NotificationChannel {
   remindersEnabled: boolean;
 }
 
+export type Locale = "en" | "es" | "fr" | "de" | "pt";
+
 export interface UserPreferences {
   timeFormat: "12h" | "24h";
   weekStartsOn: number;
   theme: "system" | "light" | "dark";
+  locale: Locale;
   defaultReminderOffsets: number[];
   adaptiveAvailability?: boolean;
   maxMeetingsPerDay?: number;

--- a/apps/web/app/(app)/layout.tsx
+++ b/apps/web/app/(app)/layout.tsx
@@ -5,8 +5,8 @@ import { TimezoneSync } from "@/components/timezone-sync";
 import { ToastProvider } from "@/components/ui/toast";
 import { aiEnabled } from "@/lib/ai/llm";
 import { getSession } from "@/lib/auth/session";
-import { resolveLocale } from "@/lib/i18n";
 import { LocaleProvider } from "@/lib/i18n/locale-provider";
+import { resolveUserLocale } from "@/lib/i18n/server";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import type { ReactNode } from "react";
@@ -15,8 +15,9 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
   const session = await getSession();
   if (!session?.user) redirect("/sign-in");
   // Server-resolve the locale so client components (Otter chrome) render the same
-  // language on the server and the client - no hydration mismatch.
-  const locale = resolveLocale((await headers()).get("accept-language"));
+  // language on the server and the client - no hydration mismatch. An explicit
+  // stored language preference wins over the browser's Accept-Language header.
+  const locale = await resolveUserLocale(session.user.id, (await headers()).get("accept-language"));
 
   return (
     <LocaleProvider locale={locale}>

--- a/apps/web/app/(app)/settings/preferences/page.tsx
+++ b/apps/web/app/(app)/settings/preferences/page.tsx
@@ -1,6 +1,7 @@
 import { AnalyticsPreferences } from "@/components/analytics-preferences";
 import { PreferencesForm } from "@/components/preferences-form";
 import { getSession } from "@/lib/auth/session";
+import { isSupportedLocale } from "@/lib/i18n/server";
 import { eq, getDb, schema } from "@dayotter/db";
 
 export const dynamic = "force-dynamic";
@@ -18,6 +19,7 @@ export default async function PreferencesSettingsPage() {
           timeFormat: prefs?.timeFormat ?? "12h",
           weekStartsOn: prefs?.weekStartsOn ?? 0,
           theme: prefs?.theme ?? "system",
+          locale: isSupportedLocale(prefs?.locale) ? prefs.locale : "en",
           defaultReminderOffsets: prefs?.defaultReminderOffsets ?? [1440, 60],
           adaptiveAvailability: prefs?.adaptiveAvailability ?? false,
           maxMeetingsPerDay: prefs?.maxMeetingsPerDay ?? 5,

--- a/apps/web/app/api/settings/preferences/route.ts
+++ b/apps/web/app/api/settings/preferences/route.ts
@@ -1,3 +1,4 @@
+import { SUPPORTED_LOCALES } from "@/lib/i18n";
 import { jsonError, withUser } from "@/lib/server/http";
 import { DEFAULT_REMINDER_OFFSETS } from "@dayotter/core";
 import { eq, getDb, schema } from "@dayotter/db";
@@ -16,6 +17,7 @@ export const GET = withUser(async (u) => {
       timeFormat: prefs?.timeFormat ?? "12h",
       weekStartsOn: prefs?.weekStartsOn ?? 0,
       theme: prefs?.theme ?? "system",
+      locale: prefs?.locale ?? "en",
       defaultReminderOffsets: prefs?.defaultReminderOffsets ?? [...DEFAULT_REMINDER_OFFSETS],
       adaptiveAvailability: prefs?.adaptiveAvailability ?? false,
       maxMeetingsPerDay: prefs?.maxMeetingsPerDay ?? 5,
@@ -41,6 +43,7 @@ const bodySchema = z.object({
   timeFormat: z.enum(["12h", "24h"]).optional(),
   weekStartsOn: z.number().int().min(0).max(6).optional(),
   theme: z.enum(["system", "light", "dark"]).optional(),
+  locale: z.enum(SUPPORTED_LOCALES).optional(),
   defaultReminderOffsets: z.array(z.number().int().min(0).max(43_200)).max(5).optional(),
   adaptiveAvailability: z.boolean().optional(),
   maxMeetingsPerDay: z.number().int().min(1).max(20).optional(),
@@ -66,6 +69,7 @@ export const PATCH = withUser(async (u, request) => {
   if (d.timeFormat !== undefined) fields.timeFormat = d.timeFormat;
   if (d.weekStartsOn !== undefined) fields.weekStartsOn = d.weekStartsOn;
   if (d.theme !== undefined) fields.theme = d.theme;
+  if (d.locale !== undefined) fields.locale = d.locale;
   if (d.defaultReminderOffsets !== undefined) {
     // De-duplicate + sort reminder offsets (largest lead time first).
     fields.defaultReminderOffsets = [...new Set(d.defaultReminderOffsets)].sort((a, b) => b - a);

--- a/apps/web/components/preferences-form.tsx
+++ b/apps/web/components/preferences-form.tsx
@@ -6,10 +6,21 @@ import { Card, CardBody } from "@/components/ui/card";
 import { Input, Label } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
 import { cn } from "@/lib/cn";
+import { type Locale, SUPPORTED_LOCALES } from "@/lib/i18n";
 import { Check, Monitor, Moon, Sun } from "lucide-react";
 import { useEffect, useState } from "react";
 
 type Theme = "system" | "light" | "dark";
+
+/** Native-language labels for the language picker. Booking + Otter chrome are
+ *  translated; the rest of the dashboard is English for now (see #81). */
+const LOCALE_LABELS: Record<Locale, string> = {
+  en: "English",
+  es: "Español",
+  fr: "Français",
+  de: "Deutsch",
+  pt: "Português",
+};
 
 /** Same mechanism as ThemeToggle so both controls stay in sync. */
 function applyTheme(theme: Theme) {
@@ -55,6 +66,7 @@ export function PreferencesForm({
     timeFormat: "12h" | "24h";
     weekStartsOn: number;
     theme: Theme;
+    locale: Locale;
     defaultReminderOffsets: number[];
     adaptiveAvailability?: boolean;
     maxMeetingsPerDay?: number;
@@ -73,6 +85,7 @@ export function PreferencesForm({
   const [timeFormat, setTimeFormat] = useState(initial.timeFormat);
   const [weekStartsOn, setWeekStartsOn] = useState(initial.weekStartsOn);
   const [theme, setTheme] = useState<Theme>(initial.theme);
+  const [locale, setLocale] = useState<Locale>(initial.locale);
   const [reminders, setReminders] = useState<number[]>(initial.defaultReminderOffsets);
   const [adaptive, setAdaptive] = useState(initial.adaptiveAvailability ?? false);
   const [maxPerDay, setMaxPerDay] = useState(initial.maxMeetingsPerDay ?? 5);
@@ -122,6 +135,7 @@ export function PreferencesForm({
         timeFormat,
         weekStartsOn,
         theme,
+        locale,
         defaultReminderOffsets: reminders,
         adaptiveAvailability: adaptive,
         maxMeetingsPerDay: maxPerDay,
@@ -144,6 +158,9 @@ export function PreferencesForm({
       return;
     }
     setSaved(true);
+    // The app shell resolves the language on the server, so a change only takes
+    // effect on reload - refresh once so the new locale applies immediately.
+    if (locale !== initial.locale) window.location.reload();
   }
 
   return (
@@ -206,6 +223,28 @@ export function PreferencesForm({
                 ))}
               </Select>
             </div>
+          </div>
+
+          <div>
+            <Label htmlFor="pref-language">Language</Label>
+            <Select
+              id="pref-language"
+              value={locale}
+              onChange={(e) => {
+                setLocale(e.target.value as Locale);
+                setSaved(false);
+              }}
+            >
+              {SUPPORTED_LOCALES.map((l) => (
+                <option key={l} value={l}>
+                  {LOCALE_LABELS[l]}
+                </option>
+              ))}
+            </Select>
+            <p className="mt-1 text-xs text-[var(--color-faint)]">
+              Your booking page and the Otter assistant use this language. The rest of the dashboard
+              is English for now.
+            </p>
           </div>
 
           <p className="border-t border-[var(--color-border)] pt-4 text-xs font-semibold uppercase tracking-wide text-[var(--color-faint)]">

--- a/apps/web/lib/i18n/server.ts
+++ b/apps/web/lib/i18n/server.ts
@@ -1,0 +1,30 @@
+import { eq, getDb, schema } from "@dayotter/db";
+import { type Locale, SUPPORTED_LOCALES, resolveLocale } from "./index";
+
+/**
+ * Server-only locale resolution. Kept apart from `./index` (which is isomorphic)
+ * because it touches the database.
+ */
+
+/** Narrow an arbitrary string to a supported `Locale`. */
+export function isSupportedLocale(value: string | null | undefined): value is Locale {
+  return !!value && (SUPPORTED_LOCALES as readonly string[]).includes(value);
+}
+
+/**
+ * The locale for a signed-in user: their stored `userPreferences.locale` if it's
+ * a supported language, otherwise the request's `Accept-Language`, otherwise the
+ * default. Used to seed the LocaleProvider in the authed app shell so an explicit
+ * language choice wins over the browser's header.
+ */
+export async function resolveUserLocale(
+  userId: string,
+  acceptLanguage: string | null,
+): Promise<Locale> {
+  const prefs = await getDb().query.userPreferences.findFirst({
+    where: eq(schema.userPreferences.userId, userId),
+    columns: { locale: true },
+  });
+  if (isSupportedLocale(prefs?.locale)) return prefs.locale;
+  return resolveLocale(acceptLanguage);
+}


### PR DESCRIPTION
Closes #81 — follow-up to #80.

## Problem
Locale was resolved from `Accept-Language` only. The DB already had a per-user
`userPreferences.locale` column (default `en`) that nothing read, and there was
no UI to pick a language.

## Changes
- **`lib/i18n/server.ts`** (new, server-only): `resolveUserLocale(userId,
  acceptLanguage)` with the fallback chain **stored preference → Accept-Language
  → default**, plus an `isSupportedLocale` type guard. Kept separate from the
  isomorphic `lib/i18n/index.ts` because it touches the DB.
- **`(app)` layout**: seeds the `LocaleProvider` from `resolveUserLocale`, so an
  explicit language choice wins over the browser header — still server-resolved,
  so no hydration mismatch and the marketing site stays static.
- **Settings → Preferences**: a Language selector on **web** (`PreferencesForm`)
  and **mobile** (settings screen), saved through the existing preferences
  endpoint. Web reloads once when the language changes so the server-resolved
  locale applies immediately.
- **Preferences API**: `locale` added to the GET response, the PATCH schema
  (`z.enum(SUPPORTED_LOCALES)`), and the partial-update field set (so a client
  that omits it doesn't wipe it).

## Coverage (phase 1, per #81)
#80 localized the booking page + Otter chrome; the rest of the dashboard is still
English. The picker copy says exactly that, so the scope is clear to users.

## Testing
- `pnpm --filter web typecheck` + `pnpm --filter mobile typecheck` — clean
- Web suite: 91 passing; Biome clean on all touched files
- The settings form is auth+DB-gated and mirrors the existing theme/time-format
  selects; verified via types + lint rather than standing up a full authed session.