### PR TITLE
fix(mobile): logout session reset, one-tap Google sign-in, sign-in redesign

### DIFF
--- a/apps/mobile/app/sign-in.tsx
+++ b/apps/mobile/app/sign-in.tsx
@@ -1,5 +1,5 @@
 import { useAuth } from "@/auth";
-import { googleAuthEnabled, phoneAuthEnabled } from "@/auth-client";
+import { googleAuthEnabled } from "@/auth-client";
 import { BrandMark } from "@/components/brand-mark";
 import { hasOnboarded } from "@/onboarding-state";
 import { serverHost } from "@/server";
@@ -21,7 +21,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function SignInScreen() {
   const router = useRouter();
-  const { signIn, signUp, signInWithGoogle, sendPhoneOtp, verifyPhoneOtp } = useAuth();
+  const { signIn, signUp, signInWithGoogle } = useAuth();
   const [isSignUp, setIsSignUp] = useState(false);
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
@@ -30,11 +30,6 @@ export default function SignInScreen() {
   const [loading, setLoading] = useState(false);
   const [googleLoading, setGoogleLoading] = useState(false);
   const [ready, setReady] = useState(false);
-  // Phone/OTP flow: "off" (collapsed) → "phone" (enter number) → "code" (enter OTP).
-  const [phoneMode, setPhoneMode] = useState<"off" | "phone" | "code">("off");
-  const [phone, setPhone] = useState("");
-  const [otp, setOtp] = useState("");
-  const [phoneLoading, setPhoneLoading] = useState(false);
 
   // First launch → show onboarding before the sign-in form.
   useEffect(() => {
@@ -64,23 +59,9 @@ export default function SignInScreen() {
     else router.replace("/");
   }
 
-  async function phoneSubmit() {
-    setPhoneLoading(true);
-    setError(null);
-    if (phoneMode === "phone") {
-      const err = await sendPhoneOtp(phone.trim());
-      setPhoneLoading(false);
-      if (err) setError(err);
-      else setPhoneMode("code");
-      return;
-    }
-    const err = await verifyPhoneOtp(phone.trim(), otp.trim());
-    setPhoneLoading(false);
-    if (err) setError(err);
-    else router.replace("/");
-  }
-
   if (!ready) return <View style={styles.safe} />;
+
+  const showGoogle = googleAuthEnabled && Platform.OS !== "ios";
 
   return (
     <SafeAreaView style={styles.safe}>
@@ -98,6 +79,26 @@ export default function SignInScreen() {
           </Text>
 
           <View style={styles.form}>
+            {/* Lead with Google - the one-tap path most people want. Hidden on
+                iOS (offering it there would require Sign in with Apple, App Store
+                guideline 4.8); email/password stays available everywhere. */}
+            {showGoogle ? (
+              <Pressable style={styles.googleBtn} onPress={google} disabled={googleLoading}>
+                <Ionicons name="logo-google" size={18} color={colors.text} />
+                <Text style={styles.googleText}>
+                  {googleLoading ? "Opening…" : "Continue with Google"}
+                </Text>
+              </Pressable>
+            ) : null}
+
+            {showGoogle ? (
+              <View style={styles.divider}>
+                <View style={styles.line} />
+                <Text style={styles.dividerText}>or continue with email</Text>
+                <View style={styles.line} />
+              </View>
+            ) : null}
+
             {isSignUp ? (
               <Field label="Name" value={name} onChange={setName} placeholder="Ada Lovelace" />
             ) : null}
@@ -121,87 +122,6 @@ export default function SignInScreen() {
                 {loading ? "Please wait…" : isSignUp ? "Create account" : "Sign in"}
               </Text>
             </Pressable>
-
-            {/* Google hidden on iOS: offering it would require Sign in with Apple
-                (App Store guideline 4.8). Email/password stays available. */}
-            {googleAuthEnabled && Platform.OS !== "ios" ? (
-              <>
-                <View style={styles.divider}>
-                  <View style={styles.line} />
-                  <Text style={styles.dividerText}>or</Text>
-                  <View style={styles.line} />
-                </View>
-                <Pressable style={styles.googleBtn} onPress={google} disabled={googleLoading}>
-                  <Ionicons name="logo-google" size={17} color={colors.text} />
-                  <Text style={styles.googleText}>
-                    {googleLoading ? "Opening…" : "Continue with Google"}
-                  </Text>
-                </Pressable>
-              </>
-            ) : null}
-            {phoneAuthEnabled ? (
-              <>
-                <View style={styles.divider}>
-                  <View style={styles.line} />
-                  <Text style={styles.dividerText}>or</Text>
-                  <View style={styles.line} />
-                </View>
-                {phoneMode === "off" ? (
-                  <Pressable
-                    style={styles.googleBtn}
-                    onPress={() => {
-                      setPhoneMode("phone");
-                      setError(null);
-                    }}
-                  >
-                    <Ionicons name="phone-portrait-outline" size={17} color={colors.text} />
-                    <Text style={styles.googleText}>Continue with phone</Text>
-                  </Pressable>
-                ) : (
-                  <View>
-                    {phoneMode === "phone" ? (
-                      <Field
-                        label="Phone number"
-                        value={phone}
-                        onChange={setPhone}
-                        placeholder="+14155551234"
-                        keyboardType="phone-pad"
-                        textContentType="telephoneNumber"
-                        autoComplete="tel"
-                      />
-                    ) : (
-                      <Field
-                        label={`Code sent to ${phone}`}
-                        value={otp}
-                        onChange={setOtp}
-                        placeholder="123456"
-                        keyboardType="number-pad"
-                        textContentType="oneTimeCode"
-                        autoComplete="sms-otp"
-                      />
-                    )}
-                    <Pressable style={styles.button} onPress={phoneSubmit} disabled={phoneLoading}>
-                      <Text style={styles.buttonText}>
-                        {phoneLoading
-                          ? "Please wait…"
-                          : phoneMode === "phone"
-                            ? "Send code"
-                            : "Verify & sign in"}
-                      </Text>
-                    </Pressable>
-                    <Pressable
-                      onPress={() => {
-                        setPhoneMode("off");
-                        setOtp("");
-                        setError(null);
-                      }}
-                    >
-                      <Text style={styles.toggle}>Cancel</Text>
-                    </Pressable>
-                  </View>
-                )}
-              </>
-            ) : null}
 
             <Pressable
               onPress={() => {

--- a/apps/mobile/src/auth-client.ts
+++ b/apps/mobile/src/auth-client.ts
@@ -33,6 +33,22 @@ export function getAuthClient(): Client {
   return cached.client;
 }
 
+/**
+ * Hard-clear the Better Auth Expo session. The client's own `signOut()` is
+ * best-effort (a network blip leaves the stored cookie behind), and it caches
+ * the cookie in memory - so on sign-out we also delete its SecureStore keys AND
+ * drop the cached client, or the previous account's session leaks into the next
+ * sign-in (e.g. logging out of X then into Y still shows X). Key names come from
+ * @better-auth/expo: `${storagePrefix}_cookie` and `${storagePrefix}_session_data`.
+ */
+export async function clearBetterAuthSession(): Promise<void> {
+  cached = null; // force a fresh client (drops any in-memory cookie) next call
+  await Promise.all([
+    SecureStore.deleteItemAsync("dayotter_cookie").catch(() => {}),
+    SecureStore.deleteItemAsync("dayotter_session_data").catch(() => {}),
+  ]);
+}
+
 /** Whether the "Continue with Google" button should render. */
 export const googleAuthEnabled = process.env.EXPO_PUBLIC_GOOGLE_AUTH === "1";
 

--- a/apps/mobile/src/auth.tsx
+++ b/apps/mobile/src/auth.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode, createContext, useContext, useEffect, useMemo, useState } from "react";
 import { ApiError, api, clearToken, hasSession, setToken } from "./api";
-import { getAuthClient } from "./auth-client";
+import { clearBetterAuthSession, getAuthClient } from "./auth-client";
 import type { AppUser } from "./models";
 import { loadServerUrl } from "./server";
 
@@ -28,6 +28,21 @@ export function useAuth(): AuthState {
 interface AuthResponse {
   token?: string;
   user: AppUser;
+}
+
+/**
+ * Load the signed-in profile, retrying through the brief window where a freshly
+ * established Better Auth cookie hasn't been persisted yet (OAuth/phone flows).
+ */
+async function loadMeWithRetry(attempts = 6, delayMs = 250): Promise<AppUser | null> {
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return (await api.get<{ user: AppUser }>("/api/me")).user;
+    } catch {
+      await new Promise((r) => setTimeout(r, delayMs));
+    }
+  }
+  return null;
 }
 
 export function AuthProvider({ children }: { children: ReactNode }) {
@@ -73,9 +88,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     try {
       const res = await getAuthClient().signIn.social({ provider: "google", callbackURL: "/" });
       if (res.error) return res.error.message ?? "Google sign-in failed";
-      // The Expo client now holds the session cookie; api.ts sends it. Confirm
-      // by loading the profile.
-      const { user: me } = await api.get<{ user: AppUser }>("/api/me");
+      // The Expo client persists the session cookie asynchronously after the
+      // browser redirect, so the first /api/me can beat the cookie write and
+      // 401 - which sent the user back to the login screen and made them sign in
+      // twice. Retry briefly so the very first attempt lands.
+      const me = await loadMeWithRetry();
+      if (!me) return "Signed in, but couldn't load your profile - please try again.";
       setUser(me);
       return null;
     } catch (err) {
@@ -97,7 +115,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     try {
       const res = await getAuthClient().phoneNumber.verify({ phoneNumber: phone, code });
       if (res.error) return res.error.message ?? "That code didn't match";
-      const { user: me } = await api.get<{ user: AppUser }>("/api/me");
+      const me = await loadMeWithRetry();
+      if (!me) return "Verified, but couldn't load your profile - please try again.";
       setUser(me);
       return null;
     } catch (err) {
@@ -119,10 +138,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       sendPhoneOtp,
       verifyPhoneOtp,
       signOut: async () => {
+        // Clear the account before anything else so a stale session can't leak
+        // into the next sign-in: server signOut (best-effort), the bearer token,
+        // AND the Better Auth Expo cookie storage.
         await getAuthClient()
           .signOut()
           .catch(() => {});
         await clearToken();
+        await clearBetterAuthSession();
         setUser(null);
       },
     }),


### PR DESCRIPTION
Three auth issues reported on the app:

### 1. Logout didn't reset the account
Signing out of X then into Y still showed X's data. Better Auth's `signOut()` is
best-effort (a network blip leaves its stored cookie behind) and it caches the
cookie in memory. On sign-out we now **also delete its SecureStore keys**
(`dayotter_cookie`, `dayotter_session_data`) and drop the cached client, so no
previous account can leak into the next sign-in.

### 2. Google sign-in needed two taps
The first tap bounced back to the login screen. The Expo client persists the
session cookie **asynchronously** after the browser redirect, so the first
`/api/me` raced the cookie write and 401'd. Now it **retries `/api/me` briefly**
(also applied to phone verify), so the first tap lands.

### 3. Sign-in UI redesign + phone removed
- Leads with **Continue with Google** and a single **"or continue with email"**
  divider, then email/password — instead of email-first with *two* stacked "or"
  dividers.
- **Removed the phone/OTP option** for now (needs working server-side SMS; a
  Firebase-based re-enable is a follow-up). The `sendPhoneOtp`/`verifyPhoneOtp`
  context methods stay for that future work.

## Verification (physical device)
- New sign-in UI confirmed on-device (screenshot: Google-first, single divider, no phone). ✅
- Logout reaches the signed-out state (session cleared). ✅
- Typecheck + biome clean.
- One-tap Google + the X→Y account switch are runtime auth flows (need a real
  Google login / two accounts) — to confirm on the device after install.

Note: this touches only auth files; the Google button visibility is unchanged
(still `EXPO_PUBLIC_GOOGLE_AUTH`, which EAS sets).