### PR TITLE
fix(booking): post-merge audit fixes for #103 / #102 / #131

### DIFF
--- a/apps/web/app/[handle]/[slug]/page.tsx
+++ b/apps/web/app/[handle]/[slug]/page.tsx
@@ -55,9 +55,10 @@ export default async function PublicBookingPage({
   const activeOoo = hostToday ? await outOfOfficeOn(host.id, hostToday) : null;
 
   // Locations the booker may choose from (falls back to the single location).
+  // A group event is one shared meeting, so no per-booker choice - use the primary.
   const offered = offeredLocations(eventType);
   const locationChoices =
-    offered.length > 1
+    offered.length > 1 && (eventType.maxAttendees ?? 1) <= 1
       ? offered.map((o) => ({ type: o.type, label: LOCATION_LABELS[o.type] ?? o.type }))
       : [];
 

--- a/apps/web/app/api/availability/troubleshoot/route.ts
+++ b/apps/web/app/api/availability/troubleshoot/route.ts
@@ -18,6 +18,11 @@ export const GET = withUser(async (u, request) => {
   if (!eventTypeId || !dateStr || !/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) {
     return jsonError("eventTypeId and a YYYY-MM-DD date are required", 400);
   }
+  // eventTypeId is a uuid column - reject a malformed value up front rather than
+  // letting Postgres throw an uncaught "invalid input syntax for type uuid" 500.
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(eventTypeId)) {
+    return jsonError("Event type not found", 404);
+  }
   const date = new Date(`${dateStr}T12:00:00Z`);
   if (Number.isNaN(date.getTime())) return jsonError("Invalid date", 400);
 

--- a/apps/web/app/api/out-of-office/route.ts
+++ b/apps/web/app/api/out-of-office/route.ts
@@ -1,6 +1,6 @@
 import { isValidDelegate, listOutOfOffice, listTeammates } from "@/lib/out-of-office";
 import { jsonError, withUser } from "@/lib/server/http";
-import { getDb, schema } from "@dayotter/db";
+import { eq, getDb, schema } from "@dayotter/db";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
@@ -30,6 +30,17 @@ export const POST = withUser(async (u, request) => {
   }
   const d = parsed.data;
   if (d.endDate < d.startDate) return jsonError("End date must be on or after start date", 400);
+
+  // Cap how many periods one user can hold, so a runaway client can't fill the
+  // table (each row is scanned on every availability computation for that user).
+  const existing = await getDb().query.outOfOfficePeriods.findMany({
+    where: eq(schema.outOfOfficePeriods.userId, u.id),
+    columns: { id: true },
+    limit: 200,
+  });
+  if (existing.length >= 100) {
+    return jsonError("You've reached the maximum number of out-of-office periods (100)", 400);
+  }
 
   // A delegate must be a real teammate - never let an arbitrary user id through.
   if (d.delegateUserId && !(await isValidDelegate(u.id, d.delegateUserId))) {

--- a/apps/web/app/embed/[handle]/[slug]/page.tsx
+++ b/apps/web/app/embed/[handle]/[slug]/page.tsx
@@ -49,8 +49,9 @@ export default async function EmbedBookingPage({
   const priceLabel =
     chargeAmount > 0 ? formatMoney(chargeAmount, eventType.currency ?? "usd") : null;
   const offered = offeredLocations(eventType);
+  // Group events share one meeting - no per-booker location choice.
   const locationChoices =
-    offered.length > 1
+    offered.length > 1 && (eventType.maxAttendees ?? 1) <= 1
       ? offered.map((o) => ({ type: o.type, label: LOCATION_LABELS[o.type] ?? o.type }))
       : [];
 

--- a/apps/web/components/availability-troubleshooter.tsx
+++ b/apps/web/components/availability-troubleshooter.tsx
@@ -151,7 +151,7 @@ export function AvailabilityTroubleshooter() {
                 <dd className="text-[var(--color-text)]">{result.blockedByBusy}</dd>
               </div>
               <div>
-                <dt>Inside min-notice</dt>
+                <dt>Notice / booking window</dt>
                 <dd className="text-[var(--color-text)]">{result.blockedByNoticeOrRange}</dd>
               </div>
             </dl>

--- a/apps/web/lib/booking/create-booking.ts
+++ b/apps/web/lib/booking/create-booking.ts
@@ -175,6 +175,13 @@ export async function createBooking(
   const capacity = eventType.maxAttendees ?? 1;
   const isGroup = capacity > 1 && Boolean(eventType.ownerId);
 
+  // A group event is ONE shared meeting, so every attendee gets the event's primary
+  // location - a per-booker choice would put mismatched locations on one meeting.
+  // (The booking page hides the picker for groups; this enforces it server-side.)
+  const finalLocation = isGroup
+    ? (resolveChosenLocation(eventType, null) ?? chosenLocation)
+    : chosenLocation;
+
   // Re-validate server-side (the picker may be stale / manipulated). Compute the
   // per-host slots once (for the chosen duration) and reuse them for the check
   // and host resolution.
@@ -441,8 +448,8 @@ export async function createBooking(
           timezone: input.attendee.timezone,
           status: initialStatus,
           isGroup,
-          location: chosenLocation.detail ?? null,
-          locationType: chosenLocation.type,
+          location: finalLocation.detail ?? null,
+          locationType: finalLocation.type,
           responses: input.responses,
           uid,
           recurrenceUid,
@@ -498,7 +505,7 @@ export async function createBooking(
           timezone: input.attendee.timezone,
           hostName: host.name ?? "your host",
           attendeeName: input.attendee.name,
-          location: chosenLocation.detail ?? undefined,
+          location: finalLocation.detail ?? undefined,
           manageUrl: attendeeManageUrl,
         }),
         to: input.attendee.email,
@@ -521,7 +528,7 @@ export async function createBooking(
             timezone: host.timezone,
             hostName: host.name ?? "you",
             attendeeName: input.attendee.name,
-            location: chosenLocation.detail ?? undefined,
+            location: finalLocation.detail ?? undefined,
             manageUrl: hostReviewUrl,
           }),
           to: host.email,

--- a/apps/web/lib/booking/reschedule-booking.ts
+++ b/apps/web/lib/booking/reschedule-booking.ts
@@ -49,6 +49,14 @@ export async function rescheduleBooking(
   });
   if (!eventType) throw new RescheduleError("Event type not found", 404);
 
+  // Honor the location the booker chose (persisted on the booking) over the event
+  // type's primary - mirrors finalizeConfirmedBooking - so a reschedule keeps the
+  // booker's chosen meeting type/link instead of silently resetting to the default.
+  if (booking.locationType) {
+    eventType.location = booking.locationType;
+    eventType.locationDetail = booking.location;
+  }
+
   const newStart = new Date(newStartISO);
   if (Number.isNaN(newStart.getTime())) throw new RescheduleError("Invalid time", 400);
   // Preserve the booking's ACTUAL length (multi-duration event types), not the


### PR DESCRIPTION
Second-pass product + security audit of the last few merged PRs (#103 multiple locations, #102 out-of-office, #131 troubleshooter, #126 locales), done with three independent adversarial reviews. **#126 and the cross-cutting schema changes came back clean.** This PR fixes what the reviews found.

## 🔴 Regression — reschedule lost the booker's chosen location (#103, medium)
`rescheduleBooking` rebuilt the moved calendar event, travel blocks, and the reschedule email from the event type's **primary** location, ignoring `booking.location_type`. A booking made as "phone" or "in-person" silently reverted to the event's default (e.g. Google Meet) on any reschedule — wrong invite, wrong/absent conference link, wrong travel reservation.
Fix: honour `booking.location_type` at the top of `rescheduleBooking`, mirroring `finalizeConfirmedBooking`. **Verified**: an `in_person` booking stays `in_person` across a reschedule.

## 🟡 Group events + multi-location were incoherent (#103, product)
A group event is one shared meeting, so letting each attendee pick a different location put mismatched locations on the same meeting. Now the location picker is **suppressed for group event types** (booking + embed pages), and `create-booking` **forces the event's primary location** for group bookings server-side (defense in depth). **Verified**: a crafted non-primary choice is overridden to the primary; the picker is absent from a group booking page.

## 🟡 Troubleshooter robustness (#131)
- A malformed (non-UUID) `eventTypeId` reached Postgres and threw an uncaught **500**; now validated up front → **404**. **Verified**.
- The "Inside min-notice" stat also counts booking-window blocks — relabelled "Notice / booking window" so the number isn't mislabeled (the plain-English reasons were already correct).

## 🟡 Out-of-office hygiene (#102)
Cap OOO periods at **100 per user** — every row is scanned on each availability computation, so an unbounded client could degrade its own availability math.

## Reviewed-and-clear (no change needed)
- **#102 OOO**: write-time enforcement is real (a direct API POST inside an OOO range is rejected 409, not just hidden), authz is user-scoped on every route, DELETE returns a clean 404 with no existence oracle, delegate must be a real teammate.
- **#103**: paid/credit/v1 booking paths all funnel through the same location validation (no bypass); `locations[].detail` is host-configured (not booker-controlled) and both the ICS and email sinks already escape; mobile round-trip can't wipe a web-set menu.
- **#126 locales** and the **additive schema columns**: clean (key/placeholder parity holds; no leak; Calendly importer + AI tools unaffected).

## Verification
Typecheck (web) + Biome clean; 39 core tests pass; all three behavioral fixes live-verified against the dev server.