### PR TITLE
feat(mobile): make Android push (FCM) configurable per deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,13 @@ pnpm-debug.log*
 # expo (mobile)
 .expo/
 
+# firebase / fcm credentials - each deployment brings its own, never commit them.
+# google-services.json is per-Firebase-project; the service-account key is a SECRET
+# (it belongs in EAS credentials, not in git). See docs/INTEGRATIONS.md.
+google-services.json
+GoogleService-Info.plist
+**/*-firebase-adminsdk-*.json
+
 # claude code (local machine settings)
 .claude/settings.local.json
 

--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -1,0 +1,35 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const base = require("./app.json");
+
+/**
+ * Dynamic Expo config. Everything static lives in app.json; this file only adds
+ * the pieces that depend on the deployment's own credentials.
+ *
+ * Android push: Expo's push service delivers to Android through Firebase Cloud
+ * Messaging, which needs THIS deployment's `google-services.json` (each operator
+ * brings their own Firebase project - we can't ship one). Supply it either by
+ * dropping the file at apps/mobile/google-services.json, or by pointing
+ * GOOGLE_SERVICES_JSON at it (that's what an EAS file secret sets).
+ *
+ * When it's absent the app still builds and runs - iOS push and everything else
+ * work; only Android push stays off. So a contributor without a Firebase project
+ * is never blocked. See docs/INTEGRATIONS.md -> "Mobile push (Android / FCM)".
+ */
+function googleServicesFile() {
+  const fromEnv = process.env.GOOGLE_SERVICES_JSON;
+  if (fromEnv && fs.existsSync(fromEnv)) return fromEnv;
+  const local = path.join(__dirname, "google-services.json");
+  return fs.existsSync(local) ? "./google-services.json" : undefined;
+}
+
+module.exports = () => {
+  const services = googleServicesFile();
+  return {
+    ...base.expo,
+    android: {
+      ...base.expo.android,
+      ...(services ? { googleServicesFile: services } : {}),
+    },
+  };
+};

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -32,6 +32,7 @@ provider rejects the callback.
 | Stripe | `STRIPE_SECRET_KEY`, `STRIPE_PRICE_PRO`, `STRIPE_WEBHOOK_SECRET` | - | `APP_URL/api/webhooks/stripe` |
 | Twilio | `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_SMS_FROM`, `TWILIO_WHATSAPP_FROM` | - | `APP_URL/api/webhooks/twilio` (set on the number/Messaging Service) |
 | Resend (email) | `RESEND_API_KEY`, `EMAIL_FROM` | - | - |
+| Mobile push | *(none - iOS works out of the box; Android needs your own Firebase project + `google-services.json`)* | - | - |
 
 ---
 
@@ -185,6 +186,45 @@ platform's, DayOtter uses **Stripe Connect (Express)**:
 3. **Inbound replies** (so people can reply to reminders): set the number's (or
    Messaging Service's) incoming-message webhook to `APP_URL/api/webhooks/twilio`.
    On DayOtter Cloud this is DayOtter's managed Twilio; self-hosters bring their own.
+
+## Mobile push (Android / FCM)
+
+The mobile app registers an **Expo push token** and the server delivers through
+Expo's push service (`packages/notifications/src/providers/push.ts`) - so there
+are **no server env vars** for push, and **iOS needs no extra setup**.
+
+Android is the exception: Expo hands Android notifications to **Firebase Cloud
+Messaging**, so each deployment needs its own Firebase project. Without it the
+app still builds and runs - only Android push stays off.
+
+1. [Firebase Console](https://console.firebase.google.com/) → create a project
+   (or pick one) → **Add app → Android**.
+2. **Android package name:** `com.dayotter.app` (must match `android.package` in
+   `apps/mobile/app.json`) → Register.
+3. Download **`google-services.json`**. Put it at `apps/mobile/google-services.json`,
+   or upload it as an EAS **file secret** and expose it as `GOOGLE_SERVICES_JSON`.
+   `apps/mobile/app.config.js` picks up either automatically. It's gitignored -
+   it's specific to your Firebase project.
+4. **Project settings → Service accounts → Generate new private key** → download
+   the JSON. ⚠️ **This is a secret** - treat it like a password. It does *not* go
+   in the repo or in `.env`.
+5. Upload that key to your Expo project so Expo can talk to FCM on your behalf:
+   ```
+   cd apps/mobile && eas credentials
+   # → Android → production → Push Notifications: FCM V1 → upload the JSON from step 4
+   ```
+   (Or expo.dev → your project → Credentials → FCM V1.)
+6. Build a real app (push never works in Expo Go - it needs a dev/production build):
+   ```
+   eas build --platform android --profile preview
+   ```
+7. Install it on a physical device, then **Settings → Notification channels →
+   "Enable push on this device"**. The endpoint sends a real test push before it
+   saves the channel, so a success there means delivery works end to end.
+
+Troubleshooting: "Couldn't get a push token" almost always means Expo Go (use a
+dev build) or missing FCM credentials (step 5). Delivery failures are logged with
+`event: push_dispatch_failed` and the HTTP status from Expo.
 
 ## Resend (transactional email)
 


### PR DESCRIPTION
Groundwork for #70.

## Finding: there was no missing push code
The mobile app already registers an Expo push token (`registerPushChannel` →
`getExpoPushTokenAsync({ projectId })` → `/api/settings/channels`) and the server
already delivers through Expo's push service
(`packages/notifications/src/providers/push.ts`). **iOS works with no extra setup.**

Android was blocked purely on **credentials**: Expo routes Android notifications
through Firebase Cloud Messaging, which needs each deployment's own Firebase
project. That can't be shipped in the repo — so this PR makes it pluggable and
documents it, rather than inventing code that wasn't missing.

## Changes
- **`apps/mobile/app.config.js`** (new) — dynamic Expo config that sets
  `android.googleServicesFile` **only when a `google-services.json` is actually
  present**: either at `apps/mobile/google-services.json`, or at the path in
  `GOOGLE_SERVICES_JSON` (what an EAS file secret sets). When it's absent the app
  still builds and runs and only Android push stays off, so contributors and
  self-hosters without Firebase are never blocked. All static config stays in
  `app.json`, which this extends.
- **`.gitignore`** — never commit `google-services.json`,
  `GoogleService-Info.plist`, or a `*-firebase-adminsdk-*.json` service-account
  key. That last one is a **secret** and belongs in EAS credentials, not git.
- **`docs/INTEGRATIONS.md`** — end-to-end Android push runbook: Firebase project →
  `google-services.json` → FCM V1 service-account key uploaded via
  `eas credentials` → dev build → enable on device. Plus the two common failure
  modes (Expo Go can't receive push; missing FCM creds) and the
  `push_dispatch_failed` log event.

## Verification
Resolved the config three ways with `expo config --type public`:
- **File absent** → output is identical to the previous `app.json` behavior:
  `android.package`, `versionCode`, `permissions`, `adaptiveIcon` and
  `extra.eas.projectId` all preserved, and **no** `googleServicesFile` key. Builds
  are unaffected.
- **File present** → emits `googleServicesFile: './google-services.json'`.
- `git check-ignore` confirms the file is ignored, so it can't be committed by accident.

Mobile typecheck + Biome clean.

This doesn't close #70 on its own — the remaining steps are operator actions on
their own Firebase/Expo accounts (generate the service-account key, upload it via
`eas credentials`, run a build), which are now documented in the runbook.