### PR TITLE
feat(availability): host-facing availability troubleshooter (#131)

### DIFF
--- a/apps/web/app/(app)/availability/page.tsx
+++ b/apps/web/app/(app)/availability/page.tsx
@@ -1,3 +1,4 @@
+import { AvailabilityTroubleshooter } from "@/components/availability-troubleshooter";
 import { FocusDefense } from "@/components/focus-defense";
 import { OutOfOffice } from "@/components/out-of-office";
 import { PageHeader } from "@/components/page-header";
@@ -75,6 +76,7 @@ export default async function AvailabilityPage() {
       />
       <TimeBlocks />
       <OutOfOffice />
+      <AvailabilityTroubleshooter />
     </>
   );
 }

--- a/apps/web/app/api/availability/troubleshoot/route.ts
+++ b/apps/web/app/api/availability/troubleshoot/route.ts
@@ -1,0 +1,39 @@
+import { eventConstraints, troubleshootHostDay } from "@/lib/booking/availability";
+import { jsonError, withUser } from "@/lib/server/http";
+import { eq, getDb, schema } from "@dayotter/db";
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Host-only diagnostic: why does a given event type offer (or not offer) slots on
+ * a given day? Returns the schedule windows, booking-window/notice status, and a
+ * per-day count of what's blocked by busy time vs notice, with plain-English
+ * reasons. See lib/booking/availability#troubleshootHostDay.
+ */
+export const GET = withUser(async (u, request) => {
+  const url = new URL(request.url);
+  const eventTypeId = url.searchParams.get("eventTypeId");
+  const dateStr = url.searchParams.get("date"); // YYYY-MM-DD
+  if (!eventTypeId || !dateStr || !/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) {
+    return jsonError("eventTypeId and a YYYY-MM-DD date are required", 400);
+  }
+  const date = new Date(`${dateStr}T12:00:00Z`);
+  if (Number.isNaN(date.getTime())) return jsonError("Invalid date", 400);
+
+  const et = await getDb().query.eventTypes.findFirst({
+    where: eq(schema.eventTypes.id, eventTypeId),
+  });
+  if (!et || et.ownerId !== u.id) return jsonError("Event type not found", 404);
+
+  const diagnosis = await troubleshootHostDay(
+    u.id,
+    et.scheduleId,
+    eventConstraints(et),
+    date,
+    et.minimumGapMinutes ?? 0,
+  );
+  if (!diagnosis) return jsonError("No availability schedule is configured.", 400);
+
+  return NextResponse.json({ diagnosis });
+});

--- a/apps/web/components/availability-troubleshooter.tsx
+++ b/apps/web/components/availability-troubleshooter.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardBody, CardHeader } from "@/components/ui/card";
+import { Input, Label } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
+import type { DayDiagnosis } from "@dayotter/core";
+import { AlertTriangle, CheckCircle2, Stethoscope } from "lucide-react";
+import { useEffect, useState } from "react";
+
+interface EventTypeLite {
+  id: string;
+  title: string;
+}
+
+function todayISO(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export function AvailabilityTroubleshooter() {
+  const [eventTypes, setEventTypes] = useState<EventTypeLite[]>([]);
+  const [eventTypeId, setEventTypeId] = useState("");
+  const [date, setDate] = useState(todayISO());
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<DayDiagnosis | null>(null);
+
+  useEffect(() => {
+    fetch("/api/event-types")
+      .then((r) => r.json())
+      .then((d: { eventTypes?: EventTypeLite[] }) => {
+        const list = d.eventTypes ?? [];
+        setEventTypes(list);
+        if (list[0]) setEventTypeId(list[0].id);
+      })
+      .catch(() => {});
+  }, []);
+
+  async function run() {
+    if (!eventTypeId) return;
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      const res = await fetch(
+        `/api/availability/troubleshoot?eventTypeId=${eventTypeId}&date=${date}`,
+      );
+      const data = await res.json();
+      if (!res.ok) {
+        setError(typeof data.error === "string" ? data.error : "Couldn't run the check.");
+        return;
+      }
+      setResult(data.diagnosis as DayDiagnosis);
+    } catch {
+      setError("Something went wrong. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Card className="mt-8">
+      <CardHeader
+        title={
+          <span className="flex items-center gap-2">
+            <Stethoscope size={16} /> Availability troubleshooter
+          </span>
+        }
+        description="See exactly why a booking type does (or doesn't) offer times on a given day."
+      />
+      <CardBody>
+        <div className="flex flex-wrap items-end gap-3">
+          <div className="min-w-48 flex-1">
+            <Label htmlFor="ts-et">Booking type</Label>
+            <Select id="ts-et" value={eventTypeId} onChange={(e) => setEventTypeId(e.target.value)}>
+              {eventTypes.length === 0 ? <option value="">No booking types</option> : null}
+              {eventTypes.map((et) => (
+                <option key={et.id} value={et.id}>
+                  {et.title}
+                </option>
+              ))}
+            </Select>
+          </div>
+          <div>
+            <Label htmlFor="ts-date">Day</Label>
+            <Input
+              id="ts-date"
+              type="date"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+            />
+          </div>
+          <Button onClick={run} disabled={loading || !eventTypeId}>
+            {loading ? "Checking…" : "Diagnose"}
+          </Button>
+        </div>
+
+        {error ? (
+          <p className="mt-4 flex items-center gap-1.5 text-sm text-[var(--color-danger)]">
+            <AlertTriangle size={14} /> {error}
+          </p>
+        ) : null}
+
+        {result ? (
+          <div className="mt-5 space-y-3 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-2)] p-4 text-sm">
+            <p className="font-medium">
+              {result.weekday}, {result.date} —{" "}
+              {result.bookableSlots > 0 ? (
+                <span className="text-[var(--color-success)]">
+                  {result.bookableSlots} slot{result.bookableSlots === 1 ? "" : "s"} bookable
+                </span>
+              ) : (
+                <span className="text-[var(--color-danger)]">no bookable slots</span>
+              )}
+            </p>
+
+            <ul className="space-y-1.5">
+              {result.reasons.map((r) => (
+                <li key={r} className="flex items-start gap-1.5 text-[var(--color-muted)]">
+                  {result.bookableSlots > 0 ? (
+                    <CheckCircle2
+                      size={14}
+                      className="mt-0.5 shrink-0 text-[var(--color-success)]"
+                    />
+                  ) : (
+                    <AlertTriangle
+                      size={14}
+                      className="mt-0.5 shrink-0 text-[var(--color-amber)]"
+                    />
+                  )}
+                  {r}
+                </li>
+              ))}
+            </ul>
+
+            <dl className="grid grid-cols-2 gap-x-6 gap-y-1 border-t border-[var(--color-border)] pt-3 text-xs text-[var(--color-muted)] sm:grid-cols-4">
+              <div>
+                <dt>Working hours</dt>
+                <dd className="text-[var(--color-text)]">
+                  {result.scheduleWindows.length
+                    ? result.scheduleWindows.map((w) => `${w.start}–${w.end}`).join(", ")
+                    : "—"}
+                </dd>
+              </div>
+              <div>
+                <dt>Schedule capacity</dt>
+                <dd className="text-[var(--color-text)]">{result.totalSlots} slots</dd>
+              </div>
+              <div>
+                <dt>Blocked by busy</dt>
+                <dd className="text-[var(--color-text)]">{result.blockedByBusy}</dd>
+              </div>
+              <div>
+                <dt>Inside min-notice</dt>
+                <dd className="text-[var(--color-text)]">{result.blockedByNoticeOrRange}</dd>
+              </div>
+            </dl>
+          </div>
+        ) : null}
+      </CardBody>
+    </Card>
+  );
+}

--- a/apps/web/lib/booking/availability.ts
+++ b/apps/web/lib/booking/availability.ts
@@ -1,7 +1,10 @@
 import {
+  type AvailabilityInput,
+  type DayDiagnosis,
   type EventConstraints,
   type Slot,
   computeAvailability,
+  explainDay,
   intersectAvailability,
 } from "@dayotter/core";
 import { and, eq, getDb, gte, inArray, lte, ne, schema, sql } from "@dayotter/db";
@@ -411,6 +414,97 @@ async function groupSlotCounts(
 }
 
 /** The user ids who host an event type (owner for individual; hosts for team). */
+/**
+ * Assemble the exact {@link AvailabilityInput} the engine sees for one host on a
+ * day - schedule + every busy source (calendar, own bookings padded by the gap,
+ * focus blocks, lunch, team rules) - and run {@link explainDay} over it. Mirrors
+ * the assembly in {@link hostSlots} (the booking path is left untouched) so the
+ * troubleshooter's reasons match what bookers actually get. Returns null when the
+ * host has no schedule.
+ */
+export async function troubleshootHostDay(
+  userId: string,
+  scheduleId: string | null,
+  event: EventConstraints,
+  date: Date,
+  gapMinutes = 0,
+): Promise<DayDiagnosis | null> {
+  const db = getDb();
+  const schedule = scheduleId
+    ? await db.query.schedules.findFirst({
+        where: eq(schema.schedules.id, scheduleId),
+        with: { availabilityRules: true, dateOverrides: true },
+      })
+    : await db.query.schedules.findFirst({
+        where: and(eq(schema.schedules.userId, userId), eq(schema.schedules.isDefault, true)),
+        with: { availabilityRules: true, dateOverrides: true },
+      });
+  if (!schedule) return null;
+
+  const zone = schedule.timezone;
+  const rangeStart = DateTime.fromJSDate(date, { zone }).startOf("day").toJSDate();
+  const rangeEnd = DateTime.fromJSDate(date, { zone }).endOf("day").toJSDate();
+
+  const connections = await db.query.calendarConnections.findMany({
+    where: eq(schema.calendarConnections.userId, userId),
+    with: { calendars: true },
+  });
+  const calendarIds = connections
+    .flatMap((c) => c.calendars)
+    .filter((cal) => cal.checkForConflicts)
+    .map((cal) => cal.id);
+
+  const [busyRows, ownBookings, blocks, prefs, teamRuleRows] = await Promise.all([
+    calendarIds.length ? busyBlocksFor(calendarIds, rangeStart, rangeEnd) : Promise.resolve([]),
+    bookingsFor([userId], rangeStart, rangeEnd),
+    timeBlocksFor(userId, rangeStart, rangeEnd),
+    getDb().query.userPreferences.findFirst({
+      where: eq(schema.userPreferences.userId, userId),
+      columns: { lunchEnabled: true, lunchStartMinute: true, lunchEndMinute: true },
+    }),
+    teamRulesFor(userId),
+  ]);
+
+  const teamBusy = teamRuleRows.length
+    ? teamRuleIntervals(teamRuleRows, zone, rangeStart, rangeEnd)
+    : [];
+  const lunchBusy = prefs?.lunchEnabled
+    ? lunchIntervals(prefs.lunchStartMinute, prefs.lunchEndMinute, zone, rangeStart, rangeEnd)
+    : [];
+
+  const input: AvailabilityInput = {
+    schedule: {
+      timezone: zone,
+      rules: schedule.availabilityRules.map((r) => ({
+        dayOfWeek: r.dayOfWeek,
+        startTime: r.startTime,
+        endTime: r.endTime,
+      })),
+      overrides: schedule.dateOverrides.map((o) => ({
+        date: o.date,
+        startTime: o.startTime,
+        endTime: o.endTime,
+      })),
+    },
+    busy: [
+      ...busyRows.map((b) => ({ start: b.startsAt, end: b.endsAt })),
+      ...blocks.map((b) => ({ start: b.startsAt, end: b.endsAt })),
+      ...ownBookings.map((b) => ({
+        start: new Date(b.startsAt.getTime() - gapMinutes * 60_000),
+        end: new Date(b.endsAt.getTime() + gapMinutes * 60_000),
+      })),
+      ...lunchBusy,
+      ...teamBusy,
+    ],
+    event,
+    rangeStart,
+    rangeEnd,
+    now: new Date(),
+  };
+
+  return explainDay(input);
+}
+
 export async function eventTypeHostIds(eventType: EventTypeRow): Promise<string[]> {
   if (eventType.ownerId) return [eventType.ownerId];
   const hosts = await getDb().query.eventTypeHosts.findMany({

--- a/packages/core/src/availability/index.ts
+++ b/packages/core/src/availability/index.ts
@@ -5,3 +5,4 @@
 export * from "./types";
 export { computeAvailability, intersectAvailability } from "./engine";
 export { roundRobinPick, type RoundRobinCandidate } from "../round-robin";
+export { explainDay, type DayDiagnosis, type DayWindow } from "./troubleshoot";

--- a/packages/core/src/availability/troubleshoot.test.ts
+++ b/packages/core/src/availability/troubleshoot.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { explainDay } from "./troubleshoot";
+import type { AvailabilityInput, Schedule } from "./types";
+
+// Mon–Fri 09:00–17:00 New York (matches engine.test.ts).
+const nineToFive: Schedule = {
+  timezone: "America/New_York",
+  rules: [1, 2, 3, 4, 5].map((dayOfWeek) => ({ dayOfWeek, startTime: "09:00", endTime: "17:00" })),
+  overrides: [],
+};
+
+// 2026-01-05 is a Monday; NY midnight = 05:00Z.
+const onDay = (dateUtc: string, over: Partial<AvailabilityInput> = {}): AvailabilityInput => ({
+  schedule: nineToFive,
+  busy: [],
+  event: {
+    durationMinutes: 30,
+    bufferBeforeMinutes: 0,
+    bufferAfterMinutes: 0,
+    minimumNoticeMinutes: 0,
+  },
+  rangeStart: new Date(dateUtc),
+  rangeEnd: new Date(dateUtc),
+  now: new Date("2026-01-05T05:00:00Z"),
+  ...over,
+});
+
+describe("explainDay", () => {
+  it("reports a normal working day with all its slots", () => {
+    const d = explainDay(onDay("2026-01-05T12:00:00Z")); // Monday
+    expect(d.weekday).toBe("Monday");
+    expect(d.dayOff).toBe(false);
+    expect(d.totalSlots).toBe(16); // 09:00..16:30
+    expect(d.bookableSlots).toBe(16);
+    expect(d.scheduleWindows).toEqual([{ start: "09:00", end: "17:00" }]);
+    expect(d.reasons.join(" ")).toMatch(/16 slots available/);
+  });
+
+  it("flags a day with no working hours (weekend)", () => {
+    const d = explainDay(onDay("2026-01-04T12:00:00Z")); // Sunday
+    expect(d.weekday).toBe("Sunday");
+    expect(d.dayOff).toBe(true);
+    expect(d.totalSlots).toBe(0);
+    expect(d.reasons.join(" ")).toMatch(/No working hours are set for Sunday/);
+  });
+
+  it("attributes slots lost to busy time", () => {
+    const d = explainDay(
+      onDay("2026-01-05T12:00:00Z", {
+        // 09:00–17:00 EST fully busy => everything blocked.
+        busy: [{ start: new Date("2026-01-05T14:00:00Z"), end: new Date("2026-01-05T22:00:00Z") }],
+      }),
+    );
+    expect(d.totalSlots).toBe(16);
+    expect(d.bookableSlots).toBe(0);
+    expect(d.blockedByBusy).toBe(16);
+    expect(d.reasons.join(" ")).toMatch(/blocked by a busy event/);
+  });
+
+  it("attributes slots lost to minimum notice", () => {
+    const d = explainDay(
+      onDay("2026-01-05T12:00:00Z", {
+        now: new Date("2026-01-05T14:00:00Z"), // 09:00 EST
+        event: {
+          durationMinutes: 30,
+          bufferBeforeMinutes: 0,
+          bufferAfterMinutes: 0,
+          minimumNoticeMinutes: 24 * 60, // pushes today's slots out
+        },
+      }),
+    );
+    expect(d.bookableSlots).toBe(0);
+    expect(d.blockedByNoticeOrRange).toBe(16);
+    expect(d.reasons.join(" ")).toMatch(/minimum-notice/);
+  });
+
+  it("honors a date override that closes the day", () => {
+    const d = explainDay(
+      onDay("2026-01-05T12:00:00Z", {
+        schedule: {
+          ...nineToFive,
+          overrides: [{ date: "2026-01-05", startTime: null, endTime: null }],
+        },
+      }),
+    );
+    expect(d.dayOff).toBe(true);
+    expect(d.override).not.toBeNull();
+    expect(d.reasons.join(" ")).toMatch(/marked unavailable/);
+  });
+
+  it("flags a day beyond the booking window", () => {
+    const d = explainDay(
+      onDay("2026-06-01T12:00:00Z", {
+        event: {
+          durationMinutes: 30,
+          bufferBeforeMinutes: 0,
+          bufferAfterMinutes: 0,
+          minimumNoticeMinutes: 0,
+          bookingWindowDays: 30,
+        },
+      }),
+    );
+    expect(d.beyondBookingWindow).toBe(true);
+    expect(d.reasons.join(" ")).toMatch(/beyond the 30-day booking window/);
+  });
+});

--- a/packages/core/src/availability/troubleshoot.ts
+++ b/packages/core/src/availability/troubleshoot.ts
@@ -1,0 +1,111 @@
+import { DateTime } from "luxon";
+import { computeAvailability } from "./engine";
+import type { AvailabilityInput, DateOverride } from "./types";
+
+const WEEKDAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+
+export interface DayWindow {
+  start: string;
+  end: string;
+}
+
+export interface DayDiagnosis {
+  /** ISO date (schedule timezone). */
+  date: string;
+  weekday: string;
+  /** Open windows that day (wall-clock), from the override or the weekly rules. */
+  scheduleWindows: DayWindow[];
+  override: DateOverride | null;
+  /** No working hours at all that day. */
+  dayOff: boolean;
+  beyondBookingWindow: boolean;
+  /** Slots the grid would produce ignoring busy/notice (i.e. schedule capacity). */
+  totalSlots: number;
+  bookableSlots: number;
+  blockedByBusy: number;
+  blockedByNoticeOrRange: number;
+  /** Human-readable explanation, most important first. */
+  reasons: string[];
+}
+
+/**
+ * Explain why a single day offers the slots it does (or none). Re-runs the real
+ * availability engine three times over the day - once raw, once with busy, once
+ * fully - and diffs the counts, so the attribution can never drift from what the
+ * booker actually sees. `input.rangeStart` selects the day (in the schedule tz).
+ */
+export function explainDay(input: AvailabilityInput): DayDiagnosis {
+  const zone = input.schedule.timezone;
+  const day = DateTime.fromJSDate(input.rangeStart, { zone });
+  const dayStart = day.startOf("day").toJSDate();
+  const dayEnd = day.endOf("day").toJSDate();
+  const isoDate = day.toISODate() ?? "";
+  const dow = day.weekday === 7 ? 0 : day.weekday; // Luxon 1=Mon..7=Sun -> 0=Sun
+
+  const override = input.schedule.overrides.find((o) => o.date === isoDate) ?? null;
+
+  const scheduleWindows: DayWindow[] = override
+    ? override.startTime && override.endTime
+      ? [{ start: override.startTime, end: override.endTime }]
+      : []
+    : input.schedule.rules
+        .filter((r) => r.dayOfWeek === dow)
+        .map((r) => ({ start: r.startTime, end: r.endTime }));
+
+  const dayRange = { ...input, rangeStart: dayStart, rangeEnd: dayEnd };
+  // Capacity/busy passes must ignore the *time gates* (minimum notice + booking
+  // window), else a distant day reads as "0 slots" purely because it's outside
+  // the window - hiding the real reason. Those gates are attributed separately.
+  const openEvent = { ...input.event, minimumNoticeMinutes: 0, bookingWindowDays: null };
+  const totalSlots = computeAvailability({
+    ...dayRange,
+    busy: [],
+    event: openEvent,
+    now: dayStart,
+  }).length;
+  const afterBusy = computeAvailability({ ...dayRange, event: openEvent, now: dayStart }).length;
+  const bookableSlots = computeAvailability(dayRange).length; // real notice + window + now
+  const blockedByBusy = Math.max(0, totalSlots - afterBusy);
+  const blockedByNoticeOrRange = Math.max(0, afterBusy - bookableSlots);
+
+  const beyondBookingWindow =
+    input.event.bookingWindowDays != null &&
+    dayStart.getTime() > input.now.getTime() + input.event.bookingWindowDays * 86_400_000;
+
+  const dayOff = totalSlots === 0;
+
+  const reasons: string[] = [];
+  if (override && (!override.startTime || !override.endTime)) {
+    reasons.push(`${isoDate} is marked unavailable (a date override closes the day).`);
+  } else if (dayOff) {
+    reasons.push(`No working hours are set for ${WEEKDAYS[dow]}.`);
+  }
+  if (beyondBookingWindow) {
+    reasons.push(`This day is beyond the ${input.event.bookingWindowDays}-day booking window.`);
+  }
+  if (!dayOff && !beyondBookingWindow && bookableSlots === 0) {
+    if (blockedByBusy > 0) {
+      reasons.push("Every slot is blocked by a busy event, a buffer, or an existing booking.");
+    }
+    if (blockedByNoticeOrRange > 0) {
+      reasons.push("Remaining slots fall inside the minimum-notice window.");
+    }
+  }
+  if (bookableSlots > 0) {
+    reasons.push(`${bookableSlots} slot${bookableSlots === 1 ? "" : "s"} available.`);
+  }
+
+  return {
+    date: isoDate,
+    weekday: WEEKDAYS[dow] ?? "",
+    scheduleWindows,
+    override,
+    dayOff,
+    beyondBookingWindow,
+    totalSlots,
+    bookableSlots,
+    blockedByBusy,
+    blockedByNoticeOrRange,
+    reasons,
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./availability/types";
 export { computeAvailability, intersectAvailability } from "./availability/engine";
+export { explainDay, type DayDiagnosis, type DayWindow } from "./availability/troubleshoot";
 export {
   encrypt,
   decrypt,


### PR DESCRIPTION
## What

Adds a host-only **Availability troubleshooter** on the Availability page: pick a booking type and a day, and it explains exactly why that day does (or doesn't) offer times.

## Why

"Why aren't my times showing?" is the single most common support question for any scheduling tool. This turns guesswork into a plain-English answer grounded in the real engine.

## How

- **`packages/core` — `explainDay(input): DayDiagnosis`** (+6 tests). Re-runs `computeAvailability` over the day three times — raw schedule capacity, with busy time, then fully gated — and diffs the counts, so the attribution can never drift from what a booker sees. The capacity/busy passes neutralize the *time gates* (minimum notice + booking window) so a distant day is reported as "beyond the booking window", not a false "day off".
- **`apps/web`** — `troubleshootHostDay` assembler (mirrors `hostSlots`, leaves it untouched → zero regression risk), an ownership-checked `GET /api/availability/troubleshoot?eventTypeId=&date=`, and an `<AvailabilityTroubleshooter />` panel.

## Verification

- `packages/core`: 39 tests pass (incl. 6 new troubleshoot tests).
- Typecheck (core + web) and Biome clean.
- Live-tested against the dev server across three cases:
  - Weekday → `16 bookable / 16 capacity`, "16 slots available."
  - Weekend → `0`, day off, "No working hours are set for Sunday."
  - Beyond window → `0 bookable / 16 capacity`, "This day is beyond the 60-day booking window." (correctly distinguishes a gated day from a closed one — this diff-attribution edge is exactly what the live test caught and the fix addresses.)

Closes #131