### PR TITLE
feat(integrations): app registry + browsable in-app app store (#107)

### DIFF
--- a/apps/web/app/(app)/settings/apps/page.tsx
+++ b/apps/web/app/(app)/settings/apps/page.tsx
@@ -1,0 +1,27 @@
+import { AppStore } from "@/components/app-store";
+import { APPS } from "@/lib/apps/registry";
+import { resolveAppStatuses } from "@/lib/apps/status";
+import { getSession } from "@/lib/auth/session";
+
+export const dynamic = "force-dynamic";
+
+export default async function AppsSettingsPage() {
+  const session = await getSession();
+  if (!session?.user) return null; // the (app) layout redirects; this guards the render race
+
+  const statuses = await resolveAppStatuses(session.user.id);
+
+  return (
+    <>
+      <div className="mb-6">
+        <h2 className="text-lg font-semibold">Apps</h2>
+        <p className="mt-1 text-sm text-[var(--color-muted)]">
+          Everything DayOtter connects to - calendars, video, CRM, payments, messaging and
+          automation. Anything marked <em>Not configured</em> needs credentials set on this server.
+        </p>
+      </div>
+
+      <AppStore apps={APPS} statuses={statuses} />
+    </>
+  );
+}

--- a/apps/web/components/app-store.tsx
+++ b/apps/web/components/app-store.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { buttonVariants } from "@/components/ui/button";
+import { Card, CardBody } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  APP_CATEGORIES,
+  type AppCategory,
+  type AppDefinition,
+  CATEGORY_LABELS,
+  appsByCategory,
+  searchApps,
+} from "@/lib/apps/registry";
+import type { AppStatus } from "@/lib/apps/status";
+import { cn } from "@/lib/cn";
+import { CheckCircle2 } from "lucide-react";
+import Link from "next/link";
+import { useMemo, useState } from "react";
+
+function StatusPill({ app, status }: { app: AppDefinition; status?: AppStatus }) {
+  if (app.builtIn) {
+    return (
+      <span className="shrink-0 rounded-full bg-[var(--color-surface-2)] px-2.5 py-1 text-xs font-medium text-[var(--color-muted)]">
+        Included
+      </span>
+    );
+  }
+  if (!status?.configured) {
+    return <span className="shrink-0 text-xs text-[var(--color-faint)]">Not configured</span>;
+  }
+  if (status.connected) {
+    return (
+      <span className="flex shrink-0 items-center gap-1 text-sm text-[var(--color-success)]">
+        <CheckCircle2 size={15} /> Connected
+      </span>
+    );
+  }
+  return null;
+}
+
+function AppTile({ app, status }: { app: AppDefinition; status?: AppStatus }) {
+  const showConnect = !app.builtIn && status?.configured && !status.connected;
+  const manageLabel = app.builtIn || status?.connected ? "Manage" : null;
+
+  return (
+    <Card>
+      <CardBody className="flex items-center gap-3 px-4 py-3">
+        <span
+          aria-hidden
+          className="h-2.5 w-2.5 shrink-0 rounded-full"
+          style={{ background: app.color }}
+        />
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium">{app.name}</p>
+          <p className="truncate text-xs text-[var(--color-muted)]">{app.blurb}</p>
+        </div>
+        <StatusPill app={app} status={status} />
+        {showConnect ? (
+          app.external ? (
+            <a href={app.href} className={buttonVariants({ variant: "outline", size: "sm" })}>
+              Connect
+            </a>
+          ) : (
+            <Link href={app.href} className={buttonVariants({ variant: "outline", size: "sm" })}>
+              Connect
+            </Link>
+          )
+        ) : manageLabel ? (
+          <Link
+            href={app.href}
+            className="shrink-0 text-xs text-[var(--color-muted)] hover:text-[var(--color-text)]"
+          >
+            {manageLabel}
+          </Link>
+        ) : null}
+      </CardBody>
+    </Card>
+  );
+}
+
+export function AppStore({
+  apps,
+  statuses,
+}: {
+  apps: AppDefinition[];
+  statuses: Record<string, AppStatus>;
+}) {
+  const [query, setQuery] = useState("");
+  const [category, setCategory] = useState<AppCategory | "all">("all");
+
+  const groups = useMemo(() => {
+    const filtered = searchApps(query, apps).filter(
+      (a) => category === "all" || a.category === category,
+    );
+    return appsByCategory(filtered);
+  }, [query, category, apps]);
+
+  const total = groups.reduce((n, g) => n + g.apps.length, 0);
+  const availableCategories = APP_CATEGORIES.filter((c) => apps.some((a) => a.category === c));
+
+  return (
+    <>
+      <Input
+        placeholder="Search apps…"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        aria-label="Search apps"
+      />
+
+      <div className="mt-3 flex flex-wrap gap-1.5">
+        {(["all", ...availableCategories] as const).map((c) => (
+          <button
+            key={c}
+            type="button"
+            onClick={() => setCategory(c)}
+            className={cn(
+              "rounded-full border px-3 py-1 text-xs font-medium transition-colors",
+              category === c
+                ? "border-[var(--color-accent)] bg-[var(--color-accent-soft)] text-[var(--color-accent)]"
+                : "border-[var(--color-border-strong)] text-[var(--color-muted)] hover:text-[var(--color-text)]",
+            )}
+          >
+            {c === "all" ? "All" : CATEGORY_LABELS[c]}
+          </button>
+        ))}
+      </div>
+
+      {total === 0 ? (
+        <p className="py-10 text-center text-sm text-[var(--color-muted)]">
+          No apps match “{query}”.
+        </p>
+      ) : (
+        <div className="mt-6 space-y-8">
+          {groups.map((g) => (
+            <section key={g.category}>
+              <h3 className="mb-3 text-sm font-semibold text-[var(--color-muted)]">{g.label}</h3>
+              <div className="space-y-2">
+                {g.apps.map((app) => (
+                  <AppTile key={app.id} app={app} status={statuses[app.id]} />
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/components/nav-items.ts
+++ b/apps/web/components/nav-items.ts
@@ -46,6 +46,7 @@ export const SETTINGS_NAV = [
   { href: "/settings/automations", label: "Automations" },
   { href: "/settings/packages", label: "Packages" },
   { href: "/settings/payouts", label: "Payouts" },
+  { href: "/settings/apps", label: "Apps" },
   { href: "/settings/calendars", label: "Calendars" },
   { href: "/settings/crm", label: "CRM" },
   { href: "/settings/import", label: "Import" },

--- a/apps/web/lib/apps/registry.test.ts
+++ b/apps/web/lib/apps/registry.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import {
+  APPS,
+  APP_CATEGORIES,
+  type AppDefinition,
+  type ConnectionState,
+  appsByCategory,
+  isConfigured,
+  isConnected,
+  searchApps,
+} from "./registry";
+
+const emptyState = (): ConnectionState => ({
+  calendars: new Set(),
+  crm: new Set(),
+  conferencing: new Set(),
+  stripe: false,
+});
+
+describe("registry integrity", () => {
+  it("has unique ids", () => {
+    const ids = APPS.map((a) => a.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("only uses known categories", () => {
+    for (const a of APPS) expect(APP_CATEGORIES).toContain(a.category);
+  });
+
+  it("gives every app a name, blurb, colour and href", () => {
+    for (const a of APPS) {
+      expect(a.name.length).toBeGreaterThan(0);
+      expect(a.blurb.length).toBeGreaterThan(0);
+      expect(a.color).toMatch(/^#[0-9a-f]{6}$/i);
+      expect(a.href.startsWith("/")).toBe(true);
+    }
+  });
+
+  it("marks OAuth-redirect apps as external API routes", () => {
+    for (const a of APPS.filter((x) => x.external)) {
+      expect(a.href.startsWith("/api/")).toBe(true);
+    }
+  });
+
+  it("never marks an app both built-in and connectable", () => {
+    for (const a of APPS) expect(a.builtIn && a.connection).toBeFalsy();
+  });
+});
+
+describe("isConfigured", () => {
+  const app = (requiresEnv?: string[]): AppDefinition => ({
+    id: "x",
+    name: "X",
+    category: "crm",
+    blurb: "b",
+    color: "#000000",
+    href: "/x",
+    requiresEnv,
+  });
+
+  it("is true when the app needs no env", () => {
+    expect(isConfigured(app(), {})).toBe(true);
+    expect(isConfigured(app([]), {})).toBe(true);
+  });
+  it("requires every listed var to be non-empty", () => {
+    expect(isConfigured(app(["A", "B"]), { A: "1", B: "2" })).toBe(true);
+    expect(isConfigured(app(["A", "B"]), { A: "1" })).toBe(false);
+    expect(isConfigured(app(["A"]), { A: "" })).toBe(false);
+  });
+
+  it("gates the real Zoom + Stripe entries on their env", () => {
+    const zoom = APPS.find((a) => a.id === "zoom")!;
+    expect(isConfigured(zoom, {})).toBe(false);
+    expect(isConfigured(zoom, { ZOOM_CLIENT_ID: "a", ZOOM_CLIENT_SECRET: "b" })).toBe(true);
+    const stripe = APPS.find((a) => a.id === "stripe")!;
+    expect(isConfigured(stripe, { STRIPE_SECRET_KEY: "sk" })).toBe(true);
+  });
+
+  it("treats CalDAV / ICS as available on every deployment", () => {
+    for (const id of ["apple-caldav", "ics-feed", "slack"]) {
+      expect(isConfigured(APPS.find((a) => a.id === id)!, {})).toBe(true);
+    }
+  });
+});
+
+describe("isConnected", () => {
+  const byId = (id: string) => APPS.find((a) => a.id === id)!;
+
+  it("matches a calendar provider", () => {
+    const s = emptyState();
+    s.calendars.add("google");
+    expect(isConnected(byId("google-calendar"), s)).toBe(true);
+    expect(isConnected(byId("microsoft-outlook"), s)).toBe(false);
+  });
+
+  it("matches CRM and conferencing providers", () => {
+    const s = emptyState();
+    s.crm.add("hubspot");
+    s.conferencing.add("zoom");
+    expect(isConnected(byId("hubspot"), s)).toBe(true);
+    expect(isConnected(byId("salesforce"), s)).toBe(false);
+    expect(isConnected(byId("zoom"), s)).toBe(true);
+  });
+
+  it("matches stripe via the account flag", () => {
+    const s = emptyState();
+    expect(isConnected(byId("stripe"), s)).toBe(false);
+    s.stripe = true;
+    expect(isConnected(byId("stripe"), s)).toBe(true);
+  });
+
+  it("returns false for built-ins (always on, nothing to connect)", () => {
+    expect(isConnected(byId("webhooks"), emptyState())).toBe(false);
+    expect(isConnected(byId("google-meet"), emptyState())).toBe(false);
+  });
+});
+
+describe("appsByCategory / searchApps", () => {
+  it("groups in category order and skips empty groups", () => {
+    const groups = appsByCategory();
+    expect(groups.length).toBeGreaterThan(0);
+    for (const g of groups) expect(g.apps.length).toBeGreaterThan(0);
+    // every app appears exactly once across groups
+    expect(groups.reduce((n, g) => n + g.apps.length, 0)).toBe(APPS.length);
+  });
+
+  it("searches name and blurb, case-insensitively", () => {
+    expect(searchApps("zoom").map((a) => a.id)).toContain("zoom");
+    expect(searchApps("HUBSPOT").map((a) => a.id)).toContain("hubspot");
+    // blurb match
+    expect(searchApps("calendly").map((a) => a.id)).toContain("calendly-import");
+    expect(searchApps("")).toHaveLength(APPS.length);
+    expect(searchApps("no-such-app-xyz")).toHaveLength(0);
+  });
+});

--- a/apps/web/lib/apps/registry.ts
+++ b/apps/web/lib/apps/registry.ts
@@ -1,0 +1,303 @@
+/**
+ * The DayOtter app registry.
+ *
+ * Every integration - calendars, video, CRM, payments, messaging, automation -
+ * is described here as an *app*: metadata, what the deployment needs configured,
+ * where to connect it, and how a per-user connection is detected. The app store
+ * (settings → Apps) renders straight from this list, so adding an integration is
+ * one entry here plus its connect route - not another hardcoded settings page.
+ *
+ * Pure and dependency-free on purpose (no DB/env access at module scope) so it
+ * can be unit-tested and imported from both server and client components.
+ */
+
+export const APP_CATEGORIES = [
+  "calendar",
+  "video",
+  "crm",
+  "payments",
+  "messaging",
+  "automation",
+  "migration",
+] as const;
+
+export type AppCategory = (typeof APP_CATEGORIES)[number];
+
+export const CATEGORY_LABELS: Record<AppCategory, string> = {
+  calendar: "Calendars",
+  video: "Video & conferencing",
+  crm: "CRM",
+  payments: "Payments",
+  messaging: "Messaging & notifications",
+  automation: "Automation & developer",
+  migration: "Import & migration",
+};
+
+/** How to tell whether *this user* has connected the app. */
+export type AppConnection =
+  | { kind: "calendar"; provider: "google" | "microsoft" | "apple" | "ics" }
+  | { kind: "crm"; provider: string }
+  | { kind: "conferencing"; provider: string }
+  | { kind: "stripe" };
+
+export interface AppDefinition {
+  id: string;
+  name: string;
+  category: AppCategory;
+  /** One line, user-facing: what connecting it actually does. */
+  blurb: string;
+  /** Brand colour for the tile marker. */
+  color: string;
+  /**
+   * Env vars the deployment must set before this app can be connected. Empty /
+   * omitted = available on every deployment.
+   */
+  requiresEnv?: string[];
+  /** Where the user goes to connect or manage it. */
+  href: string;
+  /** True when `href` is an API route that starts an OAuth redirect. */
+  external?: boolean;
+  /** Omitted for always-on capabilities that need no per-user connection. */
+  connection?: AppConnection;
+  /** Always on - no connection step (shown as "Included"). */
+  builtIn?: boolean;
+}
+
+export const APPS: AppDefinition[] = [
+  // ---- Calendars ----
+  {
+    id: "google-calendar",
+    name: "Google Calendar",
+    category: "calendar",
+    blurb: "Two-way sync: read busy times and write your bookings back.",
+    color: "#4285F4",
+    requiresEnv: ["GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"],
+    href: "/api/calendars/connect/google",
+    external: true,
+    connection: { kind: "calendar", provider: "google" },
+  },
+  {
+    id: "microsoft-outlook",
+    name: "Outlook / Microsoft 365",
+    category: "calendar",
+    blurb: "Two-way sync with Outlook and Microsoft 365 calendars.",
+    color: "#0078D4",
+    requiresEnv: ["MICROSOFT_CLIENT_ID", "MICROSOFT_CLIENT_SECRET"],
+    href: "/api/calendars/connect/microsoft",
+    external: true,
+    connection: { kind: "calendar", provider: "microsoft" },
+  },
+  {
+    id: "apple-caldav",
+    name: "Apple iCloud & CalDAV",
+    category: "calendar",
+    blurb: "iCloud, Fastmail, Mailbox.org and other CalDAV servers.",
+    color: "#111111",
+    href: "/settings/calendars",
+    connection: { kind: "calendar", provider: "apple" },
+  },
+  {
+    id: "ics-feed",
+    name: "ICS / webcal feed",
+    category: "calendar",
+    blurb: "Subscribe to a read-only calendar feed so it blocks your availability.",
+    color: "#6B7280",
+    href: "/settings/calendars",
+    connection: { kind: "calendar", provider: "ics" },
+  },
+
+  // ---- Video ----
+  {
+    id: "zoom",
+    name: "Zoom",
+    category: "video",
+    blurb: "Auto-create a Zoom meeting for every booking on a Zoom event type.",
+    color: "#2D8CFF",
+    requiresEnv: ["ZOOM_CLIENT_ID", "ZOOM_CLIENT_SECRET"],
+    href: "/api/integrations/zoom/connect",
+    external: true,
+    connection: { kind: "conferencing", provider: "zoom" },
+  },
+  {
+    id: "google-meet",
+    name: "Google Meet",
+    category: "video",
+    blurb: "Meet links are generated on the calendar invite - no extra setup.",
+    color: "#00897B",
+    href: "/settings/calendars",
+    builtIn: true,
+  },
+  {
+    id: "ms-teams",
+    name: "Microsoft Teams",
+    category: "video",
+    blurb: "Teams links are generated on the calendar invite - no extra setup.",
+    color: "#6264A7",
+    href: "/settings/calendars",
+    builtIn: true,
+  },
+
+  // ---- CRM ----
+  {
+    id: "salesforce",
+    name: "Salesforce",
+    category: "crm",
+    blurb: "Log every booking as an Event on the matched Contact.",
+    color: "#00A1E0",
+    requiresEnv: ["SALESFORCE_CLIENT_ID", "SALESFORCE_CLIENT_SECRET"],
+    href: "/api/integrations/crm/salesforce",
+    external: true,
+    connection: { kind: "crm", provider: "salesforce" },
+  },
+  {
+    id: "hubspot",
+    name: "HubSpot",
+    category: "crm",
+    blurb: "Create the contact and log the meeting, kept in sync on reschedule.",
+    color: "#FF7A59",
+    requiresEnv: ["HUBSPOT_CLIENT_ID", "HUBSPOT_CLIENT_SECRET"],
+    href: "/api/integrations/crm/hubspot",
+    external: true,
+    connection: { kind: "crm", provider: "hubspot" },
+  },
+
+  // ---- Payments ----
+  {
+    id: "stripe",
+    name: "Stripe",
+    category: "payments",
+    blurb: "Charge for bookings and get paid out via Stripe Connect.",
+    color: "#635BFF",
+    requiresEnv: ["STRIPE_SECRET_KEY"],
+    href: "/settings/payouts",
+    connection: { kind: "stripe" },
+  },
+
+  // ---- Messaging ----
+  {
+    id: "twilio-sms",
+    name: "SMS (Twilio)",
+    category: "messaging",
+    blurb: "Text reminders and booking notifications.",
+    color: "#F22F46",
+    requiresEnv: ["TWILIO_ACCOUNT_SID", "TWILIO_AUTH_TOKEN", "TWILIO_SMS_FROM"],
+    href: "/settings/notifications",
+  },
+  {
+    id: "twilio-whatsapp",
+    name: "WhatsApp (Twilio)",
+    category: "messaging",
+    blurb: "WhatsApp reminders, plus inbound messages to Otter.",
+    color: "#25D366",
+    requiresEnv: ["TWILIO_ACCOUNT_SID", "TWILIO_AUTH_TOKEN", "TWILIO_WHATSAPP_FROM"],
+    href: "/settings/notifications",
+  },
+  {
+    id: "slack",
+    name: "Slack",
+    category: "messaging",
+    blurb: "Post reminders and daily briefings to a Slack channel.",
+    color: "#611F69",
+    href: "/settings/notifications",
+  },
+  {
+    id: "web-push",
+    name: "Browser push",
+    category: "messaging",
+    blurb: "Push reminders to your browser, no app required.",
+    color: "#8B5CF6",
+    requiresEnv: ["VAPID_PUBLIC_KEY", "VAPID_PRIVATE_KEY"],
+    href: "/settings/notifications",
+  },
+
+  // ---- Automation & developer ----
+  {
+    id: "webhooks",
+    name: "Webhooks",
+    category: "automation",
+    blurb: "Fire booking events at your own endpoints, with delivery history.",
+    color: "#0EA5E9",
+    href: "/settings/developer",
+    builtIn: true,
+  },
+  {
+    id: "api-keys",
+    name: "REST API",
+    category: "automation",
+    blurb: "API keys for the public v1 API.",
+    color: "#10B981",
+    href: "/settings/developer",
+    builtIn: true,
+  },
+  {
+    id: "plugins",
+    name: "Plugins",
+    category: "automation",
+    blurb: "Extend DayOtter in-process with trusted plugins (DAYOTTER_PLUGINS).",
+    color: "#F59E0B",
+    href: "/settings/developer",
+    builtIn: true,
+  },
+
+  // ---- Migration ----
+  {
+    id: "calendly-import",
+    name: "Calendly import",
+    category: "migration",
+    blurb: "Bring your Calendly event types and weekly availability across.",
+    color: "#006BFF",
+    href: "/settings/import",
+    builtIn: true,
+  },
+];
+
+/** True when the deployment has every env var this app needs. */
+export function isConfigured(
+  app: AppDefinition,
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return (app.requiresEnv ?? []).every((k) => Boolean(env[k]));
+}
+
+/** The user's connections, as provider sets - what `isConnected` matches against. */
+export interface ConnectionState {
+  calendars: Set<string>;
+  crm: Set<string>;
+  conferencing: Set<string>;
+  stripe: boolean;
+}
+
+/** True when this user has connected the app. Built-ins are never "connected"
+ *  (they're always on); apps with no connection step return false. */
+export function isConnected(app: AppDefinition, state: ConnectionState): boolean {
+  const c = app.connection;
+  if (!c) return false;
+  switch (c.kind) {
+    case "calendar":
+      return state.calendars.has(c.provider);
+    case "crm":
+      return state.crm.has(c.provider);
+    case "conferencing":
+      return state.conferencing.has(c.provider);
+    case "stripe":
+      return state.stripe;
+  }
+}
+
+/** Apps grouped by category, preserving registry order and skipping empties. */
+export function appsByCategory(
+  apps: AppDefinition[] = APPS,
+): { category: AppCategory; label: string; apps: AppDefinition[] }[] {
+  return APP_CATEGORIES.map((category) => ({
+    category,
+    label: CATEGORY_LABELS[category],
+    apps: apps.filter((a) => a.category === category),
+  })).filter((g) => g.apps.length > 0);
+}
+
+/** Case-insensitive search over name + blurb, for the app-store filter box. */
+export function searchApps(query: string, apps: AppDefinition[] = APPS): AppDefinition[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return apps;
+  return apps.filter((a) => a.name.toLowerCase().includes(q) || a.blurb.toLowerCase().includes(q));
+}

--- a/apps/web/lib/apps/status.ts
+++ b/apps/web/lib/apps/status.ts
@@ -1,0 +1,49 @@
+import { eq, getDb, schema } from "@dayotter/db";
+import { APPS, type ConnectionState, isConfigured, isConnected } from "./registry";
+
+export interface AppStatus {
+  /** The deployment has the env this app needs (else: "Not configured"). */
+  configured: boolean;
+  /** This user has connected it. */
+  connected: boolean;
+}
+
+/**
+ * Resolve every app's status for one user in a fixed number of queries (one per
+ * connection store), rather than per-app lookups. Returns a map keyed by app id
+ * so the app store can render straight from the registry.
+ */
+export async function resolveAppStatuses(userId: string): Promise<Record<string, AppStatus>> {
+  const db = getDb();
+  const [calendars, crm, conferencing, user] = await Promise.all([
+    db.query.calendarConnections.findMany({
+      where: eq(schema.calendarConnections.userId, userId),
+      columns: { provider: true },
+    }),
+    db.query.crmConnections.findMany({
+      where: eq(schema.crmConnections.userId, userId),
+      columns: { provider: true },
+    }),
+    db.query.conferencingConnections.findMany({
+      where: eq(schema.conferencingConnections.userId, userId),
+      columns: { provider: true },
+    }),
+    db.query.users.findFirst({
+      where: eq(schema.users.id, userId),
+      columns: { stripeAccountId: true },
+    }),
+  ]);
+
+  const state: ConnectionState = {
+    calendars: new Set(calendars.map((c) => c.provider)),
+    crm: new Set(crm.map((c) => c.provider)),
+    conferencing: new Set(conferencing.map((c) => c.provider)),
+    stripe: Boolean(user?.stripeAccountId),
+  };
+
+  const out: Record<string, AppStatus> = {};
+  for (const app of APPS) {
+    out[app.id] = { configured: isConfigured(app), connected: isConnected(app, state) };
+  }
+  return out;
+}


### PR DESCRIPTION
Top-priority roadmap item **#107** — the enabler for the remaining integration issues (#108, #110, #111, #112, #113).

Integrations were hardcoded across per-category settings pages. This describes each one as an **app** in a single declarative registry, and renders a browsable app store from it.

## What's included
- **`lib/apps/registry.ts`** — pure, dependency-free catalog of **18 apps across 7 categories** (calendars, video, CRM, payments, messaging, automation, migration). Each entry carries metadata (name / blurb / colour), the env the deployment needs (`requiresEnv`), where to connect (`href`, `external` for OAuth starts), and how a per-user connection is detected (`connection`). Helpers `isConfigured` / `isConnected` / `appsByCategory` / `searchApps` are all pure.
- **`lib/apps/status.ts`** — resolves every app's status for a user in **4 queries** (one per connection store) rather than per-app lookups.
- **Settings → Apps** — search + category filter; each app shows **Connected / Connect / Included / Not configured** with the right connect or manage link.

**Adding an integration is now one registry entry + its connect route** — no new settings page.

## Verification
- **126 web tests** (15 new), including registry-integrity checks: unique ids, valid categories, `external` apps point at `/api/` routes, and no app is both built-in *and* connectable.
- Typecheck + biome clean.
- **Rendered the authenticated page against a live server + DB**: every app name, all category headings, and the status labels ("Not configured" for env-gated apps, "Included" for built-ins) come through correctly.

Closes #107.