### PR TITLE
chore(mobile): address Play Console optimization recommendations (edge-to-edge, orientation, R8)

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -5,7 +5,7 @@
     "owner": "dayotter",
     "scheme": "dayotter",
     "version": "0.2.0",
-    "orientation": "portrait",
+    "orientation": "default",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": false,
     "icon": "./assets/icon.png",
@@ -25,7 +25,8 @@
     },
     "android": {
       "package": "com.dayotter.app",
-      "versionCode": 6,
+      "versionCode": 7,
+      "edgeToEdgeEnabled": true,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#12305F"
@@ -57,7 +58,9 @@
           "android": {
             "compileSdkVersion": 35,
             "targetSdkVersion": 35,
-            "buildToolsVersion": "35.0.0"
+            "buildToolsVersion": "35.0.0",
+            "enableProguardInReleaseBuilds": true,
+            "enableShrinkResourcesInReleaseBuilds": true
           },
           "ios": {
             "deploymentTarget": "15.1"

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -31,6 +31,7 @@
     "expo-web-browser": "~14.2.0",
     "react": "19.0.0",
     "react-native": "0.79.6",
+    "react-native-edge-to-edge": "1.6.0",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-svg": "15.11.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,9 @@ importers:
       react-native:
         specifier: 0.79.6
         version: 0.79.6(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.0.0)
+      react-native-edge-to-edge:
+        specifier: 1.6.0
+        version: 1.6.0(react-native@0.79.6(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.0.0))(react@19.0.0)
       react-native-safe-area-context:
         specifier: 5.4.0
         version: 5.4.0(react-native@0.79.6(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.0.0))(react@19.0.0)
@@ -6503,7 +6506,7 @@ snapshots:
       '@better-fetch/fetch': 1.3.1
       '@opentelemetry/semantic-conventions': 1.41.1
       '@standard-schema/spec': 1.1.0
-      better-call: 1.3.7(zod@3.25.76)
+      better-call: 1.3.7(zod@4.4.3)
       jose: 6.2.3
       kysely: 0.29.2
       nanostores: 1.4.0
@@ -8385,7 +8388,7 @@ snapshots:
       '@better-fetch/fetch': 1.3.1
       '@noble/ciphers': 2.2.0
       '@noble/hashes': 2.2.0
-      better-call: 1.3.7(zod@3.25.76)
+      better-call: 1.3.7(zod@4.4.3)
       defu: 6.1.7
       jose: 6.2.3
       kysely: 0.29.2
@@ -8400,15 +8403,6 @@ snapshots:
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
-
-  better-call@1.3.7(zod@3.25.76):
-    dependencies:
-      '@better-auth/utils': 0.4.2
-      '@better-fetch/fetch': 1.3.1
-      rou3: 0.7.12
-      set-cookie-parser: 3.1.1
-    optionalDependencies:
-      zod: 3.25.76
 
   better-call@1.3.7(zod@4.4.3):
     dependencies:


### PR DESCRIPTION
Clears the 5 Play Console pre-launch **optimization** recommendations. (None of these were the crash — that was the zod fix in #95, already merged.)

| # | Recommendation | Fix | Runtime-risk |
|---|---|---|---|
| 1 | Edge-to-edge may not display | `android.edgeToEdgeEnabled: true` + `react-native-edge-to-edge@1.6.0` → `Theme.EdgeToEdge` | low (app already uses `SafeAreaProvider`) |
| 2 | Deprecated edge-to-edge APIs | Superseded by #1. Our code uses only `expo-status-bar` `style` (non-deprecated); residual warnings are RN-core / react-native-screens / material internals that clear as those libs update | none on our side |
| 3 | Orientation restriction (large screens) | `orientation: "default"` → manifest `screenOrientation="unspecified"` | low-medium (app now rotates — layouts should be checked) |
| 4 | 16 KB native alignment | **Already fixed** — shipped v0.2.0 (vc7, SDK 53) libs are `0x4000`-aligned (verified). Warning was stale, against the old vc5 (SDK 52). No change. | n/a |
| 5 | R8 optimization | `enableProguardInReleaseBuilds` + `enableShrinkResourcesInReleaseBuilds` → `minifyEnabled` | **medium — needs device test** |

## Verified so far
- `expo config` resolves all fields; `expo prebuild` applies them (Theme.EdgeToEdge, `screenOrientation="unspecified"`, `minifyEnabled` in `android/app/build.gradle`).
- Local **R8 release build: BUILD SUCCESSFUL** (R8 8.8.34), no missing-class / keep-rule warnings, `mapping.txt` produced, APK 68 MB → 63.5 MB.
- Mobile typecheck clean; `pnpm install --frozen-lockfile` consistent.

## ⚠️ Not yet validated on a device — do not merge/ship untested
The test phone dropped off USB before the on-device smoke-test, so I could **not** confirm at runtime:
- **R8** doesn't strip a reflection-used class (this class of bug compiles clean and only crashes at launch — exactly the kind of thing that caused the last Play rejection).
- **Edge-to-edge** doesn't clip content under the status/nav bars.
- **Rotation** layouts hold now that portrait lock is removed.

**Before this is merged/submitted:** reconnect the device (I'll finish the launch + rotate pass), or run an EAS internal build and install it from the track to smoke-test. R8 especially must not go to the store unvalidated.

Refs #70.