### PR TITLE
feat(import): Calendly importer (#115)

### DIFF
--- a/apps/web/app/(app)/settings/import/page.tsx
+++ b/apps/web/app/(app)/settings/import/page.tsx
@@ -1,0 +1,39 @@
+import { CalendlyImport } from "@/components/calendly-import";
+import { Card, CardBody, CardHeader } from "@/components/ui/card";
+import { getSession } from "@/lib/auth/session";
+
+export const dynamic = "force-dynamic";
+
+export default async function ImportSettingsPage() {
+  const session = await getSession();
+  if (!session?.user) return null; // the (app) layout redirects; this guards the render race
+
+  return (
+    <>
+      <div className="mb-6">
+        <h2 className="text-lg font-semibold">Import from Calendly</h2>
+        <p className="mt-1 text-sm text-[var(--color-muted)]">
+          Switching over? Bring your event types and weekly availability across in one step. We read
+          them straight from Calendly with a token you paste below - nothing is changed on the
+          Calendly side, and existing DayOtter data is never overwritten.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader
+          title="Calendly"
+          description="Event types and availability schedules. Upcoming bookings aren't moved."
+        />
+        <CardBody>
+          <CalendlyImport />
+        </CardBody>
+      </Card>
+
+      <p className="mt-4 text-xs text-[var(--color-faint)]">
+        Team round-robin / collective events import as personal event types you host. Date-specific
+        availability overrides and per-event schedules aren't mapped yet - double-check imported
+        event types before sharing them.
+      </p>
+    </>
+  );
+}

--- a/apps/web/app/api/import/calendly/route.ts
+++ b/apps/web/app/api/import/calendly/route.ts
@@ -1,0 +1,44 @@
+import { CalendlyAuthError, fetchCalendlyExport } from "@/lib/import/calendly-client";
+import { importCalendlyExport } from "@/lib/import/run-import";
+import { jsonError, withUser } from "@/lib/server/http";
+import { enforceRateLimit } from "@/lib/server/rate-limit";
+import { logger } from "@dayotter/core";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+export const dynamic = "force-dynamic";
+
+const body = z.object({ token: z.string().min(10).max(500) });
+
+/**
+ * Import a user's Calendly event types + availability from a Personal Access
+ * Token. The token is used only for this request and never stored. Host-only.
+ */
+export const POST = withUser(async (u, request) => {
+  // The import creates rows and calls an external API - throttle per user.
+  const limited = await enforceRateLimit(request, {
+    name: "calendly-import",
+    limit: 5,
+    windowSec: 600,
+    key: u.id,
+  });
+  if (limited) return limited;
+
+  const parsed = body.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) return jsonError("Paste your Calendly access token to import.", 400);
+
+  try {
+    const data = await fetchCalendlyExport(parsed.data.token.trim());
+    const summary = await importCalendlyExport(u.id, data);
+    return NextResponse.json({ ok: true, ...summary });
+  } catch (err) {
+    if (err instanceof CalendlyAuthError) {
+      return jsonError(
+        "Calendly rejected that token. Check it's a valid access token and retry.",
+        400,
+      );
+    }
+    logger.error("calendly import failed", { event: "calendly_import_failed", userId: u.id, err });
+    return jsonError("Couldn't import from Calendly right now. Please try again.", 502);
+  }
+});

--- a/apps/web/components/calendly-import.tsx
+++ b/apps/web/components/calendly-import.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input, Label } from "@/components/ui/input";
+import { AlertTriangle, CheckCircle2, Loader2 } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+interface ImportResult {
+  account: string;
+  eventTypesImported: number;
+  eventTypesSkipped: number;
+  schedulesImported: number;
+  rulesImported: number;
+  warnings: string[];
+}
+
+export function CalendlyImport() {
+  const router = useRouter();
+  const [token, setToken] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<ImportResult | null>(null);
+
+  async function run() {
+    setBusy(true);
+    setError(null);
+    setResult(null);
+    try {
+      const res = await fetch("/api/import/calendly", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ token: token.trim() }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(data.error ?? "Import failed. Please try again.");
+        return;
+      }
+      setResult(data as ImportResult);
+      setToken("");
+      router.refresh();
+    } catch {
+      setError("Something went wrong. Please try again.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (result) {
+    return (
+      <div className="space-y-4">
+        <div className="flex items-start gap-2 rounded-md border border-[var(--color-success)]/30 bg-[var(--color-success)]/10 px-4 py-3 text-sm text-[var(--color-success)]">
+          <CheckCircle2 size={16} className="mt-0.5 shrink-0" />
+          <div>
+            <p className="font-medium">Imported from {result.account}.</p>
+            <p className="mt-0.5 text-[var(--color-text)]">
+              {result.eventTypesImported} event type{result.eventTypesImported === 1 ? "" : "s"}
+              {result.schedulesImported > 0
+                ? ` and ${result.schedulesImported} availability schedule${result.schedulesImported === 1 ? "" : "s"}`
+                : ""}
+              {result.eventTypesSkipped > 0 ? ` · ${result.eventTypesSkipped} skipped` : ""}.
+            </p>
+          </div>
+        </div>
+        {result.warnings.length > 0 ? (
+          <ul className="space-y-1.5 text-xs text-[var(--color-muted)]">
+            {result.warnings.map((w) => (
+              <li key={w} className="flex items-start gap-1.5">
+                <AlertTriangle size={13} className="mt-0.5 shrink-0 text-[var(--color-amber)]" />
+                {w}
+              </li>
+            ))}
+          </ul>
+        ) : null}
+        <div className="flex gap-2">
+          <Link
+            href="/event-types"
+            className="text-sm font-medium text-[var(--color-accent)] hover:underline"
+          >
+            Review imported event types →
+          </Link>
+        </div>
+        <Button variant="outline" size="sm" onClick={() => setResult(null)}>
+          Import again
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <Label htmlFor="calendly-token">Calendly access token</Label>
+        <Input
+          id="calendly-token"
+          type="password"
+          autoComplete="off"
+          placeholder="eyJraWQiOi…"
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          className="mt-1.5 font-mono"
+        />
+        <p className="mt-1.5 text-xs text-[var(--color-muted)]">
+          Create a Personal Access Token in{" "}
+          <a
+            href="https://calendly.com/integrations/api_webhooks"
+            target="_blank"
+            rel="noreferrer"
+            className="text-[var(--color-accent)] hover:underline"
+          >
+            Calendly → Integrations → API &amp; webhooks
+          </a>
+          . It's used once for this import and never stored.
+        </p>
+      </div>
+      {error ? (
+        <p className="flex items-center gap-1.5 text-sm text-[var(--color-danger)]">
+          <AlertTriangle size={14} /> {error}
+        </p>
+      ) : null}
+      <Button onClick={run} disabled={busy || token.trim().length < 10} className="gap-1.5">
+        {busy ? <Loader2 size={15} className="animate-spin" /> : null}
+        {busy ? "Importing…" : "Import from Calendly"}
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/components/nav-items.ts
+++ b/apps/web/components/nav-items.ts
@@ -47,6 +47,7 @@ export const SETTINGS_NAV = [
   { href: "/settings/payouts", label: "Payouts" },
   { href: "/settings/calendars", label: "Calendars" },
   { href: "/settings/crm", label: "CRM" },
+  { href: "/settings/import", label: "Import" },
   { href: "/settings/billing", label: "Billing" },
   { href: "/settings/developer", label: "Developer" },
 ] as const;

--- a/apps/web/lib/import/calendly-client.ts
+++ b/apps/web/lib/import/calendly-client.ts
@@ -1,0 +1,80 @@
+import type { CalendlyAvailabilitySchedule, CalendlyEventType } from "./calendly";
+
+const CALENDLY_API = "https://api.calendly.com";
+const TIMEOUT_MS = 15_000;
+
+/** Thrown when Calendly rejects the token (401) - surfaced to the user distinctly. */
+export class CalendlyAuthError extends Error {
+  constructor() {
+    super("Calendly rejected the access token");
+    this.name = "CalendlyAuthError";
+  }
+}
+
+/** Everything we pull from Calendly for one user, ready to hand to the importer. */
+export interface RawCalendlyExport {
+  user: { name: string; uri: string };
+  eventTypes: CalendlyEventType[];
+  schedules: CalendlyAvailabilitySchedule[];
+}
+
+interface Paginated<T> {
+  collection: T[];
+  pagination?: { next_page?: string | null };
+}
+
+async function cget<T>(token: string, url: string): Promise<T> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+      signal: controller.signal,
+    });
+    if (res.status === 401) throw new CalendlyAuthError();
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw new Error(`Calendly ${res.status}: ${detail.slice(0, 200)}`);
+    }
+    return (await res.json()) as T;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Follow Calendly's cursor pagination, concatenating every page's collection. */
+async function collectAll<T>(token: string, firstUrl: string): Promise<T[]> {
+  const out: T[] = [];
+  let next: string | null | undefined = firstUrl;
+  // Guard against a pathological pagination loop.
+  for (let page = 0; next && page < 50; page++) {
+    const data: Paginated<T> = await cget<Paginated<T>>(token, next);
+    out.push(...(data.collection ?? []));
+    next = data.pagination?.next_page ?? null;
+  }
+  return out;
+}
+
+/**
+ * Fetch the current Calendly user's event types + availability schedules using a
+ * Personal Access Token. Only reads - never writes to Calendly.
+ */
+export async function fetchCalendlyExport(token: string): Promise<RawCalendlyExport> {
+  const me = await cget<{ resource: { uri: string; name?: string } }>(
+    token,
+    `${CALENDLY_API}/users/me`,
+  );
+  const userUri = me.resource.uri;
+  const userParam = encodeURIComponent(userUri);
+
+  const eventTypes = await collectAll<CalendlyEventType>(
+    token,
+    `${CALENDLY_API}/event_types?user=${userParam}&count=100`,
+  );
+  const schedules = await collectAll<CalendlyAvailabilitySchedule>(
+    token,
+    `${CALENDLY_API}/user_availability_schedules?user=${userParam}`,
+  );
+
+  return { user: { name: me.resource.name ?? "", uri: userUri }, eventTypes, schedules };
+}

--- a/apps/web/lib/import/calendly.test.ts
+++ b/apps/web/lib/import/calendly.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import {
+  type CalendlyEventType,
+  hexToColorToken,
+  mapEventType,
+  mapLocation,
+  mapQuestions,
+  mapSchedule,
+  mapScheduleRules,
+  shouldImportEventType,
+  toEventSlug,
+} from "./calendly";
+
+describe("toEventSlug", () => {
+  it("slugifies names to our lowercase-dash format", () => {
+    expect(toEventSlug("15 Minute Meeting")).toBe("15-minute-meeting");
+    expect(toEventSlug("Coffee ☕ Chat!")).toBe("coffee-chat");
+  });
+  it("never returns empty and truncates to 60", () => {
+    expect(toEventSlug("")).toBe("event");
+    expect(toEventSlug("!!!")).toBe("event");
+    expect(toEventSlug("a".repeat(80)).length).toBe(60);
+  });
+  it("trims trailing dashes left by truncation", () => {
+    expect(toEventSlug("word ".repeat(20)).endsWith("-")).toBe(false);
+  });
+});
+
+describe("hexToColorToken", () => {
+  it("buckets hues to tokens", () => {
+    expect(hexToColorToken("#ff2d2d")).toBe("coral"); // red
+    expect(hexToColorToken("#ffd400")).toBe("amber"); // yellow
+    expect(hexToColorToken("#12c98a")).toBe("mint"); // green
+    expect(hexToColorToken("#2d7dff")).toBe("sky"); // blue
+    expect(hexToColorToken("#8a2dff")).toBe("violet"); // purple
+  });
+  it("returns null for grey / invalid / missing", () => {
+    expect(hexToColorToken("#808080")).toBeNull();
+    expect(hexToColorToken("not-a-hex")).toBeNull();
+    expect(hexToColorToken(null)).toBeNull();
+  });
+});
+
+describe("mapLocation", () => {
+  it("maps conference kinds to our auto-conference types", () => {
+    expect(mapLocation([{ kind: "google_conference" }]).location).toBe("google_meet");
+    expect(mapLocation([{ kind: "microsoft_teams_conference" }]).location).toBe("ms_teams");
+  });
+  it("maps zoom, carrying a join url when present", () => {
+    const z = mapLocation([{ kind: "zoom_conference", join_url: "https://zoom.us/j/1" }]);
+    expect(z.location).toBe("zoom");
+    expect(z.locationDetail).toBe("https://zoom.us/j/1");
+  });
+  it("maps physical to in_person with the address", () => {
+    const p = mapLocation([{ kind: "physical", location: "123 Main St" }]);
+    expect(p).toEqual({ location: "in_person", locationDetail: "123 Main St" });
+  });
+  it("gives detail-requiring types a non-empty fallback detail", () => {
+    expect(mapLocation([{ kind: "zoom_conference" }]).locationDetail).toBeTruthy();
+    expect(mapLocation([{ kind: "physical" }]).locationDetail).toBeTruthy();
+  });
+  it("defaults to google_meet when there is no location", () => {
+    expect(mapLocation(null).location).toBe("google_meet");
+    expect(mapLocation([]).location).toBe("google_meet");
+    expect(mapLocation([{ kind: "something_new" }]).location).toBe("google_meet");
+  });
+});
+
+describe("mapQuestions", () => {
+  it("maps types and keeps select options, skipping disabled", () => {
+    const qs = mapQuestions([
+      { name: "Your role", type: "string", required: true },
+      { name: "Notes", type: "text", required: false },
+      { name: "Team", type: "single_select", answer_choices: ["Eng", "Sales"] },
+      { name: "Hidden", type: "string", enabled: false },
+    ]);
+    expect(qs).toHaveLength(3);
+    expect(qs[0]).toMatchObject({ label: "Your role", type: "text", required: true, id: "q1" });
+    expect(qs[1]).toMatchObject({ type: "textarea" });
+    expect(qs[2]).toMatchObject({ type: "select", options: ["Eng", "Sales"] });
+  });
+  it("caps at 20 questions", () => {
+    const many = Array.from({ length: 30 }, (_, i) => ({ name: `Q${i}`, type: "string" }));
+    expect(mapQuestions(many)).toHaveLength(20);
+  });
+});
+
+describe("mapScheduleRules", () => {
+  it("expands wday rules (incl. multiple intervals) and maps day indices", () => {
+    const rules = mapScheduleRules([
+      {
+        type: "wday",
+        wday: "monday",
+        intervals: [
+          { from: "09:00", to: "12:00" },
+          { from: "13:00", to: "17:00" },
+        ],
+      },
+      { type: "wday", wday: "sunday", intervals: [] }, // day off
+      { type: "date", date: "2026-12-25", intervals: [{ from: "10:00", to: "11:00" }] }, // skipped
+    ]);
+    expect(rules).toEqual([
+      { dayOfWeek: 1, startTime: "09:00:00", endTime: "12:00:00" },
+      { dayOfWeek: 1, startTime: "13:00:00", endTime: "17:00:00" },
+    ]);
+  });
+});
+
+describe("mapSchedule", () => {
+  it("carries name/timezone/default and its weekly rules", () => {
+    const s = mapSchedule({
+      uri: "u",
+      name: "Working hours",
+      default: true,
+      timezone: "America/New_York",
+      rules: [{ type: "wday", wday: "friday", intervals: [{ from: "09:00", to: "17:00" }] }],
+    });
+    expect(s).toMatchObject({
+      name: "Working hours",
+      timezone: "America/New_York",
+      isDefault: true,
+    });
+    expect(s.rules).toEqual([{ dayOfWeek: 5, startTime: "09:00:00", endTime: "17:00:00" }]);
+  });
+});
+
+describe("shouldImportEventType / mapEventType", () => {
+  const base: CalendlyEventType = {
+    uri: "https://api.calendly.com/event_types/A",
+    name: "Intro Call",
+    slug: "intro-call",
+    duration: 30,
+    active: true,
+    color: "#2d7dff",
+    type: "StandardEventType",
+    secret: false,
+  };
+
+  it("skips ad-hoc and deleted event types", () => {
+    expect(shouldImportEventType(base)).toBe(true);
+    expect(shouldImportEventType({ ...base, type: "AdhocEventType" })).toBe(false);
+    expect(shouldImportEventType({ ...base, deleted_at: "2026-01-01" })).toBe(false);
+  });
+
+  it("maps the core fields", () => {
+    const m = mapEventType(base);
+    expect(m).toMatchObject({
+      title: "Intro Call",
+      slug: "intro-call",
+      durationMinutes: 30,
+      location: "google_meet",
+      color: "sky",
+      isActive: true,
+      isPrivate: false,
+    });
+  });
+
+  it("clamps out-of-range durations and flags secret events private", () => {
+    expect(mapEventType({ ...base, duration: 2 }).durationMinutes).toBe(5);
+    expect(mapEventType({ ...base, duration: 900 }).durationMinutes).toBe(480);
+    expect(mapEventType({ ...base, secret: true }).isPrivate).toBe(true);
+  });
+});

--- a/apps/web/lib/import/calendly.ts
+++ b/apps/web/lib/import/calendly.ts
@@ -1,0 +1,325 @@
+import {
+  type BookingQuestionInput,
+  type LocationTypeValue,
+  NEEDS_DETAIL,
+  type QUESTION_TYPES,
+} from "../booking/event-type-input";
+
+/**
+ * Pure mapping layer: Calendly API v2 shapes → the fields DayOtter stores. Kept
+ * free of any network / DB access so it can be exhaustively unit-tested; the
+ * client (`calendly-client.ts`) and the persistence layer (`run-import.ts`)
+ * wrap it. Only the subset of Calendly's payload we actually use is typed.
+ */
+
+// ---------------------------------------------------------------------------
+// Calendly payload shapes (partial)
+// ---------------------------------------------------------------------------
+
+export interface CalendlyLocation {
+  kind?: string;
+  /** Physical address / custom text location. */
+  location?: string | null;
+  join_url?: string | null;
+  phone_number?: string | null;
+  additional_info?: string | null;
+}
+
+export interface CalendlyCustomQuestion {
+  name: string;
+  /** "string" | "text" | "phone_number" | "single_select" | "multi_select" */
+  type: string;
+  position?: number;
+  enabled?: boolean;
+  required?: boolean;
+  answer_choices?: string[] | null;
+}
+
+export interface CalendlyEventType {
+  uri: string;
+  name: string;
+  active?: boolean;
+  slug?: string | null;
+  duration: number;
+  /** "solo" | "group" */
+  kind?: string | null;
+  /** null | "round_robin" | "collective" - set for team events. */
+  pooling_type?: string | null;
+  /** "StandardEventType" | "AdhocEventType" */
+  type?: string | null;
+  color?: string | null;
+  description_plain?: string | null;
+  secret?: boolean;
+  deleted_at?: string | null;
+  locations?: CalendlyLocation[] | null;
+  custom_questions?: CalendlyCustomQuestion[] | null;
+}
+
+export interface CalendlyAvailabilityRule {
+  /** "wday" | "date" */
+  type: string;
+  /** For wday rules: "sunday" .. "saturday". */
+  wday?: string;
+  /** For date rules: "YYYY-MM-DD". */
+  date?: string;
+  intervals?: { from: string; to: string }[];
+}
+
+export interface CalendlyAvailabilitySchedule {
+  uri: string;
+  name?: string | null;
+  default?: boolean;
+  timezone?: string | null;
+  rules?: CalendlyAvailabilityRule[] | null;
+}
+
+// ---------------------------------------------------------------------------
+// Mapped (DayOtter-shaped) results
+// ---------------------------------------------------------------------------
+
+export interface MappedEventType {
+  title: string;
+  slug: string;
+  durationMinutes: number;
+  description?: string;
+  location: LocationTypeValue;
+  locationDetail?: string;
+  color: string | null;
+  isActive: boolean;
+  isPrivate: boolean;
+  questions: BookingQuestionInput[];
+}
+
+export interface MappedRule {
+  dayOfWeek: number;
+  startTime: string;
+  endTime: string;
+}
+
+export interface MappedSchedule {
+  name: string;
+  timezone: string;
+  isDefault: boolean;
+  rules: MappedRule[];
+}
+
+// ---------------------------------------------------------------------------
+// Field mappers
+// ---------------------------------------------------------------------------
+
+/** Slugify to our `^[a-z0-9-]+$` (max 60), never empty. */
+export function toEventSlug(input: string | null | undefined): string {
+  const s = (input ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60)
+    .replace(/-+$/g, "");
+  return s || "event";
+}
+
+const WDAY: Record<string, number> = {
+  sunday: 0,
+  monday: 1,
+  tuesday: 2,
+  wednesday: 3,
+  thursday: 4,
+  friday: 5,
+  saturday: 6,
+};
+
+/**
+ * Bucket a Calendly hex colour into one of our five colour tokens by hue, so
+ * imported event types keep some visual variety. Unknown / invalid → null (the
+ * app then renders the default). Pure and deterministic.
+ */
+export function hexToColorToken(hex: string | null | undefined): string | null {
+  if (!hex) return null;
+  const m = /^#?([0-9a-f]{6})$/i.exec(hex.trim());
+  if (!m) return null;
+  const int = Number.parseInt(m[1]!, 16);
+  const r = (int >> 16) & 0xff;
+  const g = (int >> 8) & 0xff;
+  const b = int & 0xff;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const d = max - min;
+  if (d < 12) return null; // near-grey: no meaningful hue
+  let h: number;
+  if (max === r) h = (((g - b) / d) % 6) * 60;
+  else if (max === g) h = ((b - r) / d + 2) * 60;
+  else h = ((r - g) / d + 4) * 60;
+  if (h < 0) h += 360;
+  // Hue buckets → tokens (violet/mint/amber/coral/sky).
+  if (h < 45 || h >= 320) return "coral";
+  if (h < 70) return "amber";
+  if (h < 170) return "mint";
+  if (h < 250) return "sky";
+  return "violet";
+}
+
+/** Map Calendly's location list to our (location, detail). Falls back to a safe,
+ *  non-empty detail for detail-requiring types so the imported record is valid. */
+export function mapLocation(locations: CalendlyLocation[] | null | undefined): {
+  location: LocationTypeValue;
+  locationDetail?: string;
+} {
+  const loc = locations?.[0];
+  const kind = loc?.kind ?? "";
+  let location: LocationTypeValue;
+  let detail: string | undefined;
+
+  switch (kind) {
+    case "google_conference":
+      location = "google_meet";
+      break;
+    case "microsoft_teams_conference":
+      location = "ms_teams";
+      break;
+    case "zoom_conference":
+      location = "zoom";
+      detail = loc?.join_url ?? loc?.location ?? undefined;
+      break;
+    case "physical":
+    case "custom":
+      location = kind === "physical" ? "in_person" : "custom";
+      detail = loc?.location ?? loc?.additional_info ?? undefined;
+      break;
+    case "outbound_call":
+      location = "phone";
+      detail = "The host will call you.";
+      break;
+    case "inbound_call":
+      location = "phone";
+      detail = loc?.phone_number ?? "Call the host.";
+      break;
+    case "ask_invitee":
+      location = "phone";
+      detail = "You'll provide a number when booking.";
+      break;
+    case "gotomeeting_conference":
+    case "webex_conference":
+      location = "custom";
+      detail = loc?.join_url ?? loc?.location ?? kind.replace(/_/g, " ");
+      break;
+    default:
+      // No/unknown location → our default auto-conference type.
+      location = "google_meet";
+  }
+
+  // Detail-requiring types must carry a non-empty detail to stay editable.
+  if (NEEDS_DETAIL.includes(location) && !detail?.trim()) {
+    detail =
+      location === "zoom"
+        ? "Add your Zoom link"
+        : location === "in_person"
+          ? "Location to be confirmed"
+          : location === "phone"
+            ? "Phone details to be confirmed"
+            : "Details to be confirmed";
+  }
+  return { location, locationDetail: detail };
+}
+
+const QUESTION_TYPE_MAP: Record<string, (typeof QUESTION_TYPES)[number]> = {
+  string: "text",
+  text: "textarea",
+  phone_number: "phone",
+  single_select: "select",
+  multi_select: "select",
+};
+
+/** Map Calendly custom questions to our booking-question shape (max 20). */
+export function mapQuestions(
+  questions: CalendlyCustomQuestion[] | null | undefined,
+): BookingQuestionInput[] {
+  if (!questions) return [];
+  const out: BookingQuestionInput[] = [];
+  for (const q of questions) {
+    if (q.enabled === false) continue;
+    const type = QUESTION_TYPE_MAP[q.type] ?? "text";
+    const label = (q.name ?? "").trim().slice(0, 200);
+    if (!label) continue;
+    const options =
+      type === "select"
+        ? (q.answer_choices ?? [])
+            .map((c) => c.slice(0, 120))
+            .filter(Boolean)
+            .slice(0, 20)
+        : undefined;
+    out.push({
+      id: `q${out.length + 1}`,
+      label,
+      type,
+      required: Boolean(q.required),
+      ...(options && options.length > 0 ? { options } : {}),
+    });
+    if (out.length >= 20) break;
+  }
+  return out;
+}
+
+const clamp = (n: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, n));
+
+/** True when a Calendly event type is worth importing (skip ad-hoc / deleted). */
+export function shouldImportEventType(et: CalendlyEventType): boolean {
+  if (et.deleted_at) return false;
+  if (et.type === "AdhocEventType") return false;
+  return true;
+}
+
+/** Map a Calendly event type to our event-type insert fields. */
+export function mapEventType(et: CalendlyEventType): MappedEventType {
+  const { location, locationDetail } = mapLocation(et.locations);
+  const description = et.description_plain?.trim().slice(0, 2000) || undefined;
+  return {
+    title: (et.name ?? "Untitled").trim().slice(0, 120) || "Untitled",
+    slug: toEventSlug(et.slug || et.name),
+    durationMinutes: clamp(Math.round(et.duration ?? 30), 5, 480),
+    description,
+    location,
+    locationDetail,
+    color: hexToColorToken(et.color),
+    isActive: et.active !== false,
+    isPrivate: Boolean(et.secret),
+    questions: mapQuestions(et.custom_questions),
+  };
+}
+
+/** Map a Calendly availability schedule's weekly (wday) rules to our rules. Date
+ *  overrides are skipped in this first version. */
+export function mapScheduleRules(
+  rules: CalendlyAvailabilityRule[] | null | undefined,
+): MappedRule[] {
+  const out: MappedRule[] = [];
+  for (const rule of rules ?? []) {
+    if (rule.type !== "wday" || rule.wday == null) continue;
+    const dayOfWeek = WDAY[rule.wday.toLowerCase()];
+    if (dayOfWeek == null) continue;
+    for (const interval of rule.intervals ?? []) {
+      const startTime = toTime(interval.from);
+      const endTime = toTime(interval.to);
+      if (startTime && endTime) out.push({ dayOfWeek, startTime, endTime });
+    }
+  }
+  return out;
+}
+
+/** Normalise a Calendly "HH:MM" (or "HH:MM:SS") to our "HH:MM:SS" time literal. */
+function toTime(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const m = /^(\d{1,2}):(\d{2})(?::(\d{2}))?$/.exec(value.trim());
+  if (!m) return null;
+  const h = String(Math.min(23, Number(m[1]))).padStart(2, "0");
+  return `${h}:${m[2]}:${m[3] ?? "00"}`;
+}
+
+/** Map a Calendly availability schedule to our schedule + rules shape. */
+export function mapSchedule(s: CalendlyAvailabilitySchedule): MappedSchedule {
+  return {
+    name: (s.name ?? "Imported schedule").trim().slice(0, 80) || "Imported schedule",
+    timezone: s.timezone?.trim() || "UTC",
+    isDefault: Boolean(s.default),
+    rules: mapScheduleRules(s.rules),
+  };
+}

--- a/apps/web/lib/import/run-import.ts
+++ b/apps/web/lib/import/run-import.ts
@@ -1,0 +1,149 @@
+import { notPersonalType } from "@/lib/booking/personal-event-type";
+import { ensureUserWorkspace } from "@/lib/bootstrap";
+import { logger } from "@dayotter/core";
+import { and, eq, getDb, schema } from "@dayotter/db";
+import { mapEventType, mapSchedule, shouldImportEventType } from "./calendly";
+import type { RawCalendlyExport } from "./calendly-client";
+
+export interface ImportSummary {
+  /** Display name of the imported Calendly account. */
+  account: string;
+  eventTypesImported: number;
+  eventTypesSkipped: number;
+  schedulesImported: number;
+  rulesImported: number;
+  /** Human-readable notes about anything that wasn't a clean 1:1 import. */
+  warnings: string[];
+}
+
+/** Suffix a slug until it's unique among the already-taken set. */
+function uniqueSlug(base: string, taken: Set<string>): string {
+  if (!taken.has(base)) return base;
+  for (let i = 2; i < 1000; i++) {
+    const candidate = `${base.slice(0, 56)}-${i}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+  return `${base.slice(0, 50)}-${Date.now()}`;
+}
+
+/**
+ * Persist a fetched Calendly export into the user's DayOtter workspace: recreate
+ * their availability schedules and event types. Idempotent-ish - re-running
+ * imports again under de-duplicated slugs rather than overwriting, so it never
+ * clobbers existing DayOtter data (imported schedules are added, never made the
+ * default; event types with a colliding slug get a `-2` suffix).
+ */
+export async function importCalendlyExport(
+  userId: string,
+  data: RawCalendlyExport,
+): Promise<ImportSummary> {
+  const db = getDb();
+  const { organizationId, scheduleId: defaultScheduleId } = await ensureUserWorkspace(userId);
+
+  const warnings: string[] = [];
+
+  // 1. Availability schedules (only those with real weekly rules). We add them
+  //    as named schedules and never flip the user's existing default.
+  let schedulesImported = 0;
+  let rulesImported = 0;
+  let importedDefaultScheduleId: string | null = null;
+
+  for (const raw of data.schedules) {
+    const mapped = mapSchedule(raw);
+    if (mapped.rules.length === 0) continue;
+    const [created] = await db
+      .insert(schema.schedules)
+      .values({
+        userId,
+        name: mapped.name,
+        timezone: mapped.timezone,
+        isDefault: false,
+      })
+      .returning();
+    if (!created) continue;
+    await db.insert(schema.availabilityRules).values(
+      mapped.rules.map((r) => ({
+        scheduleId: created.id,
+        dayOfWeek: r.dayOfWeek,
+        startTime: r.startTime,
+        endTime: r.endTime,
+      })),
+    );
+    schedulesImported++;
+    rulesImported += mapped.rules.length;
+    if (mapped.isDefault && !importedDefaultScheduleId) importedDefaultScheduleId = created.id;
+  }
+
+  // Event types point at the imported "default" schedule when we recreated one,
+  // so bookings honour the availability the user actually had on Calendly;
+  // otherwise they fall back to the DayOtter default schedule.
+  const targetScheduleId = importedDefaultScheduleId ?? defaultScheduleId;
+
+  // 2. Event types. Dedupe slugs against the user's existing ones + this run.
+  const existing = await db.query.eventTypes.findMany({
+    where: and(eq(schema.eventTypes.ownerId, userId), notPersonalType),
+    columns: { slug: true },
+  });
+  const takenSlugs = new Set(existing.map((e) => e.slug));
+
+  let eventTypesImported = 0;
+  let eventTypesSkipped = 0;
+
+  for (const raw of data.eventTypes) {
+    if (!shouldImportEventType(raw)) {
+      eventTypesSkipped++;
+      continue;
+    }
+    const m = mapEventType(raw);
+    const slug = uniqueSlug(m.slug, takenSlugs);
+    takenSlugs.add(slug);
+
+    if (raw.pooling_type) {
+      warnings.push(
+        `"${m.title}" was a Calendly team event - imported as a personal event type you host.`,
+      );
+    }
+
+    try {
+      await db.insert(schema.eventTypes).values({
+        organizationId,
+        ownerId: userId,
+        scheduleId: targetScheduleId,
+        title: m.title,
+        slug,
+        durationMinutes: m.durationMinutes,
+        description: m.description,
+        location: m.location,
+        locationDetail: m.locationDetail,
+        color: m.color,
+        isActive: m.isActive,
+        isPrivate: m.isPrivate,
+        questions: m.questions,
+      });
+      eventTypesImported++;
+    } catch (err) {
+      eventTypesSkipped++;
+      logger.error("calendly event type import failed", {
+        event: "calendly_import_event_type_failed",
+        title: m.title,
+        err,
+      });
+    }
+  }
+
+  logger.info("calendly import complete", {
+    event: "calendly_import_complete",
+    userId,
+    eventTypesImported,
+    schedulesImported,
+  });
+
+  return {
+    account: data.user.name || "your Calendly account",
+    eventTypesImported,
+    eventTypesSkipped,
+    schedulesImported,
+    rulesImported,
+    warnings,
+  };
+}


### PR DESCRIPTION
One-step migration for switchers — the biggest adoption lever on the roadmap. Paste a Calendly **Personal Access Token** and DayOtter recreates your **event types** and **weekly availability**. Read-only against Calendly; existing DayOtter data is never overwritten.

## Architecture (layered so the core is exhaustively testable)
- **`lib/import/calendly.ts`** — pure mapper, **17 unit tests**. Maps Calendly event types (name/slug/duration, location kinds → ours, hex colour → nearest colour token by hue, custom questions, `secret`→private, active flag) and availability schedules (weekly `wday` rules → our rules; date overrides skipped in v1).
- **`lib/import/calendly-client.ts`** — reads `/users/me`, `/event_types` (cursor-paginated), `/user_availability_schedules` with a Bearer PAT; `401 → CalendlyAuthError`; 15s timeout.
- **`lib/import/run-import.ts`** — persistence. Schedules are added as **named** schedules (never flips the user's default); event types are **slug-deduped** and pointed at the imported default schedule so availability carries over. Returns a summary + warnings.
- **`POST /api/import/calendly`** — host-only, rate-limited. The token is used once for the request and **never stored**.
- **Settings → Import** page + client UI: paste token, run, see a summary (imported / skipped / warnings).

## Verification
- **111 web tests pass** (17 new mapper tests); web typecheck + biome clean.
- **Live import smoke against a dev DB**: imported 2 event types (google_meet + `sky` colour + mapped question; in-person + address; 900→480 duration clamp; secret→private; inactive), **skipped** an ad-hoc type, surfaced the round-robin **team-event warning**, created a schedule with both Monday intervals (Sunday-off + a date rule correctly skipped), pointed event types at the imported schedule, and **cleaned up with no leaked rows**.

## Follow-up (not in scope)
Date-specific availability overrides, per-event-type schedule links, and optionally importing upcoming bookings.

Closes #115.