### PR TITLE
feat(mobile): close web↔mobile parity gaps (settings, teams, polls, routing)

### DIFF
--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -437,6 +437,49 @@ export default function SettingsScreen() {
           <Text style={styles.navText}>Teams</Text>
           <Ionicons name="chevron-forward" size={18} color={colors.faint} />
         </Pressable>
+        <Pressable style={[styles.navRow, { marginTop: 10 }]} onPress={() => router.push("/polls")}>
+          <Ionicons name="bar-chart-outline" size={18} color={colors.muted} />
+          <Text style={styles.navText}>Group polls</Text>
+          <Ionicons name="chevron-forward" size={18} color={colors.faint} />
+        </Pressable>
+        <Pressable
+          style={[styles.navRow, { marginTop: 10 }]}
+          onPress={() => router.push("/routing")}
+        >
+          <Ionicons name="git-branch-outline" size={18} color={colors.muted} />
+          <Text style={styles.navText}>Routing forms</Text>
+          <Ionicons name="chevron-forward" size={18} color={colors.faint} />
+        </Pressable>
+
+        <Text style={styles.section}>Billing &amp; payments</Text>
+        <Pressable style={styles.navRow} onPress={() => router.push("/billing")}>
+          <Ionicons name="card-outline" size={18} color={colors.muted} />
+          <Text style={styles.navText}>Plan &amp; billing</Text>
+          <Ionicons name="chevron-forward" size={18} color={colors.faint} />
+        </Pressable>
+        <Pressable
+          style={[styles.navRow, { marginTop: 10 }]}
+          onPress={() => router.push("/payouts")}
+        >
+          <Ionicons name="cash-outline" size={18} color={colors.muted} />
+          <Text style={styles.navText}>Payouts</Text>
+          <Ionicons name="chevron-forward" size={18} color={colors.faint} />
+        </Pressable>
+        <Pressable
+          style={[styles.navRow, { marginTop: 10 }]}
+          onPress={() => router.push("/packages")}
+        >
+          <Ionicons name="cube-outline" size={18} color={colors.muted} />
+          <Text style={styles.navText}>Packages</Text>
+          <Ionicons name="chevron-forward" size={18} color={colors.faint} />
+        </Pressable>
+
+        <Text style={styles.section}>Integrations</Text>
+        <Pressable style={styles.navRow} onPress={() => router.push("/crm")}>
+          <Ionicons name="business-outline" size={18} color={colors.muted} />
+          <Text style={styles.navText}>CRM</Text>
+          <Ionicons name="chevron-forward" size={18} color={colors.faint} />
+        </Pressable>
 
         <Text style={styles.section}>Calendars</Text>
         <Pressable style={styles.navRow} onPress={() => router.push("/calendars")}>

--- a/apps/mobile/app/billing.tsx
+++ b/apps/mobile/app/billing.tsx
@@ -1,0 +1,204 @@
+import { ApiError, api, getServerUrl } from "@/api";
+import { ErrorText, Loading } from "@/components/ui";
+import { useAsync } from "@/hooks";
+import { colors, radius } from "@/theme";
+import { Ionicons } from "@expo/vector-icons";
+import { Stack } from "expo-router";
+import { useState } from "react";
+import {
+  Alert,
+  Linking,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+
+/** Per-seat monthly price, mirroring the web app's PRO_PRICE_USD / pro-lock copy. */
+const PRO_PRICE_USD = 9;
+
+/** Headline Pro capabilities, matching the web billing page's feature list. */
+const PRO_FEATURES = [
+  "AI scheduling assistant",
+  "Automations & workflows",
+  "Booking-funnel analytics",
+  "Developer platform & API keys",
+  "Team scheduling",
+];
+
+/** Shape of `entitlements` from GET /api/me (lib/billing/entitlements.ts). */
+interface Entitlements {
+  edition: "cloud" | "self-hosted";
+  plan: "free" | "pro";
+  isCloud: boolean;
+  isPro: boolean;
+  organizationId: string | null;
+  features?: Record<string, boolean>;
+}
+
+interface MeResponse {
+  entitlements: Entitlements;
+  /** True when Stripe is configured on this deployment. */
+  paymentsEnabled?: boolean;
+}
+
+/** POST /api/billing/{portal,checkout} both return a Stripe redirect URL. */
+interface BillingUrl {
+  url?: string;
+}
+
+function FeatureList() {
+  return (
+    <View style={styles.features}>
+      {PRO_FEATURES.map((f) => (
+        <View key={f} style={styles.featureRow}>
+          <Ionicons name="checkmark" size={16} color={colors.accent} />
+          <Text style={styles.featureText}>{f}</Text>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+export default function BillingScreen() {
+  const { data, loading, error } = useAsync<MeResponse>(() => api.get<MeResponse>("/api/me"));
+  const [busy, setBusy] = useState(false);
+
+  /** Fetch a Stripe URL from the API and hand off to the browser; fall back to
+   *  the web billing page if the endpoint is unavailable or returns no URL. */
+  async function openBilling(path: "/api/billing/portal" | "/api/billing/checkout") {
+    setBusy(true);
+    try {
+      const res = await api.post<BillingUrl>(path, {});
+      const url = res.url ?? `${getServerUrl()}/settings/billing`;
+      await Linking.openURL(url);
+    } catch (e) {
+      // Owner/admin-only or misconfigured billing surfaces here - degrade to the
+      // web settings page rather than dead-ending the user.
+      if (e instanceof ApiError && e.status !== 400 && e.status !== 404) {
+        Alert.alert("Couldn't open billing", e.message);
+      } else {
+        await Linking.openURL(`${getServerUrl()}/settings/billing`).catch(() => {});
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const ent = data?.entitlements;
+
+  return (
+    <View style={styles.safe}>
+      <Stack.Screen options={{ headerShown: true, title: "Billing" }} />
+      <ScrollView contentContainerStyle={styles.scroll}>
+        {loading && !data ? (
+          <Loading />
+        ) : error ? (
+          <ErrorText message={error} />
+        ) : !ent ? (
+          <ErrorText message="Couldn't load your plan." />
+        ) : !ent.isCloud ? (
+          // Self-hosted: no billing - every Pro feature is free, forever.
+          <View style={styles.card}>
+            <View style={styles.selfRow}>
+              <Ionicons name="heart" size={16} color={colors.accent} />
+              <Text style={styles.selfTitle}>Self-hosted — everything unlocked</Text>
+            </View>
+            <Text style={styles.body}>
+              You're running the open-source edition. Every Pro feature is free, forever. No
+              subscription needed.
+            </Text>
+            <FeatureList />
+          </View>
+        ) : (
+          // DayOtter Cloud: show the plan and the upgrade / manage actions.
+          <View style={styles.card}>
+            <View style={styles.planHeader}>
+              <View style={{ flex: 1 }}>
+                <Text style={styles.overline}>Current plan</Text>
+                <Text style={styles.planName}>{ent.plan === "pro" ? "Pro" : "Free"}</Text>
+              </View>
+              <Text style={styles.planMeta}>
+                {ent.plan === "pro"
+                  ? `$${PRO_PRICE_USD}/seat/mo`
+                  : `$${PRO_PRICE_USD}/seat/mo unlocks everything below`}
+              </Text>
+            </View>
+
+            <FeatureList />
+
+            {data?.paymentsEnabled === false ? (
+              <Text style={styles.hint}>Billing isn't fully configured on this server yet.</Text>
+            ) : ent.plan === "pro" ? (
+              <Pressable
+                style={styles.secondaryBtn}
+                onPress={() => openBilling("/api/billing/portal")}
+                disabled={busy}
+              >
+                <Text style={styles.secondaryText}>{busy ? "Opening…" : "Manage billing"}</Text>
+              </Pressable>
+            ) : Platform.OS === "ios" ? (
+              // iOS: no external purchase CTA / pricing (App Store guideline 3.1.1).
+              <Text style={styles.hint}>This is included with the DayOtter Pro plan.</Text>
+            ) : (
+              <Pressable
+                style={styles.primaryBtn}
+                onPress={() => openBilling("/api/billing/checkout")}
+                disabled={busy}
+              >
+                <Text style={styles.primaryText}>{busy ? "Starting…" : "Upgrade to Pro"}</Text>
+              </Pressable>
+            )}
+          </View>
+        )}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: colors.bg },
+  scroll: { padding: 20, paddingBottom: 60 },
+  card: {
+    backgroundColor: colors.surface,
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    padding: 18,
+    gap: 16,
+  },
+  planHeader: { flexDirection: "row", alignItems: "flex-start", gap: 12 },
+  overline: {
+    fontSize: 11,
+    fontWeight: "600",
+    letterSpacing: 0.5,
+    textTransform: "uppercase",
+    color: colors.faint,
+  },
+  planName: { fontSize: 22, fontWeight: "700", color: colors.text, marginTop: 2 },
+  planMeta: { flexShrink: 1, textAlign: "right", fontSize: 13, color: colors.muted, marginTop: 14 },
+  selfRow: { flexDirection: "row", alignItems: "center", gap: 8 },
+  selfTitle: { flex: 1, fontSize: 15, fontWeight: "600", color: colors.text },
+  body: { color: colors.muted, fontSize: 14, lineHeight: 20 },
+  features: { gap: 10 },
+  featureRow: { flexDirection: "row", alignItems: "center", gap: 8 },
+  featureText: { color: colors.text, fontSize: 14 },
+  hint: { color: colors.faint, fontSize: 13, lineHeight: 19 },
+  primaryBtn: {
+    backgroundColor: colors.accent,
+    borderRadius: radius.md,
+    paddingVertical: 14,
+    alignItems: "center",
+  },
+  primaryText: { color: colors.white, fontWeight: "600", fontSize: 15 },
+  secondaryBtn: {
+    borderWidth: 1,
+    borderColor: colors.borderStrong,
+    borderRadius: radius.md,
+    paddingVertical: 14,
+    alignItems: "center",
+  },
+  secondaryText: { color: colors.text, fontWeight: "600", fontSize: 15 },
+});

--- a/apps/mobile/app/booking/[uid].tsx
+++ b/apps/mobile/app/booking/[uid].tsx
@@ -7,7 +7,16 @@ import { colors, radius, statusColor } from "@/theme";
 import { Ionicons } from "@expo/vector-icons";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useState } from "react";
-import { Alert, Linking, Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import {
+  Alert,
+  Linking,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
 
 interface Slot {
   start: string;
@@ -23,6 +32,8 @@ export default function BookingDetailScreen() {
   const [rescheduling, setRescheduling] = useState(false);
   const [slots, setSlots] = useState<Slot[] | null>(null);
   const [slotsLoading, setSlotsLoading] = useState(false);
+  // Optional note sent to attendees on cancel/reschedule (both endpoints accept it).
+  const [reason, setReason] = useState("");
 
   const { data, loading, error, reload } = useAsync<BookingDetail>(async () => {
     const res = await api.get<{ booking: BookingDetail }>(`/api/bookings/${uid}`);
@@ -54,7 +65,8 @@ export default function BookingDetailScreen() {
   async function doCancel(scope: "one" | "series") {
     setCancelling(true);
     try {
-      await api.post(`/api/bookings/${uid}/cancel`, { scope });
+      await api.post(`/api/bookings/${uid}/cancel`, { scope, reason: reason.trim() || undefined });
+      setReason("");
       reload();
     } catch {
       Alert.alert("Could not cancel", "Please try again.");
@@ -138,9 +150,13 @@ export default function BookingDetailScreen() {
         text: "Reschedule",
         onPress: async () => {
           try {
-            await api.post(`/api/bookings/${uid}/reschedule`, { start: slot.start });
+            await api.post(`/api/bookings/${uid}/reschedule`, {
+              start: slot.start,
+              reason: reason.trim() || undefined,
+            });
             setRescheduling(false);
             setSlots(null);
+            setReason("");
             reload();
           } catch (e) {
             const msg =
@@ -208,6 +224,16 @@ export default function BookingDetailScreen() {
                   </Text>
                 </Pressable>
               </View>
+
+              <TextInput
+                style={styles.reasonInput}
+                value={reason}
+                onChangeText={setReason}
+                placeholder="Reason (optional) — shared with attendees"
+                placeholderTextColor={colors.faint}
+                multiline
+                maxLength={500}
+              />
 
               {rescheduling ? (
                 <View style={styles.slotBox}>
@@ -326,6 +352,17 @@ const styles = StyleSheet.create({
     borderColor: colors.borderStrong,
     borderRadius: radius.md,
     paddingVertical: 12,
+  },
+  reasonInput: {
+    marginTop: 12,
+    minHeight: 44,
+    borderWidth: 1,
+    borderColor: colors.borderStrong,
+    borderRadius: radius.md,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    color: colors.text,
+    textAlignVertical: "top",
   },
   slotBox: {
     marginTop: 14,

--- a/apps/mobile/app/crm.tsx
+++ b/apps/mobile/app/crm.tsx
@@ -1,0 +1,281 @@
+import { ApiError, api, getServerUrl } from "@/api";
+import { Badge, EmptyState, ErrorText, Loading } from "@/components/ui";
+import { useAsync } from "@/hooks";
+import { colors, radius } from "@/theme";
+import { Ionicons } from "@expo/vector-icons";
+import { Stack } from "expo-router";
+import { useState } from "react";
+import {
+  Alert,
+  Linking,
+  Pressable,
+  RefreshControl,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+
+// CRM sync is web-CRM parity. The two supported providers mirror
+// packages/integrations/src/crm/types.ts (CRM_PROVIDERS) and the web settings
+// page apps/web/app/(app)/settings/crm/page.tsx.
+type CrmProviderId = "salesforce" | "hubspot";
+
+interface ProviderMeta {
+  id: CrmProviderId;
+  name: string;
+  color: string;
+  blurb: string;
+}
+
+const PROVIDERS: ProviderMeta[] = [
+  {
+    id: "salesforce",
+    name: "Salesforce",
+    color: "#00A1E0",
+    blurb: "Log every booking as an Event on the matched Contact.",
+  },
+  {
+    id: "hubspot",
+    name: "HubSpot",
+    color: "#FF7A59",
+    blurb: "Create the contact and log the meeting, kept in sync on reschedule.",
+  },
+];
+
+// Shape of a connected CRM, mirroring the crmConnections columns the web page reads
+// (id, provider, accountLabel, externalAccountId, lastError).
+interface CrmConnection {
+  id: string;
+  provider: CrmProviderId;
+  accountLabel?: string | null;
+  externalAccountId?: string | null;
+  lastError?: string | null;
+}
+
+// Status payload we consume when the server exposes a client-readable CRM endpoint,
+// mirroring the web page's two data sources: the connection list + crmEnabledProviders().
+// Matches the /api/calendars `{ connections }` convention.
+interface CrmStatusResponse {
+  connections: CrmConnection[];
+  enabled: CrmProviderId[];
+}
+
+// The web CRM settings page reads the DB directly on the server; there is no
+// client GET yet. Until one lands we degrade to a "manage on the web" launcher
+// so the screen is still useful instead of erroring. When the status endpoint
+// ships, we render live connected/enabled state automatically.
+type CrmState =
+  | { mode: "status"; connections: CrmConnection[]; enabled: CrmProviderId[] }
+  | { mode: "web" };
+
+const STATUS_PATH = "/api/integrations/crm";
+const WEB_SETTINGS_URL = `${getServerUrl()}/settings/crm`;
+
+export default function CrmScreen() {
+  const { data, loading, error, reload } = useAsync<CrmState>(async () => {
+    try {
+      const res = await api.get<CrmStatusResponse>(STATUS_PATH);
+      return {
+        mode: "status",
+        connections: res.connections ?? [],
+        enabled: res.enabled ?? [],
+      };
+    } catch (e) {
+      // No client-readable status endpoint on this server -> web-managed fallback.
+      // Any other failure (auth, network) is a real error worth surfacing.
+      if (e instanceof ApiError && (e.status === 404 || e.status === 405)) {
+        return { mode: "web" };
+      }
+      throw e;
+    }
+  });
+
+  const [refreshing, setRefreshing] = useState(false);
+  const [busy, setBusy] = useState<CrmProviderId | null>(null);
+
+  function onRefresh() {
+    setRefreshing(true);
+    reload();
+    // useAsync flips loading synchronously; drop the spinner on the next tick.
+    setTimeout(() => setRefreshing(false), 600);
+  }
+
+  function openWeb() {
+    Linking.openURL(WEB_SETTINGS_URL);
+  }
+
+  async function disconnect(provider: CrmProviderId) {
+    setBusy(provider);
+    try {
+      await api.del(`/api/integrations/crm/${provider}`);
+      reload();
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 404) {
+        // Already gone server-side - refresh to reconcile.
+        reload();
+      } else {
+        Alert.alert("Couldn't disconnect", e instanceof ApiError ? e.message : "Please try again.");
+      }
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  function confirmDisconnect(meta: ProviderMeta) {
+    Alert.alert(`Disconnect ${meta.name}?`, "New bookings will stop syncing to this CRM.", [
+      { text: "Keep", style: "cancel" },
+      { text: "Disconnect", style: "destructive", onPress: () => disconnect(meta.id) },
+    ]);
+  }
+
+  return (
+    <View style={styles.safe}>
+      <Stack.Screen
+        options={{
+          headerShown: true,
+          title: "CRM",
+          headerRight: () => (
+            <Pressable onPress={reload} hitSlop={10} accessibilityLabel="Reload">
+              <Ionicons name="refresh" size={20} color={colors.text} />
+            </Pressable>
+          ),
+        }}
+      />
+      <ScrollView
+        contentContainerStyle={styles.scroll}
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={colors.accent} />
+        }
+      >
+        {loading && !data ? (
+          <Loading />
+        ) : error ? (
+          <ErrorText message={error} />
+        ) : (
+          <>
+            <Text style={styles.lead}>
+              Push every booking to your CRM: DayOtter finds or creates the guest as a contact and
+              logs the meeting as an activity - updated on reschedule, closed on cancel.
+            </Text>
+
+            {PROVIDERS.map((meta) => {
+              const status = data?.mode === "status" ? data : null;
+              const conn = status?.connections.find((c) => c.provider === meta.id) ?? null;
+              const isConnected = Boolean(conn);
+              const isEnabled = status ? status.enabled.includes(meta.id) : false;
+
+              return (
+                <View key={meta.id} style={styles.row}>
+                  <View style={[styles.brandDot, { backgroundColor: meta.color }]} />
+                  <View style={styles.rowBody}>
+                    <View style={styles.rowTitleLine}>
+                      <Text style={styles.name}>{meta.name}</Text>
+                      {isConnected ? <Badge label="Connected" color={colors.success} /> : null}
+                    </View>
+                    <Text style={styles.blurb}>
+                      {conn?.accountLabel || conn?.externalAccountId || meta.blurb}
+                    </Text>
+                    {conn?.lastError ? (
+                      <Text style={styles.err}>Last sync error: {conn.lastError}</Text>
+                    ) : null}
+                  </View>
+
+                  {/* Action column: mirrors the web page's per-provider states. */}
+                  {status === null ? (
+                    // Web-managed fallback: no readable status, so send to the web page.
+                    <Pressable style={styles.linkBtn} onPress={openWeb} hitSlop={6}>
+                      <Ionicons name="open-outline" size={16} color={colors.accent} />
+                      <Text style={styles.linkText}>Manage</Text>
+                    </Pressable>
+                  ) : isConnected ? (
+                    <Pressable
+                      style={styles.dangerBtn}
+                      onPress={() => confirmDisconnect(meta)}
+                      disabled={busy === meta.id}
+                      hitSlop={6}
+                    >
+                      <Text style={styles.dangerText}>
+                        {busy === meta.id ? "Removing…" : "Disconnect"}
+                      </Text>
+                    </Pressable>
+                  ) : isEnabled ? (
+                    <Pressable style={styles.linkBtn} onPress={openWeb} hitSlop={6}>
+                      <Ionicons name="add" size={16} color={colors.accent} />
+                      <Text style={styles.linkText}>Connect</Text>
+                    </Pressable>
+                  ) : (
+                    <Text style={styles.notConfigured}>Not configured</Text>
+                  )}
+                </View>
+              );
+            })}
+
+            {data?.mode === "web" ? (
+              <EmptyState
+                title="Manage CRM sync on the web"
+                body="Connecting a CRM uses a secure OAuth sign-in that opens in your browser. Tap Manage on a provider to connect or disconnect on the DayOtter web app."
+              />
+            ) : data?.mode === "status" && data.enabled.length === 0 ? (
+              <Text style={styles.hint}>
+                No CRM is configured on this server. An admin sets the provider OAuth credentials
+                (SALESFORCE_CLIENT_ID / HUBSPOT_CLIENT_ID + secrets) to enable connecting.
+              </Text>
+            ) : null}
+
+            <Pressable style={styles.webRow} onPress={openWeb}>
+              <Ionicons name="open-outline" size={18} color={colors.text} />
+              <Text style={styles.webRowText}>Open CRM settings on the web</Text>
+              <Ionicons name="chevron-forward" size={18} color={colors.faint} />
+            </Pressable>
+          </>
+        )}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: colors.bg },
+  scroll: { padding: 20, paddingBottom: 60 },
+  lead: { color: colors.muted, fontSize: 13, lineHeight: 19, marginBottom: 16 },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    backgroundColor: colors.surface2,
+    borderRadius: radius.lg,
+    padding: 14,
+    marginBottom: 10,
+  },
+  brandDot: { width: 12, height: 12, borderRadius: 999 },
+  rowBody: { flex: 1 },
+  rowTitleLine: { flexDirection: "row", alignItems: "center", gap: 8 },
+  name: { color: colors.text, fontWeight: "600", fontSize: 15 },
+  blurb: { color: colors.muted, fontSize: 12, marginTop: 2 },
+  err: { color: colors.danger, fontSize: 12, marginTop: 4 },
+  linkBtn: { flexDirection: "row", alignItems: "center", gap: 4 },
+  linkText: { color: colors.accent, fontWeight: "600", fontSize: 14 },
+  dangerBtn: {
+    borderWidth: 1,
+    borderColor: colors.danger,
+    borderRadius: radius.md,
+    paddingVertical: 7,
+    paddingHorizontal: 12,
+  },
+  dangerText: { color: colors.danger, fontWeight: "600", fontSize: 13 },
+  notConfigured: { color: colors.faint, fontSize: 12 },
+  hint: { color: colors.faint, fontSize: 12, lineHeight: 18, marginTop: 8 },
+  webRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.md,
+    paddingVertical: 14,
+    paddingHorizontal: 14,
+    marginTop: 14,
+  },
+  webRowText: { flex: 1, color: colors.text, fontSize: 15, fontWeight: "500" },
+});

--- a/apps/mobile/app/packages.tsx
+++ b/apps/mobile/app/packages.tsx
@@ -1,0 +1,430 @@
+import { ApiError, api } from "@/api";
+import { EmptyState, ErrorText, Loading } from "@/components/ui";
+import { useAsync } from "@/hooks";
+import type { EventType } from "@/models";
+import { colors, radius } from "@/theme";
+import { Stack } from "expo-router";
+import { useState } from "react";
+import {
+  Alert,
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+
+/** A host's package offering (GET /api/packages → packages[]). */
+interface PackageRow {
+  id: string;
+  eventTypeId: string;
+  name: string;
+  sessionCount: number;
+  priceAmount: number;
+  currency: string;
+  isActive: boolean;
+}
+
+/** An outstanding client balance (GET /api/packages → credits[]). */
+interface CreditRow {
+  id: string;
+  eventTypeId: string;
+  clientEmail: string;
+  total: number;
+  used: number;
+  remaining: number;
+}
+
+interface PackagesResponse {
+  packages: PackageRow[];
+  credits: CreditRow[];
+}
+
+function money(minor: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: currency.toUpperCase(),
+    }).format(minor / 100);
+  } catch {
+    return `$${(minor / 100).toFixed(2)}`;
+  }
+}
+
+export default function PackagesScreen() {
+  const { data, loading, error, reload } = useAsync<PackagesResponse>(async () => {
+    return await api.get<PackagesResponse>("/api/packages");
+  });
+
+  // Event types are needed to scope a new package to a booking type.
+  const eventTypesState = useAsync<EventType[]>(async () => {
+    const res = await api.get<{ eventTypes: EventType[] }>("/api/event-types");
+    return res.eventTypes;
+  });
+  const eventTypes = eventTypesState.data ?? [];
+
+  function titleFor(id: string): string {
+    return eventTypes.find((e) => e.id === id)?.title ?? "Unknown booking type";
+  }
+
+  // Create-package modal.
+  const [createOpen, setCreateOpen] = useState(false);
+  const [eventTypeId, setEventTypeId] = useState("");
+  const [name, setName] = useState("");
+  const [sessions, setSessions] = useState("5");
+  const [price, setPrice] = useState("250");
+  const [saving, setSaving] = useState(false);
+
+  // Grant-credits modal (scoped to the tapped package).
+  const [grantFor, setGrantFor] = useState<PackageRow | null>(null);
+  const [grantEmail, setGrantEmail] = useState("");
+  const [granting, setGranting] = useState(false);
+
+  function openCreate() {
+    setName("");
+    setSessions("5");
+    setPrice("250");
+    setEventTypeId(eventTypes[0]?.id ?? "");
+    setCreateOpen(true);
+  }
+
+  async function createPackage() {
+    const sessionCount = Math.round(Number(sessions));
+    const priceAmount = Math.round(Number(price) * 100);
+    if (!eventTypeId || !name.trim() || !Number.isFinite(sessionCount) || sessionCount < 1) return;
+    setSaving(true);
+    try {
+      await api.post("/api/packages", {
+        eventTypeId,
+        name: name.trim(),
+        sessionCount,
+        priceAmount: Number.isFinite(priceAmount) && priceAmount > 0 ? priceAmount : 0,
+        currency: "usd",
+      });
+      setCreateOpen(false);
+      Alert.alert("Package created", `${name.trim()} is now available.`);
+      reload();
+    } catch (e) {
+      Alert.alert("Couldn't create", e instanceof ApiError ? e.message : "Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function openGrant(pkg: PackageRow) {
+    setGrantFor(pkg);
+    setGrantEmail("");
+  }
+
+  async function grant() {
+    const email = grantEmail.trim();
+    if (!grantFor || !email) return;
+    setGranting(true);
+    try {
+      await api.post("/api/packages/grant", { packageId: grantFor.id, clientEmail: email });
+      setGrantFor(null);
+      Alert.alert("Credits granted", `${grantFor.sessionCount} credits granted to ${email}.`);
+      reload();
+    } catch (e) {
+      Alert.alert("Couldn't grant", e instanceof ApiError ? e.message : "Please try again.");
+    } finally {
+      setGranting(false);
+    }
+  }
+
+  const packages = data?.packages ?? [];
+  const credits = data?.credits ?? [];
+  const noEventTypes = !eventTypesState.loading && eventTypes.length === 0;
+
+  return (
+    <View style={styles.safe}>
+      <Stack.Screen options={{ headerShown: true, title: "Packages" }} />
+      <ScrollView contentContainerStyle={styles.scroll} keyboardShouldPersistTaps="handled">
+        {loading && !data ? (
+          <Loading />
+        ) : error ? (
+          <ErrorText message={error} />
+        ) : (
+          <>
+            {noEventTypes ? (
+              <EmptyState
+                title="Create a booking type first"
+                body="Packages are sold against one of your booking types. Add a booking type, then come back here."
+              />
+            ) : (
+              <Pressable style={styles.newBtn} onPress={openCreate}>
+                <Text style={styles.newBtnText}>+ New package</Text>
+              </Pressable>
+            )}
+
+            <Text style={styles.section}>Your packages</Text>
+            {packages.length === 0 ? (
+              <EmptyState
+                title="No packages yet"
+                body="Sell a bundle of prepaid sessions for one of your booking types."
+              />
+            ) : (
+              packages.map((p) => (
+                <View key={p.id} style={styles.card}>
+                  <View style={styles.cardHead}>
+                    <Text style={styles.cardName}>{p.name}</Text>
+                    <Text style={styles.cardMeta}>
+                      {p.sessionCount} sessions · {money(p.priceAmount, p.currency)}
+                    </Text>
+                  </View>
+                  <Text style={styles.cardSub}>{titleFor(p.eventTypeId)}</Text>
+                  <Pressable style={styles.grantBtn} onPress={() => openGrant(p)}>
+                    <Text style={styles.grantBtnText}>Grant credits</Text>
+                  </Pressable>
+                </View>
+              ))
+            )}
+
+            <Text style={styles.section}>Client balances</Text>
+            {credits.length === 0 ? (
+              <Text style={styles.hint}>
+                No credits issued yet. Grant a package above, or share a purchase link from the web
+                app.
+              </Text>
+            ) : (
+              credits.map((c) => (
+                <View key={c.id} style={styles.balanceRow}>
+                  <View style={{ flex: 1 }}>
+                    <Text style={styles.balanceEmail}>{c.clientEmail}</Text>
+                    <Text style={styles.cardSub}>{titleFor(c.eventTypeId)}</Text>
+                  </View>
+                  <Text style={[styles.balanceCount, c.remaining === 0 && { color: colors.faint }]}>
+                    {c.used} of {c.total} used
+                  </Text>
+                </View>
+              ))
+            )}
+          </>
+        )}
+      </ScrollView>
+
+      {/* Create package modal */}
+      <Modal
+        visible={createOpen}
+        animationType="slide"
+        transparent
+        onRequestClose={() => setCreateOpen(false)}
+      >
+        <View style={styles.backdrop}>
+          <View style={styles.sheet}>
+            <ScrollView keyboardShouldPersistTaps="handled">
+              <Text style={styles.sheetTitle}>New package</Text>
+              <Text style={styles.hint}>
+                Clients spend one credit each time they book this booking type.
+              </Text>
+
+              <Text style={styles.label}>Booking type</Text>
+              <View style={styles.pills}>
+                {eventTypes.map((et) => (
+                  <Pressable
+                    key={et.id}
+                    onPress={() => setEventTypeId(et.id)}
+                    style={[styles.pill, et.id === eventTypeId && styles.pillOn]}
+                  >
+                    <Text style={[styles.pillText, et.id === eventTypeId && styles.pillTextOn]}>
+                      {et.title}
+                    </Text>
+                  </Pressable>
+                ))}
+              </View>
+
+              <Text style={styles.label}>Name</Text>
+              <TextInput
+                style={styles.input}
+                value={name}
+                onChangeText={setName}
+                placeholder="Coaching 5-pack"
+                placeholderTextColor={colors.faint}
+              />
+
+              <View style={styles.row}>
+                <View style={{ flex: 1 }}>
+                  <Text style={styles.label}>Sessions</Text>
+                  <TextInput
+                    style={styles.input}
+                    value={sessions}
+                    onChangeText={setSessions}
+                    keyboardType="number-pad"
+                    placeholder="5"
+                    placeholderTextColor={colors.faint}
+                  />
+                </View>
+                <View style={{ flex: 1 }}>
+                  <Text style={styles.label}>Price (USD)</Text>
+                  <TextInput
+                    style={styles.input}
+                    value={price}
+                    onChangeText={setPrice}
+                    keyboardType="decimal-pad"
+                    placeholder="250"
+                    placeholderTextColor={colors.faint}
+                  />
+                </View>
+              </View>
+
+              <Pressable
+                style={[styles.save, (saving || !name.trim() || !eventTypeId) && styles.disabled]}
+                onPress={createPackage}
+                disabled={saving || !name.trim() || !eventTypeId}
+              >
+                <Text style={styles.saveText}>{saving ? "Creating…" : "Create package"}</Text>
+              </Pressable>
+              <Pressable style={styles.cancel} onPress={() => setCreateOpen(false)}>
+                <Text style={styles.cancelText}>Cancel</Text>
+              </Pressable>
+            </ScrollView>
+          </View>
+        </View>
+      </Modal>
+
+      {/* Grant credits modal */}
+      <Modal
+        visible={grantFor !== null}
+        animationType="slide"
+        transparent
+        onRequestClose={() => setGrantFor(null)}
+      >
+        <View style={styles.backdrop}>
+          <View style={styles.sheet}>
+            <Text style={styles.sheetTitle}>Grant credits</Text>
+            {grantFor ? (
+              <Text style={styles.hint}>
+                Give {grantFor.sessionCount} credits of “{grantFor.name}” to a client who paid
+                offline.
+              </Text>
+            ) : null}
+
+            <Text style={styles.label}>Client email</Text>
+            <TextInput
+              style={styles.input}
+              value={grantEmail}
+              onChangeText={setGrantEmail}
+              placeholder="client@example.com"
+              placeholderTextColor={colors.faint}
+              keyboardType="email-address"
+              autoCapitalize="none"
+              autoCorrect={false}
+            />
+
+            <Pressable
+              style={[styles.save, (granting || !grantEmail.trim()) && styles.disabled]}
+              onPress={grant}
+              disabled={granting || !grantEmail.trim()}
+            >
+              <Text style={styles.saveText}>{granting ? "Granting…" : "Grant credits"}</Text>
+            </Pressable>
+            <Pressable style={styles.cancel} onPress={() => setGrantFor(null)}>
+              <Text style={styles.cancelText}>Cancel</Text>
+            </Pressable>
+          </View>
+        </View>
+      </Modal>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: colors.bg },
+  scroll: { padding: 20, paddingBottom: 60 },
+  newBtn: {
+    backgroundColor: colors.accent,
+    borderRadius: radius.md,
+    paddingVertical: 14,
+    alignItems: "center",
+    marginBottom: 8,
+  },
+  newBtnText: { color: colors.white, fontWeight: "600", fontSize: 15 },
+  section: { marginTop: 18, marginBottom: 10, fontWeight: "600", color: colors.muted },
+  card: {
+    backgroundColor: colors.surface,
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    padding: 16,
+    marginBottom: 10,
+  },
+  cardHead: {
+    flexDirection: "row",
+    alignItems: "baseline",
+    justifyContent: "space-between",
+    gap: 8,
+  },
+  cardName: { color: colors.text, fontWeight: "600", fontSize: 15, flexShrink: 1 },
+  cardMeta: { color: colors.muted, fontSize: 13 },
+  cardSub: { color: colors.faint, fontSize: 12, marginTop: 2 },
+  grantBtn: {
+    marginTop: 12,
+    alignSelf: "flex-start",
+    borderWidth: 1,
+    borderColor: colors.borderStrong,
+    borderRadius: radius.md,
+    paddingVertical: 9,
+    paddingHorizontal: 16,
+  },
+  grantBtnText: { color: colors.text, fontWeight: "600", fontSize: 13 },
+  balanceRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    backgroundColor: colors.surface2,
+    borderRadius: radius.lg,
+    padding: 14,
+    marginBottom: 10,
+  },
+  balanceEmail: { color: colors.text, fontWeight: "600" },
+  balanceCount: { color: colors.muted, fontSize: 13 },
+  hint: { color: colors.faint, fontSize: 13, marginBottom: 4 },
+  // Modal
+  backdrop: { flex: 1, backgroundColor: "#00000055", justifyContent: "flex-end" },
+  sheet: {
+    backgroundColor: colors.bg,
+    borderTopLeftRadius: radius.lg,
+    borderTopRightRadius: radius.lg,
+    padding: 20,
+    paddingBottom: 32,
+    maxHeight: "90%",
+  },
+  sheetTitle: { fontSize: 18, fontWeight: "700", color: colors.text, marginBottom: 6 },
+  label: { color: colors.muted, fontWeight: "600", fontSize: 13, marginBottom: 6, marginTop: 12 },
+  input: {
+    minHeight: 48,
+    borderWidth: 1,
+    borderColor: colors.borderStrong,
+    borderRadius: radius.md,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 15,
+    color: colors.text,
+    backgroundColor: colors.surface,
+  },
+  row: { flexDirection: "row", gap: 12 },
+  pills: { flexDirection: "row", flexWrap: "wrap", gap: 8 },
+  pill: {
+    borderWidth: 1,
+    borderColor: colors.borderStrong,
+    borderRadius: 999,
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+  },
+  pillOn: { borderColor: colors.accent, backgroundColor: colors.accentSoft },
+  pillText: { color: colors.muted, fontSize: 13 },
+  pillTextOn: { color: colors.text, fontWeight: "600" },
+  save: {
+    marginTop: 20,
+    backgroundColor: colors.accent,
+    borderRadius: radius.md,
+    paddingVertical: 15,
+    alignItems: "center",
+  },
+  saveText: { color: colors.white, fontWeight: "600", fontSize: 15 },
+  disabled: { opacity: 0.5 },
+  cancel: { marginTop: 10, paddingVertical: 12, alignItems: "center" },
+  cancelText: { color: colors.muted, fontWeight: "600", fontSize: 14 },
+});

--- a/apps/mobile/app/payouts.tsx
+++ b/apps/mobile/app/payouts.tsx
@@ -1,0 +1,284 @@
+import { ApiError, api, getServerUrl } from "@/api";
+import { ErrorText, Loading } from "@/components/ui";
+import { useAsync } from "@/hooks";
+import { colors, radius } from "@/theme";
+import { Ionicons } from "@expo/vector-icons";
+import { Stack } from "expo-router";
+import { useState } from "react";
+import { Alert, Linking, Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+
+// --- Local types -------------------------------------------------------------
+// Mirrors the web Payouts settings (apps/web/components/payouts-panel.tsx +
+// apps/web/app/(app)/settings/payouts/page.tsx), fed by GET /api/payments/status.
+
+/** One currency bucket on the host's connected account (minor units). */
+interface Balance {
+  currency: string;
+  /** Minor units clear to withdraw now. */
+  available: number;
+  /** Minor units still in Stripe's hold period ("on the way"). */
+  pending: number;
+}
+
+/** GET /api/payments/status shape. */
+interface PayoutStatus {
+  paymentsEnabled: boolean;
+  connected: boolean;
+  chargesEnabled: boolean;
+  payoutsEnabled: boolean;
+  detailsSubmitted: boolean;
+  balances: Balance[];
+  /** WITHDRAW_MINIMUM in minor units (10000 = $100). */
+  minimum: number;
+  feePercent: number;
+}
+
+/** POST /api/payments/withdraw success shape: one entry per paid-out currency. */
+interface WithdrawResult {
+  ok?: boolean;
+  payouts?: { amount: number; currency: string }[];
+}
+
+/** Format minor units as currency, mirroring payouts-panel's money(). */
+function money(minor: number, currency = "usd"): string {
+  return new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency: currency.toUpperCase(),
+  }).format(minor / 100);
+}
+
+export default function PayoutsScreen() {
+  const { data, loading, error, reload } = useAsync<PayoutStatus>(() =>
+    api.get<PayoutStatus>("/api/payments/status"),
+  );
+
+  const [busy, setBusy] = useState(false);
+
+  // Manual payout - the server pays out every currency bucket that clears the
+  // minimum; we surface its result/error and refresh the balances after.
+  async function withdraw() {
+    setBusy(true);
+    try {
+      const res = await api.post<WithdrawResult>("/api/payments/withdraw", {});
+      const paid = Array.isArray(res.payouts) ? res.payouts : [];
+      const sent = paid.map((p) => money(p.amount ?? 0, p.currency)).join(" + ");
+      reload();
+      Alert.alert("Withdrawal started", `${sent || "Your balance"} is on its way to your bank.`);
+    } catch (e) {
+      Alert.alert("Couldn't withdraw", e instanceof ApiError ? e.message : "Please try again.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  // Confirm before moving money.
+  function confirmWithdraw(minimum: number) {
+    Alert.alert(
+      "Withdraw to bank",
+      `Pay out your available balance to your connected bank account? Minimum ${money(minimum)} per currency.`,
+      [
+        { text: "Cancel", style: "cancel" },
+        { text: "Withdraw", onPress: withdraw },
+      ],
+    );
+  }
+
+  // Stripe Express onboarding needs a full browser redirect - open the web app.
+  function openSetup() {
+    Linking.openURL(`${getServerUrl()}/settings/payouts`);
+  }
+
+  // 302s to the host's Stripe Express dashboard (payout history, bank + tax details).
+  function openDashboard() {
+    Linking.openURL(`${getServerUrl()}/api/payments/dashboard`);
+  }
+
+  const ready = data
+    ? data.connected && data.chargesEnabled && data.payoutsEnabled && data.detailsSubmitted
+    : false;
+  // Withdraw is enabled if ANY currency bucket clears the minimum.
+  const canWithdraw = !!data && ready && data.balances.some((b) => b.available >= data.minimum);
+  const primary = data?.balances[0]?.currency ?? "usd";
+
+  return (
+    <View style={styles.safe}>
+      <Stack.Screen options={{ headerShown: true, title: "Payouts" }} />
+      <ScrollView contentContainerStyle={styles.scroll}>
+        {loading && !data ? (
+          <Loading />
+        ) : error ? (
+          <ErrorText message={error} />
+        ) : !data?.paymentsEnabled ? (
+          <View style={styles.card}>
+            <Text style={styles.cardTitle}>Payouts aren't available</Text>
+            <Text style={styles.cardBody}>
+              Payments aren't configured on this server. Once your host enables Stripe, you'll be
+              able to get paid directly for paid bookings and session packages.
+            </Text>
+          </View>
+        ) : !ready ? (
+          // Not connected, or onboarding not finished → send them to Stripe.
+          <View style={styles.card}>
+            <View style={styles.titleRow}>
+              <Ionicons name="card-outline" size={18} color={colors.accent} />
+              <Text style={styles.cardTitle}>Get paid directly</Text>
+            </View>
+            <Text style={styles.cardBody}>
+              {data.connected && data.detailsSubmitted
+                ? "Your payout account still needs a few details before Stripe can enable charges and payouts."
+                : "Connect a Stripe account so booking and package payments land in your bank - not ours. You'll add your bank details on Stripe; it takes a couple of minutes."}
+              {data.feePercent > 0
+                ? ` DayOtter keeps a ${data.feePercent}% platform fee on each payment; the rest is yours.`
+                : ""}
+            </Text>
+            <Pressable style={styles.primaryBtn} onPress={openSetup}>
+              <Ionicons name="open-outline" size={18} color={colors.white} />
+              <Text style={styles.primaryText}>
+                {data.connected && data.detailsSubmitted
+                  ? "Finish setting up payouts"
+                  : "Set up payouts (web)"}
+              </Text>
+            </Pressable>
+          </View>
+        ) : (
+          <>
+            <View style={styles.card}>
+              <View style={styles.titleRow}>
+                <Ionicons name="checkmark-circle" size={18} color={colors.success} />
+                <Text style={styles.cardTitle}>Payouts connected</Text>
+              </View>
+              <Text style={styles.cardBody}>
+                {data.feePercent > 0
+                  ? `Payments land in your Stripe account minus DayOtter's ${data.feePercent}% fee.`
+                  : "Payments land straight in your Stripe account."}
+              </Text>
+
+              <View style={styles.balBox}>
+                <Text style={styles.balLabel}>Available to withdraw</Text>
+                {data.balances.length === 0 ? (
+                  <Text style={styles.balValue}>{money(0, primary)}</Text>
+                ) : (
+                  data.balances.map((b) => (
+                    <View key={b.currency} style={styles.balRow}>
+                      <Text style={styles.balValue}>{money(b.available, b.currency)}</Text>
+                      {b.pending > 0 ? (
+                        <Text style={styles.balPending}>
+                          {money(b.pending, b.currency)} on the way
+                        </Text>
+                      ) : null}
+                    </View>
+                  ))
+                )}
+                <Text style={styles.balHint}>
+                  Minimum withdrawal {money(data.minimum, primary)} per currency. Payouts are manual
+                  - withdraw once your balance clears the minimum.
+                </Text>
+              </View>
+            </View>
+
+            <Pressable
+              style={[styles.primaryBtn, (!canWithdraw || busy) && styles.btnDisabled]}
+              onPress={() => confirmWithdraw(data.minimum)}
+              disabled={!canWithdraw || busy}
+            >
+              <Ionicons name="cash-outline" size={18} color={colors.white} />
+              <Text style={styles.primaryText}>{busy ? "Starting…" : "Withdraw to bank"}</Text>
+            </Pressable>
+            {!canWithdraw ? (
+              <Text style={styles.belowMin}>
+                You can withdraw once your balance reaches {money(data.minimum, primary)}.
+              </Text>
+            ) : null}
+
+            <Text style={styles.section}>Manage</Text>
+
+            <Pressable style={styles.addRow} onPress={openDashboard}>
+              <Ionicons name="stats-chart-outline" size={18} color={colors.text} />
+              <View style={{ flex: 1 }}>
+                <Text style={styles.addText}>Open Stripe dashboard</Text>
+                <Text style={styles.addSub}>Payout history, bank / tax details.</Text>
+              </View>
+              <Ionicons name="chevron-forward" size={18} color={colors.faint} />
+            </Pressable>
+
+            <Pressable style={styles.addRow} onPress={openSetup}>
+              <Ionicons name="open-outline" size={18} color={colors.text} />
+              <View style={{ flex: 1 }}>
+                <Text style={styles.addText}>Update payout details (web)</Text>
+                <Text style={styles.addSub}>Manage your Stripe account.</Text>
+              </View>
+              <Ionicons name="chevron-forward" size={18} color={colors.faint} />
+            </Pressable>
+          </>
+        )}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: colors.bg },
+  scroll: { padding: 20, paddingBottom: 60 },
+  card: {
+    backgroundColor: colors.surface,
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    padding: 16,
+    marginBottom: 14,
+  },
+  titleRow: { flexDirection: "row", alignItems: "center", gap: 8, marginBottom: 8 },
+  cardTitle: { color: colors.text, fontSize: 16, fontWeight: "700" },
+  cardBody: { color: colors.muted, fontSize: 14, lineHeight: 20 },
+  balBox: {
+    marginTop: 14,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.md,
+    padding: 14,
+  },
+  balLabel: {
+    color: colors.faint,
+    fontSize: 11,
+    fontWeight: "600",
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+  },
+  balRow: {
+    flexDirection: "row",
+    alignItems: "baseline",
+    justifyContent: "space-between",
+    gap: 12,
+    marginTop: 4,
+  },
+  balValue: { color: colors.text, fontSize: 28, fontWeight: "700" },
+  balPending: { color: colors.faint, fontSize: 12 },
+  balHint: { color: colors.faint, fontSize: 12, marginTop: 10 },
+  primaryBtn: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+    backgroundColor: colors.accent,
+    borderRadius: radius.md,
+    paddingVertical: 14,
+    marginBottom: 4,
+  },
+  btnDisabled: { opacity: 0.5 },
+  primaryText: { color: colors.white, fontSize: 15, fontWeight: "600" },
+  belowMin: { color: colors.muted, fontSize: 13, marginTop: 6 },
+  section: { marginTop: 20, marginBottom: 12, fontWeight: "600", color: colors.muted },
+  addRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.md,
+    paddingVertical: 14,
+    paddingHorizontal: 14,
+    marginBottom: 10,
+  },
+  addText: { color: colors.text, fontSize: 15, fontWeight: "500" },
+  addSub: { color: colors.faint, fontSize: 12, marginTop: 2 },
+});

--- a/apps/mobile/app/polls/[id].tsx
+++ b/apps/mobile/app/polls/[id].tsx
@@ -1,0 +1,255 @@
+import { ApiError, api, getServerUrl } from "@/api";
+import { Badge, ErrorText, Loading } from "@/components/ui";
+import { formatDateTime } from "@/format";
+import { useAsync } from "@/hooks";
+import { colors, radius } from "@/theme";
+import { Ionicons } from "@expo/vector-icons";
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
+import { useState } from "react";
+import { Alert, Linking, Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+
+/** GET /api/polls/[id] detail (mirrors getPollForHost). */
+interface PollOption {
+  id: string;
+  startsAt: string;
+}
+interface PollVote {
+  optionId: string;
+  voterName: string;
+  response: string; // "yes" | "no" | "maybe"
+}
+interface PollDetail {
+  id: string;
+  title: string;
+  status: string; // "open" | "finalized"
+  token: string;
+  finalizedOptionId: string | null;
+  durationMinutes?: string | number;
+  location?: string | null;
+  options: PollOption[];
+  votes: PollVote[];
+}
+
+interface OptionResult {
+  id: string;
+  startsAt: string;
+  yes: number;
+  maybe: number;
+  no: number;
+  voters: { name: string; response: string }[];
+}
+
+function tally(poll: PollDetail): OptionResult[] {
+  return poll.options.map((o) => {
+    const votes = poll.votes.filter((v) => v.optionId === o.id);
+    return {
+      id: o.id,
+      startsAt: o.startsAt,
+      yes: votes.filter((v) => v.response === "yes").length,
+      maybe: votes.filter((v) => v.response === "maybe").length,
+      no: votes.filter((v) => v.response === "no").length,
+      voters: votes.map((v) => ({ name: v.voterName, response: v.response })),
+    };
+  });
+}
+
+export default function PollDetailScreen() {
+  const router = useRouter();
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const [finalizing, setFinalizing] = useState<string | null>(null);
+
+  const { data, loading, error, reload } = useAsync<PollDetail>(async () => {
+    const res = await api.get<{ poll: PollDetail }>(`/api/polls/${id}`);
+    return res.poll;
+  }, [id]);
+
+  const isFinalized = data?.status === "finalized";
+  const results = data ? tally(data) : [];
+  const uniqueVoters = data ? new Set(data.votes.map((v) => v.voterName)).size : 0;
+
+  // Highlight the leader (most yes, then most maybe) while the poll is open.
+  const leaderId = !isFinalized
+    ? [...results].sort(
+        (a, b) => b.yes - a.yes || b.maybe - a.maybe || a.startsAt.localeCompare(b.startsAt),
+      )[0]?.id
+    : undefined;
+
+  const shareUrl = data ? `${getServerUrl().replace(/\/$/, "")}/poll/${data.token}` : "";
+
+  function confirmFinalize(opt: OptionResult) {
+    Alert.alert(
+      "Lock in this time?",
+      `${formatDateTime(opt.startsAt)}\n\nEveryone who can make it will be notified and the meeting is added to your calendar.`,
+      [
+        { text: "Back", style: "cancel" },
+        { text: "Pick this", onPress: () => finalize(opt.id) },
+      ],
+    );
+  }
+
+  async function finalize(optionId: string) {
+    setFinalizing(optionId);
+    try {
+      await api.post(`/api/polls/${id}/finalize`, { optionId });
+      reload();
+    } catch (e) {
+      Alert.alert("Couldn't finalize", e instanceof ApiError ? e.message : "Please try again.");
+    } finally {
+      setFinalizing(null);
+    }
+  }
+
+  return (
+    <View style={styles.safe}>
+      <Stack.Screen options={{ headerShown: true, title: "Group poll" }} />
+      {loading && !data ? (
+        <Loading />
+      ) : error || !data ? (
+        <ErrorText message={error ?? "Not found"} />
+      ) : (
+        <ScrollView contentContainerStyle={styles.scroll}>
+          <View style={styles.top}>
+            <Badge
+              label={isFinalized ? "Finalized" : "Open"}
+              color={isFinalized ? colors.success : colors.muted}
+            />
+          </View>
+          <Text style={styles.title}>{data.title}</Text>
+          <Text style={styles.subtitle}>
+            {isFinalized
+              ? "The time is on your calendar and everyone's been notified."
+              : `${uniqueVoters} ${uniqueVoters === 1 ? "person has" : "people have"} voted so far.`}
+          </Text>
+
+          {!isFinalized ? (
+            <Pressable style={styles.shareBox} onPress={() => Linking.openURL(shareUrl)}>
+              <Ionicons name="share-outline" size={16} color={colors.accent} />
+              <View style={{ flex: 1 }}>
+                <Text style={styles.shareLabel}>Share to collect votes</Text>
+                <Text style={styles.shareUrl} numberOfLines={1}>
+                  {shareUrl}
+                </Text>
+              </View>
+              <Ionicons name="open-outline" size={16} color={colors.faint} />
+            </Pressable>
+          ) : null}
+
+          <Text style={styles.section}>Proposed times</Text>
+          {results.map((o) => {
+            const isWinner = isFinalized && data.finalizedOptionId === o.id;
+            const isLeader = leaderId === o.id && o.yes + o.maybe > 0;
+            return (
+              <View
+                key={o.id}
+                style={[
+                  styles.option,
+                  isWinner && styles.optionWinner,
+                  isLeader && styles.optionLeader,
+                ]}
+              >
+                <View style={styles.optionHead}>
+                  <Text style={styles.optionTime}>{formatDateTime(o.startsAt)}</Text>
+                  {isWinner ? (
+                    <View style={styles.tag}>
+                      <Ionicons name="checkmark-circle" size={13} color={colors.success} />
+                      <Text style={[styles.tagText, { color: colors.success }]}>Booked</Text>
+                    </View>
+                  ) : isLeader ? (
+                    <Text style={[styles.tagText, { color: colors.accent }]}>Leading</Text>
+                  ) : null}
+                </View>
+
+                <View style={styles.counts}>
+                  <Text style={[styles.count, { color: colors.success }]}>{o.yes} yes</Text>
+                  <Text style={styles.count}>{o.maybe} maybe</Text>
+                  <Text style={[styles.count, { color: colors.faint }]}>{o.no} no</Text>
+                </View>
+
+                {o.voters.length > 0 ? (
+                  <Text style={styles.voters} numberOfLines={2}>
+                    {o.voters
+                      .slice(0, 6)
+                      .map((v) => `${v.name} (${v.response})`)
+                      .join(", ")}
+                    {o.voters.length > 6 ? ` +${o.voters.length - 6}` : ""}
+                  </Text>
+                ) : null}
+
+                {!isFinalized ? (
+                  <Pressable
+                    style={[styles.pick, isLeader && styles.pickPrimary]}
+                    onPress={() => confirmFinalize(o)}
+                    disabled={finalizing !== null}
+                  >
+                    <Text style={[styles.pickText, isLeader && styles.pickTextPrimary]}>
+                      {finalizing === o.id ? "Booking…" : "Pick this time"}
+                    </Text>
+                  </Pressable>
+                ) : null}
+              </View>
+            );
+          })}
+
+          <Pressable style={styles.back} onPress={() => router.back()}>
+            <Text style={styles.backText}>All polls</Text>
+          </Pressable>
+        </ScrollView>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: colors.bg },
+  scroll: { padding: 20, paddingBottom: 40 },
+  top: { flexDirection: "row", marginBottom: 12 },
+  title: { fontSize: 24, fontWeight: "700", color: colors.text },
+  subtitle: { color: colors.muted, marginTop: 6, fontSize: 14 },
+  shareBox: {
+    marginTop: 18,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    backgroundColor: colors.surface2,
+    borderRadius: radius.lg,
+    padding: 14,
+  },
+  shareLabel: { color: colors.muted, fontSize: 12 },
+  shareUrl: { color: colors.text, fontSize: 13, marginTop: 2 },
+  section: { marginTop: 22, marginBottom: 10, fontWeight: "600", color: colors.muted },
+  option: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.lg,
+    padding: 16,
+    marginBottom: 10,
+    backgroundColor: colors.surface,
+  },
+  optionWinner: { borderColor: colors.success, backgroundColor: colors.surface2 },
+  optionLeader: { borderColor: colors.accent, backgroundColor: colors.accentSoft },
+  optionHead: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 8,
+  },
+  optionTime: { fontWeight: "600", color: colors.text, fontSize: 15, flexShrink: 1 },
+  tag: { flexDirection: "row", alignItems: "center", gap: 4 },
+  tagText: { fontSize: 12, fontWeight: "600" },
+  counts: { flexDirection: "row", gap: 14, marginTop: 8 },
+  count: { fontSize: 13, color: colors.muted },
+  voters: { color: colors.faint, fontSize: 12, marginTop: 8 },
+  pick: {
+    marginTop: 14,
+    borderWidth: 1,
+    borderColor: colors.borderStrong,
+    borderRadius: radius.md,
+    paddingVertical: 11,
+    alignItems: "center",
+  },
+  pickPrimary: { backgroundColor: colors.accent, borderColor: colors.accent },
+  pickText: { color: colors.text, fontWeight: "600", fontSize: 14 },
+  pickTextPrimary: { color: colors.white },
+  back: { marginTop: 18, alignItems: "center" },
+  backText: { color: colors.muted },
+});

--- a/apps/mobile/app/polls/index.tsx
+++ b/apps/mobile/app/polls/index.tsx
@@ -1,0 +1,126 @@
+import { api } from "@/api";
+import { Badge, Card, EmptyState, ErrorText, Loading } from "@/components/ui";
+import { useAsync } from "@/hooks";
+import { colors } from "@/theme";
+import { Ionicons } from "@expo/vector-icons";
+import { Stack, useFocusEffect, useRouter } from "expo-router";
+import { useCallback } from "react";
+import { Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } from "react-native";
+
+/** A host's poll as returned by GET /api/polls (mirrors listPolls). */
+interface PollListItem {
+  id: string;
+  title: string;
+  status: string;
+  // The server helper returns option/vote rows; a REST wrapper may instead send
+  // pre-computed counts. Accept either so the list is robust to both shapes.
+  options?: { id: string }[];
+  votes?: { id: string }[];
+  optionCount?: number;
+  voteCount?: number;
+}
+
+function optionCount(p: PollListItem): number {
+  return p.optionCount ?? p.options?.length ?? 0;
+}
+function voteCount(p: PollListItem): number {
+  return p.voteCount ?? p.votes?.length ?? 0;
+}
+
+export default function PollsListScreen() {
+  const router = useRouter();
+  const { data, loading, error, reload } = useAsync<PollListItem[]>(async () => {
+    const res = await api.get<{ polls: PollListItem[] }>("/api/polls");
+    return res.polls;
+  });
+
+  // Refresh when returning from create / detail (a finalize changes status).
+  useFocusEffect(useCallback(() => reload(), [reload]));
+
+  return (
+    <View style={styles.safe}>
+      <Stack.Screen
+        options={{
+          headerShown: true,
+          title: "Group polls",
+          headerRight: () => (
+            <Pressable
+              onPress={() => router.push("/polls/new")}
+              hitSlop={8}
+              style={styles.headerBtn}
+            >
+              <Ionicons name="add" size={16} color={colors.white} />
+              <Text style={styles.headerBtnText}>New</Text>
+            </Pressable>
+          ),
+        }}
+      />
+      <ScrollView
+        contentContainerStyle={styles.scroll}
+        refreshControl={<RefreshControl refreshing={loading} onRefresh={reload} />}
+      >
+        {loading && !data ? (
+          <Loading />
+        ) : error ? (
+          <ErrorText message={error} />
+        ) : !data || data.length === 0 ? (
+          <EmptyState
+            title="No polls yet"
+            body="Propose a few times, share the link, and let the group vote on what works."
+          />
+        ) : (
+          data.map((p) => (
+            <Pressable key={p.id} onPress={() => router.push(`/polls/${p.id}`)}>
+              <Card>
+                <View style={styles.titleRow}>
+                  <Text style={styles.title} numberOfLines={1}>
+                    {p.title}
+                  </Text>
+                  <Badge
+                    label={p.status === "finalized" ? "Finalized" : "Open"}
+                    color={p.status === "finalized" ? colors.success : colors.muted}
+                  />
+                </View>
+                <View style={styles.metaRow}>
+                  <View style={styles.meta}>
+                    <Ionicons name="time-outline" size={13} color={colors.faint} />
+                    <Text style={styles.metaText}>{optionCount(p)} time options</Text>
+                  </View>
+                  <View style={styles.meta}>
+                    <Ionicons name="people-outline" size={13} color={colors.faint} />
+                    <Text style={styles.metaText}>{voteCount(p)} votes</Text>
+                  </View>
+                </View>
+              </Card>
+            </Pressable>
+          ))
+        )}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: colors.bg },
+  scroll: { padding: 20, paddingBottom: 40 },
+  headerBtn: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    backgroundColor: colors.accent,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 7,
+  },
+  headerBtnText: { color: colors.white, fontWeight: "600", fontSize: 14 },
+  titleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 10,
+  },
+  title: { fontWeight: "600", fontSize: 15, color: colors.text, flexShrink: 1 },
+  metaRow: { flexDirection: "row", gap: 16, marginTop: 8 },
+  meta: { flexDirection: "row", alignItems: "center", gap: 5 },
+  metaText: { color: colors.muted, fontSize: 13 },
+});

--- a/apps/mobile/app/polls/new.tsx
+++ b/apps/mobile/app/polls/new.tsx
@@ -1,0 +1,241 @@
+import { ApiError, api } from "@/api";
+import { formatDateTime } from "@/format";
+import { colors, radius } from "@/theme";
+import { Ionicons } from "@expo/vector-icons";
+import DateTimePicker from "@react-native-community/datetimepicker";
+import { Stack, useRouter } from "expo-router";
+import { useState } from "react";
+import { Alert, Pressable, ScrollView, StyleSheet, Text, TextInput, View } from "react-native";
+
+const DURATIONS = [15, 30, 45, 60, 90];
+// Values mirror the web poll create form; the server uses `location` to decide
+// whether to auto-create a conference link on finalize.
+const LOCATIONS: { value: string; label: string }[] = [
+  { value: "google_meet", label: "Google Meet" },
+  { value: "zoom", label: "Zoom" },
+  { value: "phone", label: "Phone" },
+  { value: "custom", label: "Other / in person" },
+];
+
+const MAX_TIMES = 20;
+
+export default function NewPollScreen() {
+  const router = useRouter();
+  const [title, setTitle] = useState("");
+  const [duration, setDuration] = useState(30);
+  const [location, setLocation] = useState("google_meet");
+  const [times, setTimes] = useState<Date[]>([]);
+  const [saving, setSaving] = useState(false);
+
+  // Two-step native picker (date → time) so it behaves the same on iOS + Android.
+  const [picker, setPicker] = useState<"date" | "time" | null>(null);
+  const [draft, setDraft] = useState<Date | null>(null);
+
+  function startAddTime() {
+    if (times.length >= MAX_TIMES) return;
+    // Default to the next hour, on the hour.
+    const d = new Date();
+    d.setHours(d.getHours() + 1, 0, 0, 0);
+    setDraft(d);
+    setPicker("date");
+  }
+
+  function onPick(event: { type: string }, date?: Date) {
+    if (event.type === "dismissed" || !date) {
+      setPicker(null);
+      return;
+    }
+    if (picker === "date") {
+      const base = draft ?? new Date();
+      const merged = new Date(date);
+      merged.setHours(base.getHours(), base.getMinutes(), 0, 0);
+      setDraft(merged);
+      setPicker("time");
+    } else {
+      const final = new Date(date);
+      final.setSeconds(0, 0);
+      setTimes((prev) => [...prev, final].sort((a, b) => a.getTime() - b.getTime()));
+      setDraft(null);
+      setPicker(null);
+    }
+  }
+
+  function removeTime(idx: number) {
+    setTimes((prev) => prev.filter((_, i) => i !== idx));
+  }
+
+  async function submit() {
+    if (!title.trim()) {
+      Alert.alert("Add a title", "Give your poll a name so invitees know what it's for.");
+      return;
+    }
+    // Only future times count on the server; guard here too for a clear message.
+    const iso = times.filter((d) => d.getTime() > Date.now()).map((d) => d.toISOString());
+    if (iso.length < 2) {
+      Alert.alert("Add more times", "Propose at least two future time options.");
+      return;
+    }
+    setSaving(true);
+    try {
+      const res = await api.post<{ id: string; token: string; url: string }>("/api/polls", {
+        title: title.trim(),
+        durationMinutes: duration,
+        location,
+        times: iso,
+      });
+      // Replace so Back returns to the list, not the empty create form.
+      router.replace(`/polls/${res.id}`);
+    } catch (e) {
+      Alert.alert("Couldn't create poll", e instanceof ApiError ? e.message : "Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <View style={styles.safe}>
+      <Stack.Screen options={{ headerShown: true, title: "New poll" }} />
+      <ScrollView contentContainerStyle={styles.scroll} keyboardShouldPersistTaps="handled">
+        <Text style={styles.label}>What's the meeting?</Text>
+        <TextInput
+          style={styles.input}
+          value={title}
+          onChangeText={setTitle}
+          placeholder="Q3 planning sync"
+          placeholderTextColor={colors.faint}
+        />
+
+        <Text style={styles.label}>Duration</Text>
+        <View style={styles.pills}>
+          {DURATIONS.map((m) => (
+            <Pressable
+              key={m}
+              onPress={() => setDuration(m)}
+              style={[styles.pill, m === duration && styles.pillOn]}
+            >
+              <Text style={[styles.pillText, m === duration && styles.pillTextOn]}>{m} min</Text>
+            </Pressable>
+          ))}
+        </View>
+
+        <Text style={styles.label}>Location</Text>
+        <View style={styles.pills}>
+          {LOCATIONS.map((l) => (
+            <Pressable
+              key={l.value}
+              onPress={() => setLocation(l.value)}
+              style={[styles.pill, l.value === location && styles.pillOn]}
+            >
+              <Text style={[styles.pillText, l.value === location && styles.pillTextOn]}>
+                {l.label}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+
+        <Text style={styles.label}>Propose some times</Text>
+        <Text style={styles.hint}>
+          Invitees vote on which work. Times use your device's timezone. Add at least two.
+        </Text>
+
+        {times.map((d, i) => (
+          <View key={d.toISOString()} style={styles.timeRow}>
+            <Ionicons name="time-outline" size={16} color={colors.muted} />
+            <Text style={styles.timeText}>{formatDateTime(d.toISOString())}</Text>
+            <Pressable onPress={() => removeTime(i)} hitSlop={8}>
+              <Ionicons name="close" size={18} color={colors.faint} />
+            </Pressable>
+          </View>
+        ))}
+
+        <Pressable
+          style={styles.addTime}
+          onPress={startAddTime}
+          disabled={times.length >= MAX_TIMES}
+        >
+          <Ionicons name="add" size={16} color={colors.accent} />
+          <Text style={styles.addTimeText}>
+            {times.length >= MAX_TIMES ? "Maximum times added" : "Add a time"}
+          </Text>
+        </Pressable>
+
+        <Pressable
+          style={[styles.save, (saving || !title.trim() || times.length < 2) && styles.saveOff]}
+          onPress={submit}
+          disabled={saving || !title.trim() || times.length < 2}
+        >
+          <Text style={styles.saveText}>{saving ? "Creating…" : "Create poll"}</Text>
+        </Pressable>
+      </ScrollView>
+
+      {picker ? (
+        <DateTimePicker value={draft ?? new Date()} mode={picker} onChange={onPick} />
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: colors.bg },
+  scroll: { padding: 20, paddingBottom: 60 },
+  label: { fontWeight: "600", color: colors.text, marginBottom: 8, marginTop: 4 },
+  input: {
+    minHeight: 48,
+    borderWidth: 1,
+    borderColor: colors.borderStrong,
+    borderRadius: radius.md,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 15,
+    color: colors.text,
+    backgroundColor: colors.surface,
+    marginBottom: 18,
+  },
+  pills: { flexDirection: "row", flexWrap: "wrap", gap: 8, marginBottom: 18 },
+  pill: {
+    borderWidth: 1,
+    borderColor: colors.borderStrong,
+    borderRadius: 999,
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+  },
+  pillOn: { borderColor: colors.accent, backgroundColor: colors.accentSoft },
+  pillText: { color: colors.muted, fontSize: 13 },
+  pillTextOn: { color: colors.text, fontWeight: "600" },
+  hint: { color: colors.faint, fontSize: 12, marginBottom: 12, marginTop: -2 },
+  timeRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.md,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    marginBottom: 8,
+    backgroundColor: colors.surface,
+  },
+  timeText: { flex: 1, color: colors.text, fontSize: 14 },
+  addTime: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 6,
+    borderWidth: 1,
+    borderColor: colors.borderStrong,
+    borderStyle: "dashed",
+    borderRadius: radius.md,
+    paddingVertical: 12,
+    marginTop: 4,
+  },
+  addTimeText: { color: colors.accent, fontWeight: "600", fontSize: 14 },
+  save: {
+    marginTop: 24,
+    backgroundColor: colors.accent,
+    borderRadius: radius.md,
+    paddingVertical: 15,
+    alignItems: "center",
+  },
+  saveOff: { opacity: 0.5 },
+  saveText: { color: colors.white, fontWeight: "600", fontSize: 15 },
+});

--- a/apps/mobile/app/routing/[id].tsx
+++ b/apps/mobile/app/routing/[id].tsx
@@ -1,0 +1,398 @@
+import { ApiError, api, getServerUrl } from "@/api";
+import { ErrorText, Loading } from "@/components/ui";
+import { useAsync } from "@/hooks";
+import { colors, radius } from "@/theme";
+import { Ionicons } from "@expo/vector-icons";
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
+import { useEffect, useState } from "react";
+import {
+  Alert,
+  Linking,
+  Pressable,
+  ScrollView,
+  Share,
+  StyleSheet,
+  Switch,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+
+/** A question on a routing form (mirrors @dayotter/db RoutingField). */
+interface RoutingField {
+  id: string;
+  label: string;
+  type: "select" | "text" | "email";
+  options?: string[];
+  required?: boolean;
+}
+
+/** One ordered rule (mirrors @dayotter/db RoutingRoute). */
+interface RoutingRoute {
+  id: string;
+  fieldId: string;
+  equals: string;
+  eventTypeId: string;
+}
+
+/** A routing target the host owns (subset of the event type record). */
+interface EventTypeOpt {
+  id: string;
+  title: string;
+  slug?: string;
+}
+
+/** GET /api/routing/[id] shape (mirrors getFormForHost + hostEventTypes). */
+interface RoutingFormDetail {
+  id: string;
+  title: string;
+  description: string | null;
+  token: string;
+  isActive: boolean;
+  fields: RoutingField[];
+  routes: RoutingRoute[];
+  fallbackEventTypeId: string | null;
+  responseCount: number;
+  eventTypes: EventTypeOpt[];
+}
+
+const asArray = <T,>(v: unknown): T[] => (Array.isArray(v) ? (v as T[]) : []);
+
+/**
+ * The detail GET may return the form directly or a `{ form, eventTypes }`
+ * wrapper. Normalize both, and derive the response count / event-type list from
+ * whatever the payload carries.
+ */
+function normalizeDetail(res: unknown): RoutingFormDetail {
+  const root = (res ?? {}) as Record<string, unknown>;
+  const f = (root.form && typeof root.form === "object" ? root.form : root) as Record<
+    string,
+    unknown
+  >;
+  const responsesArr = asArray<unknown>(f.responses);
+  const responseCount = typeof f.responseCount === "number" ? f.responseCount : responsesArr.length;
+  const eventTypes = asArray<Record<string, unknown>>(root.eventTypes ?? f.eventTypes).map((e) => ({
+    id: String(e.id ?? ""),
+    title: typeof e.title === "string" ? e.title : "Untitled",
+    slug: typeof e.slug === "string" ? e.slug : undefined,
+  }));
+  return {
+    id: String(f.id ?? ""),
+    title: typeof f.title === "string" ? f.title : "Untitled form",
+    description: typeof f.description === "string" ? f.description : null,
+    token: typeof f.token === "string" ? f.token : "",
+    isActive: f.isActive !== false,
+    fields: asArray<RoutingField>(f.fields),
+    routes: asArray<RoutingRoute>(f.routes),
+    fallbackEventTypeId: typeof f.fallbackEventTypeId === "string" ? f.fallbackEventTypeId : null,
+    responseCount,
+    eventTypes,
+  };
+}
+
+const FIELD_TYPE_LABEL: Record<RoutingField["type"], string> = {
+  select: "Choice",
+  text: "Short text",
+  email: "Email",
+};
+
+export default function RoutingFormScreen() {
+  const router = useRouter();
+  const { id } = useLocalSearchParams<{ id: string }>();
+
+  const { data, loading, error, reload } = useAsync<RoutingFormDetail>(async () => {
+    const res = await api.get<unknown>(`/api/routing/${id}`);
+    return normalizeDetail(res);
+  }, [id]);
+
+  // Editable basics; seeded once the form loads.
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [active, setActive] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  useEffect(() => {
+    if (data) {
+      setTitle(data.title);
+      setDescription(data.description ?? "");
+      setActive(data.isActive);
+    }
+  }, [data]);
+
+  const publicUrl = data?.token ? `${getServerUrl().replace(/\/$/, "")}/forms/${data.token}` : null;
+
+  const dirty =
+    !!data &&
+    (title.trim() !== data.title ||
+      description.trim() !== (data.description ?? "") ||
+      active !== data.isActive);
+
+  async function save() {
+    if (!data) return;
+    const name = title.trim();
+    if (!name) {
+      Alert.alert("Name required", "Give your form a name.");
+      return;
+    }
+    setSaving(true);
+    try {
+      // PUT replaces the whole form. Preserve the fields/routes/fallback loaded
+      // from the server (edited only in the web builder) and change the basics.
+      await api.put(`/api/routing/${data.id}`, {
+        title: name,
+        description: description.trim() || null,
+        isActive: active,
+        fields: data.fields,
+        routes: data.routes,
+        fallbackEventTypeId: data.fallbackEventTypeId,
+      });
+      reload();
+    } catch (e) {
+      Alert.alert("Couldn't save", e instanceof ApiError ? e.message : "Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function confirmDelete() {
+    if (!data) return;
+    Alert.alert("Delete form?", data.title, [
+      { text: "Keep", style: "cancel" },
+      {
+        text: "Delete",
+        style: "destructive",
+        onPress: async () => {
+          setDeleting(true);
+          try {
+            await api.del(`/api/routing/${data.id}`);
+            router.back();
+          } catch (e) {
+            setDeleting(false);
+            Alert.alert("Couldn't delete", e instanceof ApiError ? e.message : "Please try again.");
+          }
+        },
+      },
+    ]);
+  }
+
+  function eventTypeName(eventTypeId: string): string {
+    return data?.eventTypes.find((e) => e.id === eventTypeId)?.title ?? "a booking page";
+  }
+
+  return (
+    <View style={styles.safe}>
+      <Stack.Screen options={{ headerShown: true, title: "Routing form" }} />
+      {loading && !data ? (
+        <Loading />
+      ) : error || !data ? (
+        <ErrorText message={error ?? "Not found"} />
+      ) : (
+        <ScrollView contentContainerStyle={styles.scroll} keyboardShouldPersistTaps="handled">
+          {/* Share + status */}
+          {publicUrl ? (
+            <View style={styles.shareBox}>
+              <Text style={styles.shareLabel}>Public link</Text>
+              <Text style={styles.shareUrl} numberOfLines={1}>
+                {publicUrl}
+              </Text>
+              <View style={styles.shareActions}>
+                <Pressable
+                  style={styles.shareBtn}
+                  onPress={() => Linking.openURL(publicUrl)}
+                  hitSlop={6}
+                >
+                  <Ionicons name="open-outline" size={16} color={colors.accent} />
+                  <Text style={styles.shareBtnText}>Open</Text>
+                </Pressable>
+                <Pressable
+                  style={styles.shareBtn}
+                  onPress={() => Share.share({ message: publicUrl }).catch(() => {})}
+                  hitSlop={6}
+                >
+                  <Ionicons name="share-outline" size={16} color={colors.accent} />
+                  <Text style={styles.shareBtnText}>Share</Text>
+                </Pressable>
+                <Text style={styles.responses}>{data.responseCount} responses</Text>
+              </View>
+            </View>
+          ) : null}
+
+          {/* Editable basics */}
+          <Text style={styles.label}>Form name</Text>
+          <TextInput
+            style={styles.input}
+            value={title}
+            onChangeText={setTitle}
+            placeholder="Form name"
+            placeholderTextColor={colors.faint}
+            maxLength={120}
+          />
+
+          <Text style={styles.label}>Intro (optional)</Text>
+          <TextInput
+            style={[styles.input, styles.multiline]}
+            value={description}
+            onChangeText={setDescription}
+            placeholder="Answer a couple of questions and we'll get you to the right person."
+            placeholderTextColor={colors.faint}
+            multiline
+            maxLength={1000}
+          />
+
+          <View style={styles.toggleRow}>
+            <View style={{ flex: 1 }}>
+              <Text style={styles.toggleTitle}>Form is live</Text>
+              <Text style={styles.toggleSub}>Visitors can only submit a live form.</Text>
+            </View>
+            <Switch value={active} onValueChange={setActive} />
+          </View>
+
+          <Pressable
+            style={[styles.save, (!dirty || saving) && styles.saveDisabled]}
+            onPress={save}
+            disabled={!dirty || saving}
+          >
+            <Text style={styles.saveText}>{saving ? "Saving…" : "Save changes"}</Text>
+          </Pressable>
+
+          {/* Read-only: questions */}
+          <Text style={styles.section}>Questions</Text>
+          <Text style={styles.readonlyNote}>
+            Questions and routing rules are edited in the DayOtter web app.
+          </Text>
+          {data.fields.length > 0 ? (
+            data.fields.map((f) => (
+              <View key={f.id} style={styles.item}>
+                <View style={styles.itemHead}>
+                  <Text style={styles.itemTitle} numberOfLines={2}>
+                    {f.label || "Untitled question"}
+                  </Text>
+                  <Text style={styles.itemType}>
+                    {FIELD_TYPE_LABEL[f.type]}
+                    {f.required ? " · required" : ""}
+                  </Text>
+                </View>
+                {f.type === "select" && f.options && f.options.length > 0 ? (
+                  <Text style={styles.itemBody}>{f.options.join(" · ")}</Text>
+                ) : null}
+              </View>
+            ))
+          ) : (
+            <Text style={styles.emptyLine}>No questions yet.</Text>
+          )}
+
+          {/* Read-only: routing rules */}
+          <Text style={styles.section}>Where answers go</Text>
+          {data.routes.length > 0 ? (
+            data.routes.map((r) => {
+              const field = data.fields.find((f) => f.id === r.fieldId);
+              return (
+                <View key={r.id} style={styles.item}>
+                  <Text style={styles.itemBody}>
+                    <Text style={styles.dim}>If </Text>
+                    {field?.label || "a question"}
+                    <Text style={styles.dim}> is </Text>“{r.equals}”
+                    <Text style={styles.dim}> → </Text>
+                    {eventTypeName(r.eventTypeId)}
+                  </Text>
+                </View>
+              );
+            })
+          ) : (
+            <Text style={styles.emptyLine}>No routing rules yet.</Text>
+          )}
+          {data.fallbackEventTypeId ? (
+            <View style={styles.item}>
+              <Text style={styles.itemBody}>
+                <Text style={styles.dim}>Otherwise → </Text>
+                {eventTypeName(data.fallbackEventTypeId)}
+              </Text>
+            </View>
+          ) : null}
+
+          <Pressable style={styles.delete} onPress={confirmDelete} disabled={deleting}>
+            <Ionicons name="trash-outline" size={16} color={colors.danger} />
+            <Text style={styles.deleteText}>{deleting ? "Deleting…" : "Delete form"}</Text>
+          </Pressable>
+        </ScrollView>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: colors.bg },
+  scroll: { padding: 20, paddingBottom: 60 },
+  shareBox: {
+    backgroundColor: colors.surface2,
+    borderRadius: radius.lg,
+    padding: 14,
+    marginBottom: 20,
+  },
+  shareLabel: { color: colors.muted, fontSize: 12, fontWeight: "600" },
+  shareUrl: { color: colors.text, fontSize: 13, marginTop: 4 },
+  shareActions: { flexDirection: "row", alignItems: "center", gap: 16, marginTop: 12 },
+  shareBtn: { flexDirection: "row", alignItems: "center", gap: 4 },
+  shareBtnText: { color: colors.accent, fontSize: 13, fontWeight: "600" },
+  responses: { color: colors.faint, fontSize: 12, marginLeft: "auto" },
+  label: { color: colors.muted, fontWeight: "600", marginBottom: 8, fontSize: 13 },
+  input: {
+    minHeight: 48,
+    borderWidth: 1,
+    borderColor: colors.borderStrong,
+    borderRadius: radius.md,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 15,
+    color: colors.text,
+    backgroundColor: colors.surface,
+    marginBottom: 18,
+  },
+  multiline: { minHeight: 80, textAlignVertical: "top" },
+  toggleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    backgroundColor: colors.surface2,
+    borderRadius: radius.lg,
+    padding: 14,
+    marginBottom: 16,
+  },
+  toggleTitle: { color: colors.text, fontWeight: "600" },
+  toggleSub: { color: colors.muted, fontSize: 12, marginTop: 2 },
+  save: {
+    backgroundColor: colors.accent,
+    borderRadius: radius.md,
+    paddingVertical: 15,
+    alignItems: "center",
+  },
+  saveDisabled: { opacity: 0.5 },
+  saveText: { color: colors.white, fontWeight: "600", fontSize: 15 },
+  section: { marginTop: 26, marginBottom: 8, fontWeight: "700", color: colors.text, fontSize: 16 },
+  readonlyNote: { color: colors.faint, fontSize: 12, marginBottom: 12 },
+  item: {
+    backgroundColor: colors.surface2,
+    borderRadius: radius.md,
+    padding: 14,
+    marginBottom: 10,
+  },
+  itemHead: { flexDirection: "row", alignItems: "center", justifyContent: "space-between", gap: 8 },
+  itemTitle: { color: colors.text, fontWeight: "600", flexShrink: 1 },
+  itemType: { color: colors.faint, fontSize: 11 },
+  itemBody: { color: colors.text, fontSize: 14, marginTop: 6, lineHeight: 20 },
+  dim: { color: colors.muted },
+  emptyLine: { color: colors.muted, fontSize: 13, marginBottom: 10 },
+  delete: {
+    marginTop: 24,
+    flexDirection: "row",
+    gap: 6,
+    alignItems: "center",
+    justifyContent: "center",
+    borderWidth: 1,
+    borderColor: colors.danger,
+    borderRadius: radius.md,
+    paddingVertical: 13,
+  },
+  deleteText: { color: colors.danger, fontWeight: "600" },
+});

--- a/apps/mobile/app/routing/index.tsx
+++ b/apps/mobile/app/routing/index.tsx
@@ -1,0 +1,168 @@
+import { api, getServerUrl } from "@/api";
+import { EmptyState, ErrorText, Loading } from "@/components/ui";
+import { useAsync } from "@/hooks";
+import { colors, radius } from "@/theme";
+import { Ionicons } from "@expo/vector-icons";
+import { Stack, useRouter } from "expo-router";
+import { Linking, Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+
+/** Shareable public URL for a form's booker page (mirrors web `/forms/<token>`). */
+const publicFormUrl = (token: string) => `${getServerUrl().replace(/\/$/, "")}/forms/${token}`;
+
+/** One row of GET /api/routing (mirrors listForms() on the web). */
+interface RoutingFormListItem {
+  id: string;
+  title: string;
+  description: string | null;
+  token: string;
+  isActive: boolean;
+  routes: unknown[];
+  responses: unknown[];
+}
+
+/**
+ * The list GET may return a bare array or a `{ forms }` wrapper (the mobile API
+ * convention). Accept either so the screen is resilient to the shape the shared
+ * route ships.
+ */
+function normalizeList(res: unknown): RoutingFormListItem[] {
+  const raw = Array.isArray(res)
+    ? res
+    : res && typeof res === "object" && Array.isArray((res as { forms?: unknown[] }).forms)
+      ? (res as { forms: unknown[] }).forms
+      : [];
+  return raw.map((r) => {
+    const f = (r ?? {}) as Record<string, unknown>;
+    return {
+      id: String(f.id ?? ""),
+      title: typeof f.title === "string" ? f.title : "Untitled form",
+      description: typeof f.description === "string" ? f.description : null,
+      token: typeof f.token === "string" ? f.token : "",
+      isActive: f.isActive !== false,
+      routes: Array.isArray(f.routes) ? f.routes : [],
+      responses: Array.isArray(f.responses) ? f.responses : [],
+    };
+  });
+}
+
+export default function RoutingListScreen() {
+  const router = useRouter();
+  const { data, loading, error, reload } = useAsync<RoutingFormListItem[]>(async () => {
+    const res = await api.get<unknown>("/api/routing");
+    return normalizeList(res);
+  });
+
+  return (
+    <View style={styles.safe}>
+      <Stack.Screen
+        options={{
+          headerShown: true,
+          title: "Routing forms",
+          headerRight: () => (
+            <Pressable onPress={() => router.push("/routing/new")} hitSlop={10}>
+              <Ionicons name="add" size={24} color={colors.accent} />
+            </Pressable>
+          ),
+        }}
+      />
+      <ScrollView contentContainerStyle={styles.scroll}>
+        {loading && !data ? (
+          <Loading />
+        ) : error ? (
+          <ErrorText message={error} />
+        ) : data && data.length > 0 ? (
+          <>
+            <Text style={styles.intro}>
+              Ask a few questions up front, then send each visitor to the right booking page.
+            </Text>
+            {data.map((f) => (
+              <View key={f.id} style={styles.row}>
+                <Pressable style={styles.card} onPress={() => router.push(`/routing/${f.id}`)}>
+                  <View style={{ flex: 1 }}>
+                    <View style={styles.titleLine}>
+                      <Ionicons name="git-branch-outline" size={15} color={colors.accent} />
+                      <Text style={styles.title} numberOfLines={1}>
+                        {f.title}
+                      </Text>
+                    </View>
+                    <Text style={styles.meta}>
+                      {f.routes.length} rule{f.routes.length === 1 ? "" : "s"} ·{" "}
+                      {f.responses.length} response{f.responses.length === 1 ? "" : "s"}
+                    </Text>
+                  </View>
+                  <View style={[styles.badge, f.isActive ? styles.badgeLive : styles.badgeDraft]}>
+                    <Text
+                      style={[
+                        styles.badgeText,
+                        f.isActive ? styles.badgeTextLive : styles.badgeTextDraft,
+                      ]}
+                    >
+                      {f.isActive ? "Live" : "Draft"}
+                    </Text>
+                  </View>
+                </Pressable>
+                {f.token ? (
+                  <Pressable
+                    onPress={() => Linking.openURL(publicFormUrl(f.token))}
+                    hitSlop={8}
+                    style={styles.linkBtn}
+                    accessibilityLabel="Open public form"
+                  >
+                    <Ionicons name="open-outline" size={18} color={colors.faint} />
+                  </Pressable>
+                ) : null}
+              </View>
+            ))}
+          </>
+        ) : (
+          <EmptyState
+            title="No routing forms yet"
+            body="Route enterprise leads to you and everyone else to the team — automatically, based on their answers."
+          />
+        )}
+
+        <Pressable style={styles.new} onPress={() => router.push("/routing/new")}>
+          <Ionicons name="add" size={18} color={colors.white} />
+          <Text style={styles.newText}>New form</Text>
+        </Pressable>
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: colors.bg },
+  scroll: { padding: 20, paddingBottom: 60 },
+  intro: { color: colors.muted, fontSize: 13, marginBottom: 16, lineHeight: 19 },
+  row: { flexDirection: "row", alignItems: "center", gap: 8, marginBottom: 10 },
+  card: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    backgroundColor: colors.surface2,
+    borderRadius: radius.lg,
+    padding: 14,
+  },
+  titleLine: { flexDirection: "row", alignItems: "center", gap: 6 },
+  title: { color: colors.text, fontWeight: "600", flexShrink: 1 },
+  meta: { color: colors.muted, fontSize: 12, marginTop: 3 },
+  badge: { borderRadius: 999, paddingHorizontal: 10, paddingVertical: 4 },
+  badgeLive: { backgroundColor: `${colors.success}26` },
+  badgeDraft: { backgroundColor: colors.border },
+  badgeText: { fontSize: 11, fontWeight: "600" },
+  badgeTextLive: { color: colors.success },
+  badgeTextDraft: { color: colors.muted },
+  linkBtn: { padding: 6 },
+  new: {
+    marginTop: 18,
+    flexDirection: "row",
+    gap: 6,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: colors.accent,
+    borderRadius: radius.md,
+    paddingVertical: 15,
+  },
+  newText: { color: colors.white, fontWeight: "600", fontSize: 15 },
+});

--- a/apps/mobile/app/routing/new.tsx
+++ b/apps/mobile/app/routing/new.tsx
@@ -1,0 +1,111 @@
+import { ApiError, api } from "@/api";
+import { colors, radius } from "@/theme";
+import { Stack, useRouter } from "expo-router";
+import { useState } from "react";
+import { Pressable, ScrollView, StyleSheet, Text, TextInput, View } from "react-native";
+
+/** POST /api/routing response — `{ id, url }` (mirrors createForm on the web). */
+interface CreateResponse {
+  id: string;
+  url?: string;
+}
+
+export default function NewRoutingFormScreen() {
+  const router = useRouter();
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  async function submit() {
+    const name = title.trim();
+    if (!name) return setError("Give your form a name.");
+    setError(null);
+    setSaving(true);
+    try {
+      // Body matches the POST zod schema exactly: title (required), description (optional).
+      const body: { title: string; description?: string } = { title: name };
+      const desc = description.trim();
+      if (desc) body.description = desc;
+      const res = await api.post<CreateResponse>("/api/routing", body);
+      // Continue building on the detail screen. Replace so Back returns to the list.
+      router.replace(`/routing/${res.id}`);
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : "Could not create form");
+      setSaving(false);
+    }
+  }
+
+  return (
+    <View style={styles.safe}>
+      <Stack.Screen options={{ headerShown: true, title: "New routing form" }} />
+      <ScrollView contentContainerStyle={styles.scroll} keyboardShouldPersistTaps="handled">
+        <Text style={styles.intro}>
+          Ask a couple of questions, then send each visitor to the right booking page automatically.
+        </Text>
+
+        <Text style={styles.label}>Form name</Text>
+        <TextInput
+          style={styles.input}
+          value={title}
+          onChangeText={setTitle}
+          placeholder="Talk to sales"
+          placeholderTextColor={colors.faint}
+          autoFocus
+          maxLength={120}
+        />
+
+        <Text style={styles.label}>Intro (optional)</Text>
+        <TextInput
+          style={[styles.input, styles.multiline]}
+          value={description}
+          onChangeText={setDescription}
+          placeholder="Answer a couple of questions and we'll get you to the right person."
+          placeholderTextColor={colors.faint}
+          multiline
+          maxLength={1000}
+        />
+
+        {error ? <Text style={styles.error}>{error}</Text> : null}
+
+        <Pressable
+          style={[styles.save, (saving || !title.trim()) && styles.saveDisabled]}
+          onPress={submit}
+          disabled={saving || !title.trim()}
+        >
+          <Text style={styles.saveText}>{saving ? "Creating…" : "Create & build"}</Text>
+        </Pressable>
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: colors.bg },
+  scroll: { padding: 20, paddingBottom: 60 },
+  intro: { color: colors.muted, fontSize: 13, marginBottom: 20, lineHeight: 19 },
+  label: { color: colors.muted, fontWeight: "600", marginBottom: 8, fontSize: 13 },
+  input: {
+    minHeight: 48,
+    borderWidth: 1,
+    borderColor: colors.borderStrong,
+    borderRadius: radius.md,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 15,
+    color: colors.text,
+    backgroundColor: colors.surface,
+    marginBottom: 18,
+  },
+  multiline: { minHeight: 88, textAlignVertical: "top" },
+  error: { color: colors.danger, marginBottom: 12 },
+  save: {
+    marginTop: 4,
+    backgroundColor: colors.accent,
+    borderRadius: radius.md,
+    paddingVertical: 15,
+    alignItems: "center",
+  },
+  saveDisabled: { opacity: 0.5 },
+  saveText: { color: colors.white, fontWeight: "600", fontSize: 15 },
+});

--- a/apps/mobile/app/teams.tsx
+++ b/apps/mobile/app/teams.tsx
@@ -4,10 +4,11 @@ import { useAsync } from "@/hooks";
 import type { Team } from "@/models";
 import { colors } from "@/theme";
 import { Ionicons } from "@expo/vector-icons";
-import { Stack } from "expo-router";
-import { RefreshControl, ScrollView, StyleSheet, Text, View } from "react-native";
+import { Stack, useRouter } from "expo-router";
+import { Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } from "react-native";
 
 export default function TeamsScreen() {
+  const router = useRouter();
   const { data, loading, error, reload } = useAsync<Team[]>(async () => {
     const res = await api.get<{ teams: Team[] }>("/api/teams");
     return res.teams;
@@ -31,19 +32,22 @@ export default function TeamsScreen() {
           />
         ) : (
           data.map((t) => (
-            <Card key={t.id}>
-              <View style={styles.row}>
-                <View style={styles.iconBox}>
-                  <Ionicons name="people" size={20} color={colors.accent} />
+            <Pressable key={t.id} onPress={() => router.push(`/teams/${t.id}`)}>
+              <Card>
+                <View style={styles.row}>
+                  <View style={styles.iconBox}>
+                    <Ionicons name="people" size={20} color={colors.accent} />
+                  </View>
+                  <View style={styles.grow}>
+                    <Text style={styles.name}>{t.name}</Text>
+                    <Text style={styles.members}>
+                      {t.memberCount} member{t.memberCount === 1 ? "" : "s"}
+                    </Text>
+                  </View>
+                  <Ionicons name="chevron-forward" size={18} color={colors.faint} />
                 </View>
-                <View>
-                  <Text style={styles.name}>{t.name}</Text>
-                  <Text style={styles.members}>
-                    {t.memberCount} member{t.memberCount === 1 ? "" : "s"}
-                  </Text>
-                </View>
-              </View>
-            </Card>
+              </Card>
+            </Pressable>
           ))
         )}
       </ScrollView>
@@ -55,6 +59,7 @@ const styles = StyleSheet.create({
   safe: { flex: 1, backgroundColor: colors.bg },
   scroll: { padding: 20, paddingBottom: 32 },
   row: { flexDirection: "row", alignItems: "center" },
+  grow: { flex: 1 },
   iconBox: {
     height: 42,
     width: 42,

--- a/apps/mobile/app/teams/[id].tsx
+++ b/apps/mobile/app/teams/[id].tsx
@@ -1,0 +1,534 @@
+import { ApiError, api } from "@/api";
+import { ErrorText, Loading } from "@/components/ui";
+import { useAsync } from "@/hooks";
+import type { Team } from "@/models";
+import { colors, radius } from "@/theme";
+import { Ionicons } from "@expo/vector-icons";
+import { Stack, useLocalSearchParams } from "expo-router";
+import { useState } from "react";
+import {
+  Alert,
+  Pressable,
+  RefreshControl,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+
+/**
+ * A team scheduling rule (GET /api/teams/[id]/rules). Company holidays and
+ * meeting-free windows that block bookings for every member.
+ */
+interface TeamRule {
+  id: string;
+  kind: "holiday" | "no_meeting";
+  label: string | null;
+  theDate: string | null;
+  dayOfWeek: number | null;
+  startMinute: number | null;
+  endMinute: number | null;
+}
+
+type Role = "owner" | "admin" | "member";
+
+/** A member row from GET /api/teams/[id]. */
+interface Member {
+  id: string;
+  userId: string;
+  name: string | null;
+  email: string;
+  role: Role;
+  priority: number;
+}
+
+/** Everything the detail screen needs, loaded together so one reload refreshes all. */
+interface DetailData {
+  team: Team;
+  viewerRole: Role;
+  members: Member[];
+  rules: TeamRule[];
+}
+
+const DAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const DAYS_LONG = [
+  "Sundays",
+  "Mondays",
+  "Tuesdays",
+  "Wednesdays",
+  "Thursdays",
+  "Fridays",
+  "Saturdays",
+];
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const TIME_RE = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+const pad = (n: number) => String(n).padStart(2, "0");
+const toHHMM = (m: number) => `${pad(Math.floor(m / 60))}:${pad(m % 60)}`;
+const toMin = (s: string): number => {
+  const [h, m] = s.split(":").map(Number);
+  return (h || 0) * 60 + (m || 0);
+};
+
+/** "2026-12-25" -> "Dec 25, 2026" without timezone drift from Date parsing. */
+function formatDate(iso: string | null): string {
+  if (!iso || !DATE_RE.test(iso)) return "a day";
+  const [y, m, d] = iso.split("-").map(Number);
+  return `${MONTHS[(m || 1) - 1] ?? ""} ${d}, ${y}`;
+}
+
+function describeRule(r: TeamRule): string {
+  if (r.kind === "holiday") return `Holiday · ${formatDate(r.theDate)}`;
+  const when = r.dayOfWeek == null ? "Every day" : DAYS_LONG[r.dayOfWeek];
+  const win =
+    r.startMinute != null && r.endMinute != null
+      ? `${toHHMM(r.startMinute)}–${toHHMM(r.endMinute)}`
+      : "";
+  return `No meetings · ${when} ${win}`.trim();
+}
+
+export default function TeamDetailScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+
+  // Team detail (name + roster + viewer's role) and rules, loaded together so a
+  // single reload() refreshes team + members + rules.
+  const { data, loading, error, reload } = useAsync<DetailData>(async () => {
+    const [detailRes, rulesRes] = await Promise.all([
+      api.get<{
+        team: { id: string; name: string; slug: string };
+        viewerRole: Role;
+        members: Member[];
+      }>(`/api/teams/${id}`),
+      api.get<{ rules: TeamRule[] }>(`/api/teams/${id}/rules`),
+    ]);
+    const team: Team = {
+      id: detailRes.team.id,
+      name: detailRes.team.name,
+      slug: detailRes.team.slug,
+      memberCount: detailRes.members.length,
+    };
+    return {
+      team,
+      viewerRole: detailRes.viewerRole,
+      members: detailRes.members,
+      rules: rulesRes.rules,
+    };
+  }, [id]);
+
+  const canManage = data?.viewerRole === "owner" || data?.viewerRole === "admin";
+
+  // Add member (POST /api/teams/[id]/members). Roster listing + removal aren't
+  // exposed by the REST API, so this is add-only; the server gates to admins.
+  const [email, setEmail] = useState("");
+  const [addingMember, setAddingMember] = useState(false);
+
+  async function addMember() {
+    const value = email.trim();
+    if (!value) return;
+    setAddingMember(true);
+    try {
+      const res = await api.post<{ ok: boolean; name: string }>(`/api/teams/${id}/members`, {
+        email: value,
+      });
+      setEmail("");
+      Alert.alert("Member added", `${res.name} is now on the team.`);
+      reload();
+    } catch (err) {
+      Alert.alert(
+        "Couldn't add member",
+        err instanceof ApiError ? err.message : "Please try again.",
+      );
+    } finally {
+      setAddingMember(false);
+    }
+  }
+
+  // Remove member (DELETE /api/teams/[id]/members/[memberId]). Owner/admin only;
+  // the owner can't be removed. Server enforces both — we mirror in the UI.
+  function confirmRemoveMember(member: Member) {
+    Alert.alert("Remove member?", member.name ?? member.email, [
+      { text: "Keep", style: "cancel" },
+      {
+        text: "Remove",
+        style: "destructive",
+        onPress: async () => {
+          try {
+            await api.del(`/api/teams/${id}/members/${member.id}`);
+            reload();
+          } catch (err) {
+            Alert.alert(
+              "Couldn't remove",
+              err instanceof ApiError ? err.message : "Please try again.",
+            );
+          }
+        },
+      },
+    ]);
+  }
+
+  // Add rule (POST /api/teams/[id]/rules).
+  const [ruleKind, setRuleKind] = useState<"holiday" | "no_meeting">("holiday");
+  const [ruleLabel, setRuleLabel] = useState("");
+  const [ruleDate, setRuleDate] = useState("");
+  const [ruleDow, setRuleDow] = useState<number | null>(null); // null = every day
+  const [ruleStart, setRuleStart] = useState("13:00");
+  const [ruleEnd, setRuleEnd] = useState("17:00");
+  const [savingRule, setSavingRule] = useState(false);
+
+  const canAddRule =
+    ruleKind === "holiday"
+      ? DATE_RE.test(ruleDate.trim())
+      : TIME_RE.test(ruleStart.trim()) &&
+        TIME_RE.test(ruleEnd.trim()) &&
+        toMin(ruleEnd.trim()) > toMin(ruleStart.trim());
+
+  async function addRule() {
+    if (!canAddRule) return;
+    setSavingRule(true);
+    try {
+      const body =
+        ruleKind === "holiday"
+          ? { kind: "holiday", label: ruleLabel.trim() || undefined, theDate: ruleDate.trim() }
+          : {
+              kind: "no_meeting",
+              label: ruleLabel.trim() || undefined,
+              dayOfWeek: ruleDow,
+              startMinute: toMin(ruleStart.trim()),
+              endMinute: toMin(ruleEnd.trim()),
+            };
+      await api.post(`/api/teams/${id}/rules`, body);
+      setRuleLabel("");
+      setRuleDate("");
+      reload();
+    } catch (err) {
+      Alert.alert("Couldn't add rule", err instanceof ApiError ? err.message : "Please try again.");
+    } finally {
+      setSavingRule(false);
+    }
+  }
+
+  function confirmDeleteRule(rule: TeamRule) {
+    Alert.alert("Remove rule?", describeRule(rule), [
+      { text: "Keep", style: "cancel" },
+      {
+        text: "Remove",
+        style: "destructive",
+        onPress: async () => {
+          try {
+            await api.del(`/api/teams/${id}/rules/${rule.id}`);
+            reload();
+          } catch (err) {
+            Alert.alert(
+              "Couldn't remove",
+              err instanceof ApiError ? err.message : "Please try again.",
+            );
+          }
+        },
+      },
+    ]);
+  }
+
+  return (
+    <View style={styles.safe}>
+      <Stack.Screen options={{ headerShown: true, title: "Team" }} />
+      {loading && !data ? (
+        <Loading />
+      ) : error || !data ? (
+        <ErrorText message={error ?? "Not found"} />
+      ) : (
+        <ScrollView
+          contentContainerStyle={styles.scroll}
+          keyboardShouldPersistTaps="handled"
+          refreshControl={<RefreshControl refreshing={loading} onRefresh={reload} />}
+        >
+          <Text style={styles.title}>{data.team.name}</Text>
+          <Text style={styles.subtitle}>
+            {data.team.memberCount} member{data.team.memberCount === 1 ? "" : "s"}
+          </Text>
+
+          {/* MEMBERS — roster with role + weight; add/remove gated on admin. */}
+          <Text style={styles.section}>Members</Text>
+          {data.members.map((m) => (
+            <View key={m.id} style={styles.member}>
+              <View style={styles.avatar}>
+                <Text style={styles.avatarText}>{(m.name ?? m.email).charAt(0).toUpperCase()}</Text>
+              </View>
+              <View style={styles.memberInfo}>
+                <View style={styles.memberNameRow}>
+                  <Text style={styles.memberName} numberOfLines={1}>
+                    {m.name ?? "Member"}
+                  </Text>
+                  <View style={styles.roleBadge}>
+                    <Text style={styles.roleBadgeText}>{m.role}</Text>
+                  </View>
+                </View>
+                <Text style={styles.memberEmail} numberOfLines={1}>
+                  {m.email}
+                </Text>
+                <Text style={styles.memberWeight}>Weight {m.priority}</Text>
+              </View>
+              {canManage && m.role !== "owner" ? (
+                <Pressable onPress={() => confirmRemoveMember(m)} hitSlop={8}>
+                  <Ionicons name="person-remove-outline" size={18} color={colors.faint} />
+                </Pressable>
+              ) : null}
+            </View>
+          ))}
+
+          {canManage ? (
+            <>
+              <Text style={styles.help}>
+                Add a teammate by their DayOtter email. They need an account first.
+              </Text>
+              <TextInput
+                style={styles.input}
+                value={email}
+                onChangeText={setEmail}
+                placeholder="teammate@company.com"
+                placeholderTextColor={colors.faint}
+                autoCapitalize="none"
+                keyboardType="email-address"
+                autoCorrect={false}
+              />
+              <Pressable
+                style={[styles.primary, (!email.trim() || addingMember) && styles.disabled]}
+                onPress={addMember}
+                disabled={!email.trim() || addingMember}
+              >
+                <Ionicons name="person-add-outline" size={16} color={colors.white} />
+                <Text style={styles.primaryText}>{addingMember ? "Adding…" : "Add member"}</Text>
+              </Pressable>
+            </>
+          ) : null}
+
+          {/* RULES — list, add (holiday / meeting-free window), remove. */}
+          <Text style={styles.section}>Scheduling rules</Text>
+          <Text style={styles.help}>
+            Company holidays and meeting-free windows that block bookings for every member.
+          </Text>
+          {data.rules.length > 0 ? (
+            data.rules.map((r) => (
+              <View key={r.id} style={styles.rule}>
+                <Ionicons
+                  name={r.kind === "holiday" ? "calendar-clear-outline" : "time-outline"}
+                  size={18}
+                  color={colors.accent}
+                />
+                <View style={{ flex: 1 }}>
+                  {r.label ? <Text style={styles.ruleName}>{r.label}</Text> : null}
+                  <Text style={styles.ruleDesc}>{describeRule(r)}</Text>
+                </View>
+                {canManage ? (
+                  <Pressable onPress={() => confirmDeleteRule(r)} hitSlop={8}>
+                    <Ionicons name="trash-outline" size={18} color={colors.faint} />
+                  </Pressable>
+                ) : null}
+              </View>
+            ))
+          ) : (
+            <Text style={styles.help}>
+              No rules yet. Add a company holiday or meeting-free window below.
+            </Text>
+          )}
+
+          {canManage ? (
+            <>
+              <Text style={styles.subsection}>New rule</Text>
+              <View style={styles.pills}>
+                {(["holiday", "no_meeting"] as const).map((k) => (
+                  <Pressable
+                    key={k}
+                    onPress={() => setRuleKind(k)}
+                    style={[styles.pill, k === ruleKind && styles.pillOn]}
+                  >
+                    <Text style={[styles.pillText, k === ruleKind && styles.pillTextOn]}>
+                      {k === "holiday" ? "Company holiday" : "Meeting-free window"}
+                    </Text>
+                  </Pressable>
+                ))}
+              </View>
+
+              <TextInput
+                style={styles.input}
+                value={ruleLabel}
+                onChangeText={setRuleLabel}
+                placeholder={
+                  ruleKind === "holiday" ? "Christmas Day (optional)" : "Focus Fridays (optional)"
+                }
+                placeholderTextColor={colors.faint}
+              />
+
+              {ruleKind === "holiday" ? (
+                <TextInput
+                  style={styles.input}
+                  value={ruleDate}
+                  onChangeText={setRuleDate}
+                  placeholder="YYYY-MM-DD"
+                  placeholderTextColor={colors.faint}
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                />
+              ) : (
+                <>
+                  <Text style={styles.fieldLabel}>Day</Text>
+                  <View style={styles.pills}>
+                    <Pressable
+                      onPress={() => setRuleDow(null)}
+                      style={[styles.pill, ruleDow === null && styles.pillOn]}
+                    >
+                      <Text style={[styles.pillText, ruleDow === null && styles.pillTextOn]}>
+                        Every day
+                      </Text>
+                    </Pressable>
+                    {DAYS.map((d, i) => (
+                      <Pressable
+                        key={d}
+                        onPress={() => setRuleDow(i)}
+                        style={[styles.pill, ruleDow === i && styles.pillOn]}
+                      >
+                        <Text style={[styles.pillText, ruleDow === i && styles.pillTextOn]}>
+                          {d}
+                        </Text>
+                      </Pressable>
+                    ))}
+                  </View>
+                  <View style={styles.timeRow}>
+                    <View style={styles.timeCol}>
+                      <Text style={styles.fieldLabel}>From</Text>
+                      <TextInput
+                        style={styles.input}
+                        value={ruleStart}
+                        onChangeText={setRuleStart}
+                        placeholder="13:00"
+                        placeholderTextColor={colors.faint}
+                        autoCapitalize="none"
+                        autoCorrect={false}
+                      />
+                    </View>
+                    <View style={styles.timeCol}>
+                      <Text style={styles.fieldLabel}>To</Text>
+                      <TextInput
+                        style={styles.input}
+                        value={ruleEnd}
+                        onChangeText={setRuleEnd}
+                        placeholder="17:00"
+                        placeholderTextColor={colors.faint}
+                        autoCapitalize="none"
+                        autoCorrect={false}
+                      />
+                    </View>
+                  </View>
+                </>
+              )}
+
+              <Pressable
+                style={[styles.primary, (!canAddRule || savingRule) && styles.disabled]}
+                onPress={addRule}
+                disabled={!canAddRule || savingRule}
+              >
+                <Ionicons name="add" size={18} color={colors.white} />
+                <Text style={styles.primaryText}>{savingRule ? "Adding…" : "Add rule"}</Text>
+              </Pressable>
+            </>
+          ) : null}
+        </ScrollView>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: colors.bg },
+  scroll: { padding: 20, paddingBottom: 60 },
+  title: { fontSize: 24, fontWeight: "700", color: colors.text },
+  subtitle: { color: colors.muted, marginTop: 4 },
+  section: { marginTop: 26, marginBottom: 6, fontWeight: "700", color: colors.text, fontSize: 16 },
+  subsection: { marginTop: 18, marginBottom: 10, fontWeight: "600", color: colors.muted },
+  help: { color: colors.muted, fontSize: 13, marginBottom: 12, lineHeight: 18 },
+  fieldLabel: { color: colors.muted, fontSize: 13, marginBottom: 6 },
+  input: {
+    minHeight: 48,
+    borderWidth: 1,
+    borderColor: colors.borderStrong,
+    borderRadius: radius.md,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 15,
+    color: colors.text,
+    backgroundColor: colors.surface,
+    marginBottom: 12,
+  },
+  timeRow: { flexDirection: "row", gap: 12 },
+  timeCol: { flex: 1 },
+  member: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    backgroundColor: colors.surface2,
+    borderRadius: radius.lg,
+    padding: 14,
+    marginBottom: 10,
+  },
+  avatar: {
+    height: 36,
+    width: 36,
+    borderRadius: 18,
+    backgroundColor: colors.accent,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  avatarText: { color: colors.white, fontWeight: "700", fontSize: 14 },
+  memberInfo: { flex: 1 },
+  memberNameRow: { flexDirection: "row", alignItems: "center", gap: 8 },
+  memberName: { color: colors.text, fontWeight: "600", flexShrink: 1 },
+  roleBadge: {
+    borderRadius: 999,
+    backgroundColor: colors.accentSoft,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+  },
+  roleBadgeText: {
+    color: colors.accent,
+    fontSize: 11,
+    fontWeight: "600",
+    textTransform: "capitalize",
+  },
+  memberEmail: { color: colors.muted, fontSize: 12, marginTop: 2 },
+  memberWeight: { color: colors.faint, fontSize: 11, marginTop: 2 },
+  rule: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    backgroundColor: colors.surface2,
+    borderRadius: radius.lg,
+    padding: 14,
+    marginBottom: 10,
+  },
+  ruleName: { color: colors.text, fontWeight: "600" },
+  ruleDesc: { color: colors.muted, fontSize: 12, marginTop: 2 },
+  pills: { flexDirection: "row", flexWrap: "wrap", gap: 8, marginBottom: 12 },
+  pill: {
+    borderWidth: 1,
+    borderColor: colors.borderStrong,
+    borderRadius: 999,
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+  },
+  pillOn: { borderColor: colors.accent, backgroundColor: colors.accentSoft },
+  pillText: { color: colors.muted, fontSize: 13 },
+  pillTextOn: { color: colors.text, fontWeight: "600" },
+  primary: {
+    marginTop: 6,
+    flexDirection: "row",
+    gap: 8,
+    backgroundColor: colors.accent,
+    borderRadius: radius.md,
+    paddingVertical: 15,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  primaryText: { color: colors.white, fontWeight: "600", fontSize: 15 },
+  disabled: { opacity: 0.5 },
+});

--- a/apps/web/app/api/integrations/crm/route.ts
+++ b/apps/web/app/api/integrations/crm/route.ts
@@ -1,0 +1,27 @@
+import { withUser } from "@/lib/server/http";
+import { eq, getDb, schema } from "@dayotter/db";
+import { crmEnabledProviders } from "@dayotter/integrations";
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * CRM connection status for the signed-in user (the mobile CRM screen; the web
+ * settings page reads the same data server-side). Returns the user's connected
+ * providers and which providers are configured (env-gated) on this server.
+ */
+export const GET = withUser(async (u) => {
+  const rows = await getDb().query.crmConnections.findMany({
+    where: eq(schema.crmConnections.userId, u.id),
+  });
+  return NextResponse.json({
+    connections: rows.map((c) => ({
+      id: c.id,
+      provider: c.provider,
+      accountLabel: c.accountLabel,
+      externalAccountId: c.externalAccountId,
+      lastError: c.lastError,
+    })),
+    enabled: crmEnabledProviders(),
+  });
+});

--- a/apps/web/app/api/payments/status/route.ts
+++ b/apps/web/app/api/payments/status/route.ts
@@ -1,0 +1,63 @@
+import {
+  type CurrencyBalance,
+  WITHDRAW_MINIMUM,
+  connectedBalances,
+  paymentsEnabled,
+  platformFeePercent,
+  retrieveConnectStatus,
+} from "@/lib/payments/stripe";
+import { withUser } from "@/lib/server/http";
+import { eq, getDb, schema } from "@dayotter/db";
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Stripe Connect payout status for the signed-in host (the mobile Payouts
+ * screen; the web settings page computes the same values server-side). Mirrors
+ * the balance + onboarding flags the web page hands to <PayoutsPanel>.
+ */
+export const GET = withUser(async (u) => {
+  if (!paymentsEnabled) {
+    return NextResponse.json({ paymentsEnabled: false });
+  }
+
+  const db = getDb();
+  const user = await db.query.users.findFirst({
+    where: eq(schema.users.id, u.id),
+    columns: { stripeAccountId: true },
+  });
+
+  let chargesEnabled = false;
+  let payoutsEnabled = false;
+  let detailsSubmitted = false;
+  let balances: CurrencyBalance[] = [];
+
+  if (user?.stripeAccountId) {
+    try {
+      const status = await retrieveConnectStatus(user.stripeAccountId);
+      chargesEnabled = status.chargesEnabled;
+      payoutsEnabled = status.payoutsEnabled;
+      detailsSubmitted = status.detailsSubmitted;
+      // Persist the fresh flags so charge-routing + withdraw don't wait on the webhook.
+      await db
+        .update(schema.users)
+        .set({ stripeChargesEnabled: chargesEnabled, stripePayoutsEnabled: payoutsEnabled })
+        .where(eq(schema.users.id, u.id));
+      if (payoutsEnabled) balances = await connectedBalances(user.stripeAccountId);
+    } catch {
+      /* Stripe hiccup - report unconnected so the host can re-connect. */
+    }
+  }
+
+  return NextResponse.json({
+    paymentsEnabled: true,
+    connected: Boolean(user?.stripeAccountId),
+    chargesEnabled,
+    payoutsEnabled,
+    detailsSubmitted,
+    balances,
+    minimum: WITHDRAW_MINIMUM,
+    feePercent: platformFeePercent,
+  });
+});

--- a/apps/web/app/api/polls/[id]/route.ts
+++ b/apps/web/app/api/polls/[id]/route.ts
@@ -1,8 +1,16 @@
-import { deletePoll } from "@/lib/polls/polls";
+import { deletePoll, getPollForHost } from "@/lib/polls/polls";
 import { jsonError, withUser } from "@/lib/server/http";
 import { NextResponse } from "next/server";
 
 export const dynamic = "force-dynamic";
+
+/** A poll's full results for its host (mobile Poll detail: options + votes). */
+export const GET = withUser(async (u, _request, ctx: { params: Promise<{ id: string }> }) => {
+  const { id } = await ctx.params;
+  const poll = await getPollForHost(id, u.id);
+  if (!poll) return jsonError("Poll not found", 404);
+  return NextResponse.json({ poll });
+});
 
 export const DELETE = withUser(async (u, _request, ctx: { params: Promise<{ id: string }> }) => {
   const { id } = await ctx.params;

--- a/apps/web/app/api/polls/route.ts
+++ b/apps/web/app/api/polls/route.ts
@@ -1,9 +1,14 @@
-import { PollError, createPoll } from "@/lib/polls/polls";
+import { PollError, createPoll, listPolls } from "@/lib/polls/polls";
 import { jsonError, withUser } from "@/lib/server/http";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
 export const dynamic = "force-dynamic";
+
+/** The host's polls with lightweight option/vote rows (mobile Polls list). */
+export const GET = withUser(async (u) => {
+  return NextResponse.json({ polls: await listPolls(u.id) });
+});
 
 const bodySchema = z.object({
   title: z.string().min(1).max(120),

--- a/apps/web/app/api/routing/[id]/route.ts
+++ b/apps/web/app/api/routing/[id]/route.ts
@@ -1,9 +1,23 @@
-import { RoutingError, deleteForm, updateForm } from "@/lib/routing/routing";
+import {
+  RoutingError,
+  deleteForm,
+  getFormForHost,
+  hostEventTypes,
+  updateForm,
+} from "@/lib/routing/routing";
 import { jsonError, withUser } from "@/lib/server/http";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
 export const dynamic = "force-dynamic";
+
+/** A routing form's full definition + the host's event types (mobile detail). */
+export const GET = withUser(async (u, _request, ctx: { params: Promise<{ id: string }> }) => {
+  const { id } = await ctx.params;
+  const form = await getFormForHost(id, u.id);
+  if (!form) return jsonError("Form not found", 404);
+  return NextResponse.json({ form, eventTypes: await hostEventTypes(u.id) });
+});
 
 const fieldSchema = z.object({
   id: z.string().min(1).max(64),

--- a/apps/web/app/api/routing/route.ts
+++ b/apps/web/app/api/routing/route.ts
@@ -1,9 +1,14 @@
-import { RoutingError, createForm } from "@/lib/routing/routing";
+import { RoutingError, createForm, listForms } from "@/lib/routing/routing";
 import { jsonError, withUser } from "@/lib/server/http";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
 export const dynamic = "force-dynamic";
+
+/** The host's routing forms with response counts (mobile Routing list). */
+export const GET = withUser(async (u) => {
+  return NextResponse.json({ forms: await listForms(u.id) });
+});
 
 const bodySchema = z.object({
   title: z.string().min(1).max(120),

--- a/apps/web/app/api/teams/[id]/members/[memberId]/route.ts
+++ b/apps/web/app/api/teams/[id]/members/[memberId]/route.ts
@@ -65,3 +65,51 @@ export async function PATCH(
 
   return NextResponse.json({ ok: true });
 }
+
+/** Remove a member from the team. Admins/owners only; owners can't be removed. */
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string; memberId: string }> },
+) {
+  const session = await getSession();
+  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const { id: teamId, memberId } = await params;
+  const db = getDb();
+
+  const caller = await db.query.teamMembers.findFirst({
+    where: and(
+      eq(schema.teamMembers.teamId, teamId),
+      eq(schema.teamMembers.userId, session.user.id),
+    ),
+  });
+  if (!caller || (caller.role !== "owner" && caller.role !== "admin")) {
+    return NextResponse.json({ error: "Only team admins can remove members" }, { status: 403 });
+  }
+
+  const member = await db.query.teamMembers.findFirst({
+    where: and(eq(schema.teamMembers.id, memberId), eq(schema.teamMembers.teamId, teamId)),
+  });
+  if (!member) return NextResponse.json({ error: "Member not found" }, { status: 404 });
+  if (member.role === "owner") {
+    return NextResponse.json({ error: "The team owner can't be removed" }, { status: 400 });
+  }
+
+  await db.delete(schema.teamMembers).where(eq(schema.teamMembers.id, memberId));
+  // Drop the member from the team's round-robin event types too.
+  const teamEventTypes = await db.query.eventTypes.findMany({
+    where: eq(schema.eventTypes.teamId, teamId),
+    columns: { id: true },
+  });
+  for (const et of teamEventTypes) {
+    await db
+      .delete(schema.eventTypeHosts)
+      .where(
+        and(
+          eq(schema.eventTypeHosts.eventTypeId, et.id),
+          eq(schema.eventTypeHosts.userId, member.userId),
+        ),
+      );
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/web/app/api/teams/[id]/route.ts
+++ b/apps/web/app/api/teams/[id]/route.ts
@@ -1,0 +1,60 @@
+import { getSession } from "@/lib/auth/session";
+import { and, eq, getDb, inArray, schema } from "@dayotter/db";
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Team detail for a member: the team plus its member roster (name, email, role,
+ * round-robin weight) and the caller's own role. The web team page reads this
+ * server-side from the DB; the mobile team screen calls this endpoint.
+ */
+export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getSession();
+  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const { id: teamId } = await params;
+  const db = getDb();
+
+  const caller = await db.query.teamMembers.findFirst({
+    where: and(
+      eq(schema.teamMembers.teamId, teamId),
+      eq(schema.teamMembers.userId, session.user.id),
+    ),
+  });
+  if (!caller) return NextResponse.json({ error: "Not a team member" }, { status: 403 });
+
+  const team = await db.query.teams.findFirst({
+    where: eq(schema.teams.id, teamId),
+    columns: { id: true, name: true, slug: true },
+  });
+  if (!team) return NextResponse.json({ error: "Team not found" }, { status: 404 });
+
+  const rows = await db.query.teamMembers.findMany({
+    where: eq(schema.teamMembers.teamId, teamId),
+  });
+  const userIds = rows.map((r) => r.userId);
+  const users = userIds.length
+    ? await db.query.users.findMany({
+        where: inArray(schema.users.id, userIds),
+        columns: { id: true, name: true, email: true },
+      })
+    : [];
+  const byId = new Map(users.map((u) => [u.id, u]));
+
+  const members = rows
+    .map((r) => ({
+      id: r.id,
+      userId: r.userId,
+      name: byId.get(r.userId)?.name ?? null,
+      email: byId.get(r.userId)?.email ?? "",
+      role: r.role,
+      priority: r.priority,
+    }))
+    // Owners first, then admins, then members; stable by email within a role.
+    .sort((a, b) => {
+      const rank = { owner: 0, admin: 1, member: 2 } as const;
+      return rank[a.role] - rank[b.role] || a.email.localeCompare(b.email);
+    });
+
+  return NextResponse.json({ team, viewerRole: caller.role, members });
+}


### PR DESCRIPTION
Brings the Expo mobile app up to near-parity with the web dashboard. Every web
feature that mobile was missing now has a screen — reachable from the tab-bar
Settings — consuming the same REST API the web app uses.

## New mobile screens
| Feature | What mobile can now do |
|---|---|
| **CRM** (`/crm`) | See Salesforce/HubSpot status, connect (opens web OAuth), disconnect |
| **Billing** (`/billing`) | Plan/edition; upgrade→checkout, manage→portal; self-host = free-tier state; iOS purchase-guideline aware |
| **Payouts** (`/payouts`) | Connect balance + onboarding state, per-currency available/pending, withdraw (gated at the $100 min), Stripe dashboard |
| **Packages** (`/packages`) | List packages + client balances, create a package, grant credits |
| **Team detail** (`/teams/[id]`) | Member roster, add/remove members (admins only), collective rules |
| **Group polls** (`/polls`, `/polls/[id]`, `/polls/new`) | List, create with candidate times, per-option tally, finalize |
| **Routing forms** (`/routing`, `/routing/[id]`, `/routing/new`) | List, create, rename/activate/delete, public link |
| **Booking** (`/booking/[uid]`) | Cancel/reschedule now capture an optional **reason** sent to attendees |

## Backend: added the read APIs mobile needs
The web pages read most of this data **server-side in React Server Components**, so
there was no JSON endpoint for a native client to call. Added (auth-scoped, and
useful for any API consumer):
- `GET /api/integrations/crm` — connection status
- `GET /api/payments/status` — Connect balance + onboarding flags
- `GET /api/teams/[id]` + `DELETE /api/teams/[id]/members/[memberId]` — roster + removal
- `GET /api/polls`, `GET /api/polls/[id]`
- `GET /api/routing`, `GET /api/routing/[id]`

Each mirrors the exact data the corresponding web page already computes.

## Scope / deferred
- **Android push (FCM)** — needs an external Firebase project; stays as #70.
- **Deep builders** — the web routing field/rule builder and poll option editor
  stay web-only; mobile does create/list/activate/finalize/delete and renders the
  complex editors read-only, with an in-screen note pointing to the web app.

## Testing
- `pnpm --filter mobile typecheck` + `pnpm --filter web typecheck` — clean
- Web suite: 94 passing; Biome clean on all touched files
- Screens follow existing mobile conventions (`api`/`useAsync`/`ui`/theme, expo-router).
  Live device runs weren't performed in this environment; verification is types + lint + the web API contracts.

Closes #71, #72, #73, #74, #75, #76, #77, #78.