### PR TITLE
feat(platform): embeddable React SDK + embed route (#116)

### DIFF
--- a/apps/web/app/embed/[handle]/[slug]/page.tsx
+++ b/apps/web/app/embed/[handle]/[slug]/page.tsx
@@ -1,0 +1,95 @@
+import { EmbedBridge } from "@/components/embed-bridge";
+import { SlotPicker } from "@/components/slot-picker";
+import { aiEnabled } from "@/lib/ai/llm";
+import { brandStyle, getHostBranding } from "@/lib/booking/branding";
+import { LOCATION_LABELS } from "@/lib/booking/event-type-input";
+import { chargeFor, formatMoney } from "@/lib/booking/money";
+import { resolveLocale, t } from "@/lib/i18n/booking";
+import { LocaleProvider } from "@/lib/i18n/locale-provider";
+import { paymentsEnabled } from "@/lib/payments/stripe";
+import { and, eq, getDb, schema } from "@dayotter/db";
+import { Clock, Video } from "lucide-react";
+import { headers } from "next/headers";
+import { notFound } from "next/navigation";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Chrome-less booking flow for embedding in an iframe (embed.js or the
+ * @dayotter/embed-react SDK). Same data as the public page, minus the site
+ * shell, plus theme/brand from the query and an EmbedBridge that relays height +
+ * booking events to the parent window.
+ */
+export default async function EmbedBookingPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ handle: string; slug: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const { handle, slug } = await params;
+  const sp = await searchParams;
+  const db = getDb();
+
+  const host = await db.query.users.findFirst({ where: eq(schema.users.handle, handle) });
+  if (!host) notFound();
+
+  const eventType = await db.query.eventTypes.findFirst({
+    where: and(
+      eq(schema.eventTypes.ownerId, host.id),
+      eq(schema.eventTypes.slug, slug),
+      eq(schema.eventTypes.isActive, true),
+    ),
+  });
+  if (!eventType) notFound();
+
+  const branding = await getHostBranding(host.id);
+  const locale = resolveLocale((await headers()).get("accept-language"));
+  const chargeAmount = paymentsEnabled ? chargeFor(eventType.price, eventType.depositAmount) : 0;
+  const priceLabel =
+    chargeAmount > 0 ? formatMoney(chargeAmount, eventType.currency ?? "usd") : null;
+
+  const themeParam = typeof sp.theme === "string" ? sp.theme : "auto";
+  const theme = themeParam === "dark" ? "dark" : themeParam === "light" ? "light" : "auto";
+  const primaryColor =
+    typeof sp.primaryColor === "string"
+      ? `#${sp.primaryColor.replace(/^#/, "")}`
+      : branding.brandColor;
+  const hideDetails = sp.hideDetails === "1" || sp.hideDetails === "true";
+
+  return (
+    <main style={brandStyle(primaryColor)} className="mx-auto max-w-2xl px-4 py-5">
+      <EmbedBridge theme={theme} />
+      <LocaleProvider locale={locale}>
+        {hideDetails ? null : (
+          <div className="mb-5">
+            <h1 className="font-display text-xl leading-tight tracking-[-0.01em]">
+              {eventType.title}
+            </h1>
+            <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-sm text-[var(--color-muted)]">
+              <span className="flex items-center gap-1.5">
+                <Clock size={14} /> {t(locale, "minutes", { n: eventType.durationMinutes })}
+              </span>
+              <span className="flex items-center gap-1.5">
+                <Video size={14} /> {LOCATION_LABELS[eventType.location] ?? eventType.location}
+              </span>
+              {priceLabel ? <span className="font-medium">{priceLabel}</span> : null}
+            </div>
+            {eventType.description ? (
+              <p className="mt-2 text-sm text-[var(--color-muted)]">{eventType.description}</p>
+            ) : null}
+          </div>
+        )}
+        <SlotPicker
+          embed
+          eventTypeId={eventType.id}
+          questions={eventType.questions}
+          priceLabel={priceLabel}
+          defaultDuration={eventType.durationMinutes}
+          durationOptions={eventType.durationOptions ?? []}
+          requiresCode={eventType.accessCodeHash != null}
+        />
+      </LocaleProvider>
+    </main>
+  );
+}

--- a/apps/web/components/embed-bridge.tsx
+++ b/apps/web/components/embed-bridge.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Client bridge for the embed iframe: applies the requested theme and posts the
+ * document height to the parent window whenever it changes, so the host page's
+ * embed.js / React SDK can auto-resize the frame. Renders nothing.
+ */
+export function EmbedBridge({ theme }: { theme: "light" | "dark" | "auto" }) {
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === "dark") root.classList.add("dark");
+    else if (theme === "light") root.classList.remove("dark");
+    // "auto" leaves whatever the app shell resolved from prefers-color-scheme.
+
+    const post = () => {
+      const height = Math.ceil(document.documentElement.scrollHeight);
+      window.parent?.postMessage({ type: "dayotter:height", height }, "*");
+    };
+
+    post();
+    const ro = new ResizeObserver(post);
+    ro.observe(document.documentElement);
+    window.addEventListener("load", post);
+    // A couple of delayed posts catch late layout (fonts, async content).
+    const t1 = window.setTimeout(post, 300);
+    const t2 = window.setTimeout(post, 1200);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener("load", post);
+      window.clearTimeout(t1);
+      window.clearTimeout(t2);
+    };
+  }, [theme]);
+
+  return null;
+}

--- a/apps/web/components/slot-picker.tsx
+++ b/apps/web/components/slot-picker.tsx
@@ -25,6 +25,7 @@ export function SlotPicker({
   linkToken,
   requiresCode = false,
   assistantEnabled = false,
+  embed = false,
 }: {
   eventTypeId: string;
   questions?: BookingQuestionInput[];
@@ -37,6 +38,8 @@ export function SlotPicker({
   requiresCode?: boolean;
   /** Show the floating "find me a time" AI helper (host preference). */
   assistantEnabled?: boolean;
+  /** Rendered inside an embed iframe: relay booking success to the parent page. */
+  embed?: boolean;
 }) {
   const router = useRouter();
   const zone = useLocalZone();
@@ -116,6 +119,11 @@ export function SlotPicker({
       return;
     }
     track("Booking Confirmed", { eventTypeId });
+    // Embed: tell the host page a booking landed (their React SDK / embed.js
+    // surfaces this as onBookingSuccessful) before we navigate inside the frame.
+    if (embed && typeof window !== "undefined" && window.parent !== window) {
+      window.parent.postMessage({ type: "dayotter:booking", uid: data.uid, url: data.url }, "*");
+    }
     // Honor a host-configured redirect (external URL) over the DayOtter confirmation.
     if (typeof data.redirectUrl === "string" && /^https?:\/\//.test(data.redirectUrl)) {
       window.location.href = data.redirectUrl;

--- a/apps/web/lib/apps/registry.ts
+++ b/apps/web/lib/apps/registry.ts
@@ -247,6 +247,15 @@ export const APPS: AppDefinition[] = [
     href: "/settings/developer",
     builtIn: true,
   },
+  {
+    id: "embed-sdk",
+    name: "Embed & React SDK",
+    category: "automation",
+    blurb: "Drop your booking pages into any site (embed.js) or React app (@dayotter/embed-react).",
+    color: "#0ea5e9",
+    href: "/settings/developer",
+    builtIn: true,
+  },
 
   // ---- Migration ----
   {

--- a/packages/embed-react/README.md
+++ b/packages/embed-react/README.md
@@ -1,0 +1,63 @@
+# @dayotter/embed-react
+
+White-label React components to embed [DayOtter](https://dayotter.com) scheduling
+in your own app. Renders the booking flow in an auto-resizing iframe, so there's
+no API token to manage and your bookers get the real, always-up-to-date flow.
+
+```bash
+npm install @dayotter/embed-react
+```
+
+## Inline booker
+
+```tsx
+import { DayOtterBooker } from "@dayotter/embed-react";
+
+export function Contact() {
+  return (
+    <DayOtterBooker
+      handle="ada"
+      slug="intro"
+      theme="light"
+      primaryColor="#6743e6"
+      onBookingSuccessful={(b) => console.log("booked", b.uid)}
+    />
+  );
+}
+```
+
+The iframe auto-resizes to its content and calls `onBookingSuccessful` when a
+booking is confirmed.
+
+## Popup button
+
+```tsx
+import { DayOtterButton } from "@dayotter/embed-react";
+
+<DayOtterButton handle="ada" slug="intro">Book a call</DayOtterButton>;
+```
+
+Or open it imperatively (works outside React too):
+
+```ts
+import { openDayOtterPopup } from "@dayotter/embed-react";
+
+const popup = openDayOtterPopup({ handle: "ada", slug: "intro" });
+// popup.close();
+```
+
+## Props
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `handle` | `string` | Your public booking handle (required) |
+| `slug` | `string` | The event-type slug (required) |
+| `baseUrl` | `string` | Your instance origin. Defaults to `https://dayotter.com` — set it when self-hosting |
+| `theme` | `"light" \| "dark" \| "auto"` | Force a colour scheme |
+| `primaryColor` | `string` | Accent colour (hex) |
+| `hideDetails` | `boolean` | Show only the time picker |
+| `onBookingSuccessful` | `(b: { uid, url }) => void` | Fired on confirmation |
+| `onHeightChange` | `(height: number) => void` | Inline booker only |
+
+Self-hosting? Point `baseUrl` at your instance — the components load
+`${baseUrl}/embed/<handle>/<slug>`.

--- a/packages/embed-react/package.json
+++ b/packages/embed-react/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@dayotter/embed-react",
+  "version": "0.1.0",
+  "description": "White-label React components to embed DayOtter scheduling in your own app.",
+  "license": "AGPL-3.0-or-later",
+  "type": "module",
+  "exports": { ".": "./src/index.tsx" },
+  "files": ["src"],
+  "keywords": ["dayotter", "scheduling", "booking", "embed", "react"],
+  "scripts": { "typecheck": "tsc --noEmit" },
+  "peerDependencies": { "react": ">=18", "react-dom": ">=18" },
+  "devDependencies": {
+    "@types/react": "~19.1.0",
+    "react": "^19.0.0",
+    "typescript": "^5.7.2"
+  }
+}

--- a/packages/embed-react/src/index.tsx
+++ b/packages/embed-react/src/index.tsx
@@ -1,0 +1,223 @@
+import { type CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+/** Where the booking pages are served. Point at your own instance when self-hosting. */
+export const DEFAULT_BASE_URL = "https://dayotter.com";
+
+export interface BookingSuccess {
+  /** The booking's public uid. */
+  uid: string;
+  /** Relative confirmation URL, e.g. `/booking/<uid>`. */
+  url: string;
+}
+
+export interface EmbedOptions {
+  /** Public booking handle, e.g. "ada". */
+  handle: string;
+  /** Event-type slug, e.g. "intro". */
+  slug: string;
+  /** Instance origin (no trailing slash needed). Defaults to dayotter.com. */
+  baseUrl?: string;
+  /** Force a colour scheme, or follow the frame's default ("auto"). */
+  theme?: "light" | "dark" | "auto";
+  /** Accent colour as a hex string (with or without leading #). */
+  primaryColor?: string;
+  /** Hide the event-details header (show only the time picker). */
+  hideDetails?: boolean;
+}
+
+function trimSlash(s: string): string {
+  return s.replace(/\/+$/, "");
+}
+
+/** Build the `/embed/<handle>/<slug>` URL with the white-label query params. */
+export function buildEmbedUrl(opts: EmbedOptions): string {
+  const base = trimSlash(opts.baseUrl || DEFAULT_BASE_URL);
+  const params = new URLSearchParams();
+  if (opts.theme && opts.theme !== "auto") params.set("theme", opts.theme);
+  if (opts.primaryColor) params.set("primaryColor", opts.primaryColor.replace(/^#/, ""));
+  if (opts.hideDetails) params.set("hideDetails", "1");
+  const qs = params.toString();
+  return `${base}/embed/${encodeURIComponent(opts.handle)}/${encodeURIComponent(opts.slug)}${
+    qs ? `?${qs}` : ""
+  }`;
+}
+
+interface DayOtterMessage {
+  type?: string;
+  height?: number;
+  uid?: string;
+  url?: string;
+}
+
+export interface DayOtterBookerProps extends EmbedOptions {
+  /** Fired once a booking is confirmed inside the frame. */
+  onBookingSuccessful?: (booking: BookingSuccess) => void;
+  /** Fired whenever the embedded content reports a new height. */
+  onHeightChange?: (height: number) => void;
+  /** Initial height before the frame reports its own (px). Default 640. */
+  initialHeight?: number;
+  className?: string;
+  style?: CSSProperties;
+}
+
+/**
+ * Inline embedded DayOtter booker. Renders the booking flow in an iframe that
+ * auto-resizes to its content (via postMessage) and reports booking success.
+ */
+export function DayOtterBooker({
+  onBookingSuccessful,
+  onHeightChange,
+  initialHeight = 640,
+  className,
+  style,
+  handle,
+  slug,
+  baseUrl,
+  theme,
+  primaryColor,
+  hideDetails,
+}: DayOtterBookerProps) {
+  const ref = useRef<HTMLIFrameElement>(null);
+  const [height, setHeight] = useState(initialHeight);
+  const src = useMemo(
+    () => buildEmbedUrl({ handle, slug, baseUrl, theme, primaryColor, hideDetails }),
+    [handle, slug, baseUrl, theme, primaryColor, hideDetails],
+  );
+  const origin = useMemo(() => {
+    try {
+      return new URL(src).origin;
+    } catch {
+      return "";
+    }
+  }, [src]);
+
+  useEffect(() => {
+    function onMessage(e: MessageEvent<DayOtterMessage>) {
+      // Only trust messages from the iframe we rendered.
+      if (origin && e.origin !== origin) return;
+      if (ref.current && e.source !== ref.current.contentWindow) return;
+      const data = e.data;
+      if (!data || typeof data !== "object") return;
+      if (data.type === "dayotter:height" && typeof data.height === "number") {
+        setHeight(data.height);
+        onHeightChange?.(data.height);
+      } else if (data.type === "dayotter:booking" && data.uid && data.url) {
+        onBookingSuccessful?.({ uid: data.uid, url: data.url });
+      }
+    }
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, [origin, onBookingSuccessful, onHeightChange]);
+
+  return (
+    <iframe
+      ref={ref}
+      src={src}
+      title="DayOtter booking"
+      loading="lazy"
+      allow="payment"
+      className={className}
+      style={{ width: "100%", border: "0", height, ...style }}
+    />
+  );
+}
+
+export interface PopupOptions extends EmbedOptions {
+  onBookingSuccessful?: (booking: BookingSuccess) => void;
+}
+
+/**
+ * Open the booker in a centered modal overlay. Framework-agnostic (plain DOM),
+ * so it works outside React too. Returns a `close()` handle.
+ */
+export function openDayOtterPopup(opts: PopupOptions): { close: () => void } {
+  const src = buildEmbedUrl(opts);
+  let origin = "";
+  try {
+    origin = new URL(src).origin;
+  } catch {
+    /* ignore */
+  }
+
+  const overlay = document.createElement("div");
+  overlay.setAttribute("data-dayotter-overlay", "");
+  overlay.style.cssText =
+    "position:fixed;inset:0;z-index:2147483647;background:rgba(15,15,20,.55);display:flex;align-items:center;justify-content:center;padding:16px";
+
+  const box = document.createElement("div");
+  box.style.cssText =
+    "position:relative;background:#fff;border-radius:14px;overflow:hidden;width:100%;max-width:820px;height:88vh;box-shadow:0 20px 60px rgba(0,0,0,.3)";
+
+  const frame = document.createElement("iframe");
+  frame.src = src;
+  frame.title = "DayOtter booking";
+  frame.setAttribute("allow", "payment");
+  frame.style.cssText = "border:0;width:100%;height:100%";
+
+  const closeBtn = document.createElement("button");
+  closeBtn.setAttribute("aria-label", "Close");
+  closeBtn.innerHTML = "&times;";
+  closeBtn.style.cssText =
+    "position:absolute;top:8px;right:10px;z-index:1;border:0;background:rgba(0,0,0,.06);border-radius:999px;width:30px;height:30px;font-size:20px;line-height:1;cursor:pointer";
+
+  function close() {
+    window.removeEventListener("message", onMessage);
+    overlay.remove();
+  }
+  function onMessage(e: MessageEvent<DayOtterMessage>) {
+    if (origin && e.origin !== origin) return;
+    if (e.source !== frame.contentWindow) return;
+    if (e.data?.type === "dayotter:booking" && e.data.uid && e.data.url) {
+      opts.onBookingSuccessful?.({ uid: e.data.uid, url: e.data.url });
+    }
+  }
+
+  closeBtn.addEventListener("click", close);
+  overlay.addEventListener("click", (e) => {
+    if (e.target === overlay) close();
+  });
+  window.addEventListener("message", onMessage);
+
+  box.appendChild(closeBtn);
+  box.appendChild(frame);
+  overlay.appendChild(box);
+  document.body.appendChild(overlay);
+  return { close };
+}
+
+export interface DayOtterButtonProps extends PopupOptions {
+  children?: React.ReactNode;
+  className?: string;
+  style?: CSSProperties;
+}
+
+/** A button that opens the booker in a modal popup. */
+export function DayOtterButton({
+  children = "Book a time",
+  className,
+  style,
+  onBookingSuccessful,
+  handle,
+  slug,
+  baseUrl,
+  theme,
+  primaryColor,
+  hideDetails,
+}: DayOtterButtonProps) {
+  const open = useCallback(() => {
+    openDayOtterPopup({
+      handle,
+      slug,
+      baseUrl,
+      theme,
+      primaryColor,
+      hideDetails,
+      onBookingSuccessful,
+    });
+  }, [handle, slug, baseUrl, theme, primaryColor, hideDetails, onBookingSuccessful]);
+  return (
+    <button type="button" onClick={open} className={className} style={style}>
+      {children}
+    </button>
+  );
+}

--- a/packages/embed-react/tsconfig.json
+++ b/packages/embed-react/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "rootDir": "src", "outDir": "dist", "jsx": "react-jsx", "lib": ["DOM", "ES2022"] },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -391,6 +391,22 @@ importers:
         specifier: ^5.7.2
         version: 5.7.3
 
+  packages/embed-react:
+    dependencies:
+      react-dom:
+        specifier: '>=18'
+        version: 19.2.7(react@19.0.0)
+    devDependencies:
+      '@types/react':
+        specifier: ~19.1.0
+        version: 19.1.17
+      react:
+        specifier: ^19.0.0
+        version: 19.0.0
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+
   packages/integrations:
     dependencies:
       '@dayotter/calendar':
@@ -10654,7 +10670,6 @@ snapshots:
     dependencies:
       react: 19.0.0
       scheduler: 0.27.0
-    optional: true
 
   react-dom@19.2.7(react@19.2.7):
     dependencies:


### PR DESCRIPTION
A white-label way to drop DayOtter scheduling into any **React app** or website — beyond the existing `embed.js` iframe loader.

## `@dayotter/embed-react` (new package)
```tsx
import { DayOtterBooker } from "@dayotter/embed-react";
<DayOtterBooker handle="ada" slug="intro" theme="light" primaryColor="#6743e6"
  onBookingSuccessful={(b) => track(b.uid)} />
```
- **`<DayOtterBooker>`** — inline iframe that **auto-resizes** to its content (postMessage) and fires `onBookingSuccessful`.
- **`<DayOtterButton>` / `openDayOtterPopup()`** — modal popup (works outside React too).
- **`buildEmbedUrl`** + full types. React peer-dep only; **`baseUrl`** points at any self-hosted instance. Ships a README.

## Supporting pieces
- **`/embed/[handle]/[slug]`** — a chrome-less booking flow for the iframe: same data as the public page minus the site shell, themeable via `?theme` / `?primaryColor` / `?hideDetails`, wrapped in an **EmbedBridge** that posts its height and relays booking success to the parent.
- **`SlotPicker`** gains an `embed` prop → postMessages `dayotter:booking` on success (surfaced by the SDK / embed.js).
- App registry lists **Embed & React SDK** under developer tools.

**Framing stays safe:** the middleware only denies framing of authenticated app routes; public + `/embed` pages remain embeddable (unchanged). The SDK validates every message against the iframe's origin + window.

## Verification
embed-react + web typecheck; **134 web tests**; biome clean. Live-rendered `/embed/<handle>/<slug>?theme=dark&primaryColor=…` — booker + event details render and honor the theme/brand params; `buildEmbedUrl` produces correct URLs including self-hosted `baseUrl` + query flags.

Follow-up: true "native" Atoms (components hitting a public availability API with an access token) depend on **#117** (platform OAuth / managed users); this iframe-based SDK is the secure, works-today v1.

Closes #116.