### PR TITLE
fix(mobile): resolve zod to v4 so the production Android build stops crashing on launch

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -4,7 +4,7 @@
     "slug": "dayotter",
     "owner": "dayotter",
     "scheme": "dayotter",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "orientation": "portrait",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": false,
@@ -17,7 +17,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.dayotter.app",
-      "buildNumber": "1",
+      "buildNumber": "2",
       "infoPlist": {
         "NSSpeechRecognitionUsageDescription": "DayOtter turns your spoken commands into scheduling actions.",
         "NSMicrophoneUsageDescription": "DayOtter uses the microphone so you can speak scheduling commands."
@@ -25,7 +25,7 @@
     },
     "android": {
       "package": "com.dayotter.app",
-      "versionCode": 5,
+      "versionCode": 6,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#12305F"

--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -24,7 +24,21 @@ config.resolver.disableHierarchicalLookup = true;
 //    Default-on in Expo SDK 53; opt-in here on SDK 52.
 config.resolver.unstable_enablePackageExports = true;
 
-// 5. Import *.svg files as React components (react-native-svg-transformer).
+// 5. Point the bare `zod` specifier at its v4 entry. better-auth (1.6.x) calls
+//    zod-v4-only APIs like `.meta()`; with zod 3.25's dual export Metro was
+//    resolving the classic v3 module (no `.meta`), so every route module threw
+//    at eval time and the app crashed on launch in production (dev tolerated
+//    it). The mobile bundle uses zod ONLY via better-auth, so this is safe and
+//    keeps all schema instances on one (v4) implementation.
+const baseResolveRequest = config.resolver.resolveRequest;
+config.resolver.resolveRequest = (context, moduleName, platform) => {
+  const target = moduleName === "zod" ? "zod/v4" : moduleName;
+  return baseResolveRequest
+    ? baseResolveRequest(context, target, platform)
+    : context.resolveRequest(context, target, platform);
+};
+
+// 6. Import *.svg files as React components (react-native-svg-transformer).
 config.transformer.babelTransformerPath = require.resolve("react-native-svg-transformer");
 config.resolver.assetExts = config.resolver.assetExts.filter((ext) => ext !== "svg");
 config.resolver.sourceExts = [...config.resolver.sourceExts, "svg"];


### PR DESCRIPTION
## Symptom
The **release** Android build crashes immediately on open. Debug builds are fine.
Production logcat, repeated for every route:
```
TypeError: z.coerce.boolean().meta is not a function (it is undefined)
Route "./(tabs)/_layout.tsx" is missing the required default export. …
→ Cannot read property 'ErrorBoundary' of undefined  (ContextNavigator)  → FATAL
```

## Root cause (not the app code)
- `better-auth` (1.6.x) — pulled in by the auth client that **every** route uses via
  `AuthProvider` — calls **zod-v4-only** APIs like `.meta()`.
- `zod@3.25` ships a dual export: the classic **v3** module (no `.meta()`) and a **v4**
  implementation under `zod/v4`. Confirmed locally: classic `zod` → `.meta` is
  `undefined`; `zod/v4` → `.meta` is a function.
- Metro resolved the bare `zod` specifier to the **classic v3** module, so better-auth
  threw at module-eval time. In **dev** expo-router only warns per route; in
  **production** it eagerly evaluates every route to build the static tree, so the throw
  cascades — every route loses its default export, the tree is empty, and the navigator
  crashes.
- **Why now:** latent until this batch. Adding `openai` (#83) pulled `zod@4.4.3` into the
  monorepo and shifted resolution. `apps/mobile/package.json` itself was never changed.

## Fix
Point the bare `zod` specifier at `zod/v4` in the mobile Metro resolver
(`apps/mobile/metro.config.js`). The mobile bundle imports zod **only** through
better-auth — the app's own source imports none — so this is safe and keeps every schema
instance on a single (v4) implementation.

## Verification (physical device, OnePlus / Android 16)
Reproduced and fixed without guesswork, using a production-mode Metro bundle
(`expo start --no-dev --minify`) so `__DEV__` matches a release build:
- **Before:** `.meta` error + "missing default export" for every route; `FATAL EXCEPTION`; app dies.
- **After:** `Running "main"`, **zero** JS errors of any kind, app mounts.

A full release-APK rebuild with the fix is being validated on-device as the final check.

## Why CI/typecheck didn't catch it
`tsc` and Biome can't see runtime module resolution, and **debug builds don't crash** —
only a production bundle on a real device surfaces it. This is exactly why the device test
before the Play Store build was worth doing.

Refs #70.