### PR TITLE
docs(marketing): DayOtter Android app is live on Google Play

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,11 @@ We think the assistant that reads your calendar and acts on your time is exactly
 
 **Platform** · multi-channel reminders (email, Slack, WhatsApp, SMS, push) · automations & workflows · API keys & webhooks · mobile app (Expo, iOS + Android)
 
-## Mobile app (in progress)
+## Mobile app
 
-A native **iOS + Android** app (`apps/mobile`, built with Expo/React Native) is in active development. It already covers the day-to-day host workflow - dashboard, bookings, availability, event types, calendars, insights, reminders/channels, automations, workflows, and preferences - with voice input for Otter. Remaining screens (payouts, packages, polls, routing) are tracked in [`docs/TASKS.md`](./docs/TASKS.md).
+The **Android app is live on Google Play**: **[play.google.com/store/apps/details?id=com.dayotter.app](https://play.google.com/store/apps/details?id=com.dayotter.app)**. The **iOS** build (same Expo/React Native codebase in `apps/mobile`) is on the way.
+
+It covers the day-to-day host workflow - dashboard, bookings, availability, event types, calendars, insights, reminders/channels, automations, workflows, and preferences - with voice input for Otter.
 
 **Bring your own server - built for organisations.** The app isn't hard-wired to our cloud. It ships with a **Server** setting where anyone can point the same app at *their own* self-hosted DayOtter instance. So an organisation can:
 

--- a/apps/web/app/(marketing)/changelog/page.tsx
+++ b/apps/web/app/(marketing)/changelog/page.tsx
@@ -10,6 +10,16 @@ export const metadata: Metadata = {
 const ENTRIES = [
   {
     date: "July 2026",
+    title: "DayOtter for Android is live on Google Play",
+    items: [
+      "The Android app is now on Google Play - the full host workflow in your pocket, with push reminders and voice input for Otter. iOS is on the way.",
+      "Import from Calendly: bring your event types and weekly availability across in one step.",
+      "Opt-in bookings: require your approval before a request is confirmed.",
+      "Offset start times: shift a booking type's slots off the hour (e.g. :05 / :35).",
+    ],
+  },
+  {
+    date: "July 2026",
     title: "Ask Otter, a refreshed interface & new sign-in",
     items: [
       "Ask Otter: a conversational assistant in your dashboard - by chat or voice - that reads your schedule and can act on your whole setup (bookings, booking types, availability, focus time, preferences, teams, reminder channels, automations). Always confirm-first; deletes ask twice.",

--- a/apps/web/components/marketing/hero.tsx
+++ b/apps/web/components/marketing/hero.tsx
@@ -57,7 +57,7 @@ export function Hero() {
             className="mt-4 inline-flex items-center gap-2 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)]/60 px-3.5 py-1.5 text-sm text-[var(--color-muted)] backdrop-blur transition-colors hover:text-[var(--color-text)]"
           >
             <Smartphone size={14} className="text-[var(--color-accent)]" />
-            On the web today - iOS &amp; Android on the way
+            On the web and Android today - iOS on the way
             <ArrowRight size={13} />
           </a>
         </FadeUp>

--- a/apps/web/components/marketing/mobile.tsx
+++ b/apps/web/components/marketing/mobile.tsx
@@ -35,14 +35,42 @@ function PlayLogo({ size = 18 }: { size?: number }) {
   );
 }
 
-function StoreBadge({ logo, label }: { logo: React.ReactNode; label: string }) {
-  return (
-    <div className="inline-flex items-center gap-3 rounded-[13px] border border-white/10 bg-[#0d0c11] px-4 py-2.5 text-white shadow-[var(--shadow-card)]">
+function StoreBadge({
+  logo,
+  label,
+  href,
+}: {
+  logo: React.ReactNode;
+  label: string;
+  /** When set, the badge is a live download link; otherwise it reads "Coming soon". */
+  href?: string;
+}) {
+  const cls =
+    "inline-flex items-center gap-3 rounded-[13px] border border-white/10 bg-[#0d0c11] px-4 py-2.5 text-white shadow-[var(--shadow-card)]";
+  const inner = (
+    <>
       {logo}
       <div className="text-left leading-tight">
-        <div className="text-[10px] uppercase tracking-[0.12em] text-white/60">Coming soon</div>
+        <div className="text-[10px] uppercase tracking-[0.12em] text-white/60">
+          {href ? "Get it on" : "Coming soon"}
+        </div>
         <div className="text-[15px] font-semibold">{label}</div>
       </div>
+    </>
+  );
+  return href ? (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      aria-label={`Get DayOtter on ${label}`}
+      className={`${cls} transition-transform hover:-translate-y-0.5`}
+    >
+      {inner}
+    </a>
+  ) : (
+    <div className={`${cls} opacity-80`} aria-label={`${label} - coming soon`}>
+      {inner}
     </div>
   );
 }
@@ -142,16 +170,20 @@ export function MobileApps() {
             Your calendar, <em className="text-[var(--color-accent)]">in your pocket.</em>
           </h2>
           <p className="mt-5 max-w-md text-lg leading-relaxed text-[var(--color-muted)]">
-            Native apps for iPhone and Android are on the way - the same calm scheduling, built for
+            The DayOtter Android app is live on Google Play - the same calm scheduling, built for
             the moments you're on the move. Push reminders, one-tap booking, and your whole team's
-            availability, wherever you are.
+            availability, wherever you are. iPhone is on the way.
           </p>
           <div className="mt-8 flex flex-wrap gap-3">
+            <StoreBadge
+              logo={<PlayLogo />}
+              label="Google Play"
+              href="https://play.google.com/store/apps/details?id=com.dayotter.app"
+            />
             <StoreBadge logo={<AppleLogo />} label="App Store" />
-            <StoreBadge logo={<PlayLogo />} label="Google Play" />
           </div>
           <p className="mt-4 text-sm text-[var(--color-faint)]">
-            Available on the web today · native apps landing soon.
+            On the web and Android today · iOS landing soon.
           </p>
         </Reveal>
 

--- a/apps/web/components/seo/json-ld.tsx
+++ b/apps/web/components/seo/json-ld.tsx
@@ -35,7 +35,7 @@ export function OrganizationJsonLd() {
           "@type": "SoftwareApplication",
           name: BRAND.name,
           applicationCategory: "BusinessApplication",
-          operatingSystem: "Web, iOS, Android",
+          operatingSystem: "Web, Android",
           description:
             "AI-native, open-source scheduling platform. Otter books meetings, protects focus, and clears the back-and-forth - confirm-first.",
           offers: [


### PR DESCRIPTION
The Android app is live on Google Play (`com.dayotter.app`): https://play.google.com/store/apps/details?id=com.dayotter.app. This reflects it across the marketing site and README; iOS stays framed as upcoming.

- **Mobile section**: Google Play badge → live download link ("Get it on"); App Store stays "Coming soon"; copy updated from *on the way* to *Android is live*.
- **Hero**: "On the web and Android today — iOS on the way".
- **Changelog**: new top entry for the Android launch, plus the recent Calendly import / opt-in bookings / offset start times.
- **JSON-LD**: `operatingSystem: "Web, Android"`.
- **README**: Mobile app section links to the Play Store listing.

Verified in the server-rendered homepage HTML: live Play link, "Get it on" + "Coming soon" badges, and the updated hero/section copy all present. Typecheck + biome clean.