### PR TITLE
perf(booking): parallelize recurring finalize, dedupe prefs read, batch import

### DIFF
--- a/apps/web/lib/booking/create-booking.ts
+++ b/apps/web/lib/booking/create-booking.ts
@@ -65,6 +65,11 @@ async function resolveHost(
   if (free.length === 0) throw new BookingError("No host available at that time", 409);
 
   // One grouped query for all free hosts' current load (was N queries).
+  // "Current load" for round-robin fairness = recent + upcoming meetings, not
+  // every booking the host has ever had. Windowing keeps this from scanning an
+  // unbounded history as hosts accrue bookings (and matches the intent - a
+  // meeting from two years ago shouldn't tilt today's assignment).
+  const loadWindowStart = new Date(Date.now() - 30 * 86_400_000);
   const loads = await db
     .select({ hostId: schema.bookings.hostId, count: sql<number>`count(*)::int` })
     .from(schema.bookings)
@@ -75,6 +80,7 @@ async function resolveHost(
           free.map((h) => h.userId),
         ),
         eq(schema.bookings.status, "confirmed"),
+        gte(schema.bookings.startsAt, loadWindowStart),
       ),
     )
     .groupBy(schema.bookings.hostId);

--- a/apps/web/lib/booking/finalize-booking.ts
+++ b/apps/web/lib/booking/finalize-booking.ts
@@ -9,9 +9,7 @@ import { createZoomMeeting } from "../integrations/zoom";
 import { AUTO_CONFERENCE } from "./event-type-input";
 import { fanOutBookingLifecycle } from "./lifecycle";
 import {
-  hostWantsOverflowNotice,
-  hostWantsScribe,
-  reminderOffsetsForHost,
+  hostBookingPrefs,
   scheduleBookingReminders,
   scheduleOverflowCheck,
   scheduleScribe,
@@ -146,14 +144,12 @@ export async function finalizeConfirmedBooking(ctx: FinalizeContext): Promise<vo
     await db.update(schema.bookings).set({ meetingUrl }).where(eq(schema.bookings.id, booking.id));
   }
 
-  // Host opt-ins (computed once; reused for the recurring occurrences below).
-  const [wantsOverflow, wantsScribe] = await Promise.all([
-    hostWantsOverflowNotice(host.id),
-    hostWantsScribe(host.id),
-  ]);
+  // Host opt-ins + reminder offsets in ONE read (reused for the recurring
+  // occurrences below), instead of three separate userPreferences lookups.
+  const { wantsOverflow, wantsScribe, reminderOffsets } = await hostBookingPrefs(host.id);
 
   // Schedule reminders at the host's preferred lead times.
-  await scheduleBookingReminders(booking.id, start, await reminderOffsetsForHost(host.id));
+  await scheduleBookingReminders(booking.id, start, reminderOffsets);
 
   // Proactive overflow: if the host opted in, schedule an end-of-meeting check
   // that auto-notifies a back-to-back next meeting when this one runs over.
@@ -236,12 +232,11 @@ export async function finalizeConfirmedBooking(ctx: FinalizeContext): Promise<vo
   if (isRecurring) {
     const zone = attendee.timezone || host.timezone || "UTC";
     const base = DateTime.fromJSDate(start).setZone(zone);
-    const offsets = await reminderOffsetsForHost(host.id);
     const attendeeList = [
       { email: attendee.email, name: attendee.name },
       ...guests.map((email) => ({ email })),
     ];
-    for (let i = 1; i < recurringCount; i++) {
+    const finalizeOccurrence = async (i: number): Promise<void> => {
       const occStart =
         eventType.recurringFrequency === "monthly"
           ? base.plus({ months: i }).toJSDate()
@@ -269,7 +264,7 @@ export async function finalizeConfirmedBooking(ctx: FinalizeContext): Promise<vo
             recurrenceUid,
           })
           .returning();
-        if (!occ) continue;
+        if (!occ) return;
         await db.insert(schema.bookingAttendees).values([
           {
             bookingId: occ.id,
@@ -279,7 +274,7 @@ export async function finalizeConfirmedBooking(ctx: FinalizeContext): Promise<vo
           },
           ...guests.map((email) => ({ bookingId: occ.id, email })),
         ]);
-        await scheduleBookingReminders(occ.id, occStart, offsets);
+        await scheduleBookingReminders(occ.id, occStart, reminderOffsets);
         const written = await writeBookingToCalendar(host.id, {
           title: eventType.title,
           description: notes ?? undefined,
@@ -361,6 +356,15 @@ export async function finalizeConfirmedBooking(ctx: FinalizeContext): Promise<vo
           err,
         });
       }
+    };
+
+    // Occurrences are independent; run them in bounded-concurrency chunks so a
+    // long series doesn't serialize ~50 × (calendar write + fan-out) on the
+    // request path - while not firing all 51 calendar writes at once.
+    const CONCURRENCY = 4;
+    const indices = Array.from({ length: recurringCount - 1 }, (_, k) => k + 1);
+    for (let c = 0; c < indices.length; c += CONCURRENCY) {
+      await Promise.all(indices.slice(c, c + CONCURRENCY).map(finalizeOccurrence));
     }
   }
 }

--- a/apps/web/lib/booking/reminders.ts
+++ b/apps/web/lib/booking/reminders.ts
@@ -177,6 +177,33 @@ export async function hostWantsOverflowNotice(userId: string): Promise<boolean> 
   return prefs?.overflowNotifyEnabled ?? false;
 }
 
+export interface HostBookingPrefs {
+  wantsOverflow: boolean;
+  wantsScribe: boolean;
+  reminderOffsets: number[];
+}
+
+/**
+ * The host preferences the booking-finalize path needs, in ONE read instead of
+ * three separate `userPreferences` lookups for the same row.
+ */
+export async function hostBookingPrefs(userId: string): Promise<HostBookingPrefs> {
+  const prefs = await getDb().query.userPreferences.findFirst({
+    where: eq(schema.userPreferences.userId, userId),
+    columns: {
+      overflowNotifyEnabled: true,
+      scribeEnabled: true,
+      defaultReminderOffsets: true,
+    },
+  });
+  const offsets = prefs?.defaultReminderOffsets;
+  return {
+    wantsOverflow: prefs?.overflowNotifyEnabled ?? false,
+    wantsScribe: prefs?.scribeEnabled ?? false,
+    reminderOffsets: offsets && offsets.length > 0 ? offsets : [...DEFAULT_REMINDER_OFFSETS],
+  };
+}
+
 /** Whether the host has opted into the post-meeting recap ("Scribe"). */
 export async function hostWantsScribe(userId: string): Promise<boolean> {
   const prefs = await getDb().query.userPreferences.findFirst({

--- a/apps/web/lib/import/run-import.ts
+++ b/apps/web/lib/import/run-import.ts
@@ -101,9 +101,11 @@ export async function importCalendlyExport(
   });
   const takenSlugs = new Set(existing.map((e) => e.slug));
 
-  let eventTypesImported = 0;
   let eventTypesSkipped = 0;
 
+  // Build the insert rows in one pass (slug dedup is in-memory), then insert them
+  // in a single batch instead of a round-trip per event type.
+  const rows: (typeof schema.eventTypes.$inferInsert)[] = [];
   for (const raw of data.eventTypes) {
     if (!shouldImportEventType(raw)) {
       eventTypesSkipped++;
@@ -124,30 +126,48 @@ export async function importCalendlyExport(
       );
     }
 
+    rows.push({
+      organizationId,
+      ownerId: userId,
+      scheduleId: targetScheduleId,
+      title: m.title,
+      slug,
+      durationMinutes: m.durationMinutes,
+      description: m.description,
+      location: m.location,
+      locationDetail: m.locationDetail,
+      color: m.color,
+      isActive: m.isActive,
+      isPrivate: m.isPrivate,
+      questions: m.questions,
+    });
+  }
+
+  let eventTypesImported = 0;
+  if (rows.length > 0) {
     try {
-      await db.insert(schema.eventTypes).values({
-        organizationId,
-        ownerId: userId,
-        scheduleId: targetScheduleId,
-        title: m.title,
-        slug,
-        durationMinutes: m.durationMinutes,
-        description: m.description,
-        location: m.location,
-        locationDetail: m.locationDetail,
-        color: m.color,
-        isActive: m.isActive,
-        isPrivate: m.isPrivate,
-        questions: m.questions,
-      });
-      eventTypesImported++;
+      await db.insert(schema.eventTypes).values(rows);
+      eventTypesImported = rows.length;
     } catch (err) {
-      eventTypesSkipped++;
-      logger.error("calendly event type import failed", {
-        event: "calendly_import_event_type_failed",
-        title: m.title,
+      // A batch failure (unexpected - slugs are pre-deduped) shouldn't sink the
+      // whole import; retry per row so one bad row is isolated and attributable.
+      logger.warn("calendly batch insert failed; falling back to per-row", {
+        event: "calendly_import_batch_fallback",
         err,
       });
+      for (const r of rows) {
+        try {
+          await db.insert(schema.eventTypes).values(r);
+          eventTypesImported++;
+        } catch (rowErr) {
+          eventTypesSkipped++;
+          logger.error("calendly event type import failed", {
+            event: "calendly_import_event_type_failed",
+            title: r.title,
+            err: rowErr,
+          });
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Optimization follow-ups from the last-20-PR audit (the "unoptimized code" half).

- **Recurring expansion** ([finalize-booking.ts](apps/web/lib/booking/finalize-booking.ts)) ran up to **51 occurrences fully sequentially** — each ~2 external calls (calendar write + lifecycle fan-out) + ~6 DB writes — on the **synchronous booking response path**, so a weekly-for-a-year booking stalled the HTTP response for seconds. Now runs in **bounded-concurrency chunks (4 at a time)**: independent occurrences overlap, without firing all ~51 calendar writes simultaneously.
- **`user_preferences` read 3×/booking** (overflow + scribe + reminder offsets) → folded into one `hostBookingPrefs` read, and the offsets are reused for the recurring occurrences (was a 4th read).
- **Calendly import** ([run-import.ts](apps/web/lib/import/run-import.ts)) inserted event types **one-at-a-time** → single **batched insert**, with per-row fallback only if the batch fails (keeps a bad row isolated + attributable).
- **Round-robin host-load count** ([create-booking.ts](apps/web/lib/booking/create-booking.ts)) scanned a host's **entire booking history** → windowed to the last 30 days (recent load is what fairness should weigh; also bounds the scan).

## Verified
web typecheck + **111 tests** + biome clean. **Live import smoke** against a dev DB confirmed the batched insert imports the right rows (adhoc skipped, group warning surfaced, schedule created) and cleans up. Recurring-finalize refactor preserves the exact per-occurrence body (verified by reading; `continue`→`return` for the function form).