### PR TITLE
Fix/error logging hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,7 +84,8 @@ SMTP_URL=
 # with a 550. Change this to your own verified domain before going live.
 EMAIL_FROM="DayOtter <no-reply@dayotter.com>"
 # Where the public contact form sends messages. Defaults to hello@dayotter.com.
-CONTACT_EMAIL=
+
+CONTACT_EMAIL=hello@dayotter.com
 
 # ---- Captcha on the public booking form (optional) ----
 # Cloudflare Turnstile. Leave blank to disable captcha entirely.

--- a/apps/web/app/api/ai/chat/route.ts
+++ b/apps/web/app/api/ai/chat/route.ts
@@ -71,7 +71,11 @@ export const POST = withUser(async (u, request) => {
           await streamAssistant({ userId: u.id, turns, emit: send });
         }
       } catch (err) {
-        logger.error("ai chat stream failed", { event: "ai_chat_failed", userId: u.id, err });
+        logger.error("ai chat stream failed", 
+          { event: "ai_chat_failed", 
+            userId: u.id, 
+            error: err instanceof Error ? err.message : String(err)
+          });
         send({ type: "error", message: "The assistant hit a snag. Please try again." });
       } finally {
         controller.close();

--- a/apps/web/app/api/calendars/apple/route.ts
+++ b/apps/web/app/api/calendars/apple/route.ts
@@ -1,6 +1,7 @@
 import { AppleConnectError, connectAppleAccount } from "@/lib/calendar/calendar-connect";
 import { jsonError, withUser } from "@/lib/server/http";
 import { NextResponse } from "next/server";
+import { logger } from "@dayotter/core";
 import { z } from "zod";
 
 export const dynamic = "force-dynamic";
@@ -37,7 +38,12 @@ export const POST = withUser(async (u, request) => {
     return NextResponse.json({ ok: true, calendarCount: result.calendarCount });
   } catch (err) {
     if (err instanceof AppleConnectError) return jsonError(err.message, 400);
-    console.error("[calendars/apple] connect failed:", err);
+    logger.error("[calendars/apple] connect failed:",
+      {
+        event:"[calendars/apple] connect failed",
+        userId :u.id,
+        error: err instanceof Error ? err.message :String(err)
+      });
     return jsonError("Could not connect. Please try again.", 500);
   }
 });

--- a/apps/web/app/api/import/calendly/route.ts
+++ b/apps/web/app/api/import/calendly/route.ts
@@ -38,7 +38,11 @@ export const POST = withUser(async (u, request) => {
         400,
       );
     }
-    logger.error("calendly import failed", { event: "calendly_import_failed", userId: u.id, err });
+    logger.error("calendly import failed",
+       { event: "calendly_import_failed", 
+        userId: u.id, 
+        error: err instanceof Error ? err.message : String(err)
+      });
     return jsonError("Couldn't import from Calendly right now. Please try again.", 502);
   }
 });

--- a/deploy/.env.prod.example
+++ b/deploy/.env.prod.example
@@ -54,6 +54,9 @@ MICROSOFT_CLIENT_SECRET=
 SMTP_URL=
 EMAIL_FROM="dayotter <no-reply@example.com>"
 
+# Email address that receives contact form submissions.
+CONTACT_EMAIL=hello@dayotter.com
+
 # AI scheduling (Anthropic). Hidden entirely when unset.
 ANTHROPIC_API_KEY=
 


### PR DESCRIPTION
<!-- Thanks for contributing to DayOtter! Keep PRs focused - one logical change. -->

## What & why

This PR hardens error logging by avoiding logging full error objects in a few API routes.

Instead of logging the entire `err` object, it now logs only the error message using:

```ts
err instanceof Error ? err.message : String(err)
```

This reduces the risk of accidentally logging sensitive data if upstream libraries change their error shapes while preserving useful debugging information.

Closes #144

## How I verified it

- [x] `pnpm turbo typecheck` passes
- [ ] `pnpm biome check` passes (repository currently has unrelated Biome issues)
- [ ] Verified the change by driving the actual flow / endpoint
- [ ] Added/updated a DB migration (`pnpm --filter @dayotter/db generate`) if the schema changed
- [ ] Updated docs / module README if behaviour or an extension point changed

## Notes for the reviewer

This is a defense-in-depth change only. It does not affect application behavior—only how errors are logged.

`pnpm turbo typecheck` passes locally. I wasn't able to fully exercise the affected endpoints, and `pnpm biome check` currently reports unrelated repository-wide issues.

---

By submitting this PR I confirm I wrote this code (or have the right to contribute it) and agree to license it under **AGPLv3** (or the EE license for changes under `ee/`).