### PR TITLE
fix(security): harden Calendly import, CalDAV egress, public booking input

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,12 @@ NEXT_PUBLIC_GOOGLE_AUTH=
 MICROSOFT_CLIENT_ID=
 MICROSOFT_CLIENT_SECRET=
 
+# ---- CalDAV (Apple iCloud + generic) ----
+# Custom (non-iCloud) CalDAV servers are restricted to an allowlist to prevent
+# SSRF. Managed providers (iCloud, Fastmail, Mailbox.org, ...) are allowed by
+# default; add any self-hosted hosts (Nextcloud, Baïkal, ...) here, comma-separated.
+CALDAV_ALLOWED_HOSTS=
+
 # ---- Zoom integration (optional) ----
 # Auto-creates a Zoom meeting for "zoom" event types when a host connects Zoom.
 # Hidden entirely when unset. Register a Zoom OAuth app with redirect

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ GoogleService-Info.plist
 
 # test
 coverage/
+
+# Local security audit notes (not for the public repo)
+SECURITY-AUDIT.md

--- a/apps/web/app/api/book/route.ts
+++ b/apps/web/app/api/book/route.ts
@@ -21,7 +21,16 @@ const schema = z.object({
   }),
   guests: z.array(z.string().email()).max(10).optional(),
   notes: z.string().max(2000).optional(),
-  responses: z.record(z.unknown()).optional(),
+  // Intake answers, keyed by question id. Bounded so an unauthenticated caller
+  // can't persist a multi-MB blob into bookings.responses: at most 50 answers,
+  // each a short string / boolean / small string[] (matches BookingQuestion types).
+  responses: z
+    .record(
+      z.string().max(64),
+      z.union([z.string().max(5000), z.boolean(), z.array(z.string().max(500)).max(50)]),
+    )
+    .refine((r) => Object.keys(r).length <= 50, { message: "Too many responses" })
+    .optional(),
   durationMinutes: z.number().int().min(5).max(1440).optional(),
   captchaToken: z.string().max(4000).optional(),
   /** Single-use booking-link token, if the booker came through one. */

--- a/apps/web/lib/import/calendly-client.ts
+++ b/apps/web/lib/import/calendly-client.ts
@@ -1,7 +1,13 @@
 import type { CalendlyAvailabilitySchedule, CalendlyEventType } from "./calendly";
 
 const CALENDLY_API = "https://api.calendly.com";
+const CALENDLY_ORIGIN = "https://api.calendly.com/";
 const TIMEOUT_MS = 15_000;
+/** Hard cap on any single page body (defends against a huge/hostile response). */
+const MAX_BODY_BYTES = 5 * 1024 * 1024;
+/** Cap on items pulled per resource, so one import can't commit unbounded rows. */
+export const MAX_EVENT_TYPES = 200;
+export const MAX_SCHEDULES = 50;
 
 /** Thrown when Calendly rejects the token (401) - surfaced to the user distinctly. */
 export class CalendlyAuthError extends Error {
@@ -23,36 +29,65 @@ interface Paginated<T> {
   pagination?: { next_page?: string | null };
 }
 
+/** Read a response body with a hard byte ceiling, aborting past the cap. */
+async function readCapped(res: Response): Promise<string> {
+  const reader = res.body?.getReader();
+  if (!reader) return res.text();
+  const decoder = new TextDecoder();
+  let text = "";
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) {
+      total += value.byteLength;
+      if (total > MAX_BODY_BYTES) {
+        await reader.cancel().catch(() => {});
+        throw new Error("Calendly response too large");
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+  }
+  return text + decoder.decode();
+}
+
 async function cget<T>(token: string, url: string): Promise<T> {
+  // Only ever talk to Calendly. The first URL is a constant; `next_page` comes
+  // from the response body, so pin it to Calendly's origin and refuse redirects
+  // - otherwise a bad/redirecting URL could carry the Bearer token off-host.
+  if (!url.startsWith(CALENDLY_ORIGIN)) {
+    throw new Error("Refusing to fetch a non-Calendly URL");
+  }
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
   try {
     const res = await fetch(url, {
       headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
       signal: controller.signal,
+      redirect: "error",
     });
     if (res.status === 401) throw new CalendlyAuthError();
     if (!res.ok) {
       const detail = await res.text().catch(() => "");
       throw new Error(`Calendly ${res.status}: ${detail.slice(0, 200)}`);
     }
-    return (await res.json()) as T;
+    return JSON.parse(await readCapped(res)) as T;
   } finally {
     clearTimeout(timer);
   }
 }
 
-/** Follow Calendly's cursor pagination, concatenating every page's collection. */
-async function collectAll<T>(token: string, firstUrl: string): Promise<T[]> {
+/** Follow Calendly's cursor pagination, concatenating pages up to `limit` items. */
+async function collectAll<T>(token: string, firstUrl: string, limit: number): Promise<T[]> {
   const out: T[] = [];
   let next: string | null | undefined = firstUrl;
-  // Guard against a pathological pagination loop.
-  for (let page = 0; next && page < 50; page++) {
+  // Bounded by both a page cap (loop guard) and the item cap (`limit`).
+  for (let page = 0; next && page < 50 && out.length < limit; page++) {
     const data: Paginated<T> = await cget<Paginated<T>>(token, next);
     out.push(...(data.collection ?? []));
     next = data.pagination?.next_page ?? null;
   }
-  return out;
+  return out.slice(0, limit);
 }
 
 /**
@@ -70,10 +105,12 @@ export async function fetchCalendlyExport(token: string): Promise<RawCalendlyExp
   const eventTypes = await collectAll<CalendlyEventType>(
     token,
     `${CALENDLY_API}/event_types?user=${userParam}&count=100`,
+    MAX_EVENT_TYPES,
   );
   const schedules = await collectAll<CalendlyAvailabilitySchedule>(
     token,
     `${CALENDLY_API}/user_availability_schedules?user=${userParam}`,
+    MAX_SCHEDULES,
   );
 
   return { user: { name: me.resource.name ?? "", uri: userUri }, eventTypes, schedules };

--- a/apps/web/lib/import/run-import.ts
+++ b/apps/web/lib/import/run-import.ts
@@ -3,7 +3,7 @@ import { ensureUserWorkspace } from "@/lib/bootstrap";
 import { logger } from "@dayotter/core";
 import { and, eq, getDb, schema } from "@dayotter/db";
 import { mapEventType, mapSchedule, shouldImportEventType } from "./calendly";
-import type { RawCalendlyExport } from "./calendly-client";
+import { MAX_EVENT_TYPES, type RawCalendlyExport } from "./calendly-client";
 
 export interface ImportSummary {
   /** Display name of the imported Calendly account. */
@@ -41,6 +41,11 @@ export async function importCalendlyExport(
   const { organizationId, scheduleId: defaultScheduleId } = await ensureUserWorkspace(userId);
 
   const warnings: string[] = [];
+  if (data.eventTypes.length >= MAX_EVENT_TYPES) {
+    warnings.push(
+      `Import is capped at ${MAX_EVENT_TYPES} event types per run - only the first ${MAX_EVENT_TYPES} were brought in.`,
+    );
+  }
 
   // 1. Availability schedules (only those with real weekly rules). We add them
   //    as named schedules and never flip the user's existing default. Names are

--- a/packages/calendar/src/providers/apple.ts
+++ b/packages/calendar/src/providers/apple.ts
@@ -27,6 +27,43 @@ const ICLOUD_CALDAV = "https://caldav.icloud.com";
  * connects, so this is check-then-use, not a hard IP pin - good enough here since
  * the credentials are the user's own, but keep it in mind.
  */
+/**
+ * Well-known managed CalDAV hosts allowed by default. Self-hosted servers
+ * (Nextcloud, Baïkal, Radicale, ...) are added by the deployer via
+ * `CALDAV_ALLOWED_HOSTS` (comma-separated hostnames / parent domains).
+ */
+const DEFAULT_CALDAV_HOSTS = [
+  "icloud.com",
+  "me.com",
+  "mac.com",
+  "fastmail.com",
+  "messagingengine.com",
+  "mailbox.org",
+  "posteo.de",
+  "posteo.net",
+  "gmx.net",
+  "web.de",
+  "zoho.com",
+  "yahoo.com",
+];
+
+function allowedCaldavHosts(): string[] {
+  const extra = (process.env.CALDAV_ALLOWED_HOSTS ?? "")
+    .split(",")
+    .map((h) => h.trim().toLowerCase())
+    .filter(Boolean);
+  return [...DEFAULT_CALDAV_HOSTS, ...extra];
+}
+
+/**
+ * Validate a user-supplied CalDAV server URL. We resolve-and-reject internal IPs,
+ * but `tsdav` re-resolves DNS at connect time (check-then-use), so that alone is
+ * defeatable by DNS rebinding. The load-bearing control is therefore a HOST
+ * ALLOWLIST - only well-known managed providers (plus any the deployer adds via
+ * CALDAV_ALLOWED_HOSTS) may be reached, which closes the SSRF regardless of what
+ * DNS returns later. Default iCloud connections don't pass a serverUrl and skip
+ * this entirely.
+ */
 async function assertPublicHttpsUrl(raw: string): Promise<void> {
   let url: URL;
   try {
@@ -35,8 +72,17 @@ async function assertPublicHttpsUrl(raw: string): Promise<void> {
     throw new Error("Invalid CalDAV server URL");
   }
   if (url.protocol !== "https:") throw new Error("CalDAV server URL must use https");
+
+  const host = url.hostname.toLowerCase();
+  const allowed = allowedCaldavHosts().some((h) => host === h || host.endsWith(`.${h}`));
+  if (!allowed) {
+    throw new Error(
+      "That CalDAV host isn't on the allowed list. Ask your admin to add it to CALDAV_ALLOWED_HOSTS.",
+    );
+  }
+
   try {
-    await resolvePublicIp(url.hostname); // throws if it resolves to an internal IP
+    await resolvePublicIp(url.hostname); // belt-and-braces: still reject internal IPs
   } catch {
     throw new Error("CalDAV server URL points at a disallowed (internal) host");
   }


### PR DESCRIPTION
Security-audit follow-ups from a review of the last 20 PRs. The audit found **no auth/IDOR, SQLi, stored-XSS, or secret-leak issues**; this PR closes the SSRF and DoS gaps it did find.

## CalDAV SSRF (MEDIUM) — [apple.ts](packages/calendar/src/providers/apple.ts)
PR #82's "SSRF hardening" validated the user-supplied `serverUrl` with a DNS resolve-and-reject, but `tsdav` re-resolves DNS at connect time — a check-then-use that's defeatable by **DNS rebinding** to an internal host (169.254.169.254, localhost), reachable by any authenticated user. Since tsdav owns its socket and can't be IP-pinned, the fix adds a **host allowlist** as the load-bearing control: only well-known managed providers plus hosts a deployer adds via `CALDAV_ALLOWED_HOSTS` are reachable. Default iCloud connections (no `serverUrl`) are unaffected. Verified it rejects metadata IPs, localhost, `http://`, and suffix-confusion hosts (`noticloud.com.evil.com`) while allowing provider subdomains and env-added hosts.

## Calendly import DoS (HIGH) — [calendly-client.ts](apps/web/lib/import/calendly-client.ts)
- **Total-row cap**: pull at most 200 event types / 50 schedules per import, so one request can't commit thousands of rows (there's no per-user event-type quota).
- **Response byte ceiling**: 5 MB streamed cap, aborting past it.
- **Origin pin + `redirect:"error"`**: the paginated `next_page` comes from the response body — pin every fetch to `api.calendly.com` and refuse redirects so the Bearer token can't leak off-host.
- run-import surfaces a warning when truncated.

## Public booking input DoS (MED-HIGH) — [book/route.ts](apps/web/app/api/book/route.ts)
`responses` was `z.record(z.unknown())` (unbounded) and persisted verbatim from the **unauthenticated** `/api/book`. Now bounded to ≤50 answers, each a short string / boolean / small string[].

## Verified
web + calendar typecheck; **111 web tests**; biome clean; allowlist logic sanity-checked against SSRF payloads. `CALDAV_ALLOWED_HOSTS` documented in `.env.example`.

Remaining lower-severity items (access-code hashing, rate limits on write-heavy routes, email CRLF/scheme hardening) are being filed as tracked issues.