### PR TITLE
feat(i18n): booking-page language picker

### DIFF
--- a/apps/web/app/[handle]/[slug]/page.tsx
+++ b/apps/web/app/[handle]/[slug]/page.tsx
@@ -1,6 +1,8 @@
 import { BookingPixels } from "@/components/booking-pixels";
 import { HostAvatar } from "@/components/host-avatar";
+import { LanguagePicker } from "@/components/language-picker";
 import { SlotPicker } from "@/components/slot-picker";
+import { Tr } from "@/components/tr";
 import { Card, CardBody } from "@/components/ui/card";
 import { ViewTracker } from "@/components/view-tracker";
 import { aiEnabled } from "@/lib/ai/llm";
@@ -10,7 +12,7 @@ import { brandStyle, getHostBranding } from "@/lib/booking/branding";
 import { LOCATION_LABELS, offeredLocations } from "@/lib/booking/event-type-input";
 import { chargeFor, formatMoney } from "@/lib/booking/money";
 import { brandingHidden } from "@/lib/ee/white-label";
-import { resolveLocale, t } from "@/lib/i18n/booking";
+import { resolveLocale } from "@/lib/i18n/booking";
 import { LocaleProvider } from "@/lib/i18n/locale-provider";
 import { outOfOfficeOn } from "@/lib/out-of-office";
 import { paymentsEnabled } from "@/lib/payments/stripe";
@@ -110,63 +112,68 @@ export default async function PublicBookingPage({
           </div>
         </div>
       ) : null}
-      <Card>
-        <div className="grid gap-0 md:grid-cols-[280px_1fr]">
-          {/* Event details */}
-          <div className="border-b border-[var(--color-border)] p-6 md:border-b-0 md:border-r">
-            <div className="flex items-center gap-2">
-              <HostAvatar name={host.name ?? host.handle ?? "?"} image={host.image} size={36} />
-              <span className="text-sm text-[var(--color-muted)]">{host.name ?? host.handle}</span>
-            </div>
-            {branding.welcomeMessage ? (
-              <p className="mt-3 text-sm text-[var(--color-muted)]">{branding.welcomeMessage}</p>
-            ) : null}
-            <h1 className="font-display mt-4 text-2xl leading-tight tracking-[-0.01em]">
-              {eventType.title}
-            </h1>
-            {eventType.description ? (
-              <p className="mt-2 text-sm text-[var(--color-muted)]">{eventType.description}</p>
-            ) : null}
-            <div className="mt-4 space-y-2 text-sm text-[var(--color-muted)]">
-              <p className="flex items-center gap-2">
-                <Clock size={15} /> {t(locale, "minutes", { n: eventType.durationMinutes })}
-              </p>
-              <p className="flex items-center gap-2">
-                <Video size={15} />{" "}
-                {locationChoices.length > 1
-                  ? locationChoices.map((l) => l.label).join(" · ")
-                  : (LOCATION_LABELS[eventType.location] ?? eventType.location)}
-              </p>
-              {eventType.recurringCount > 1 ? (
-                <p className="flex items-center gap-2 font-medium text-[var(--color-text)]">
-                  <Repeat size={15} /> Repeats{" "}
-                  {eventType.recurringFrequency === "monthly"
-                    ? "monthly"
-                    : eventType.recurringFrequency === "biweekly"
-                      ? "every 2 weeks"
-                      : "weekly"}{" "}
-                  · {eventType.recurringCount} sessions
-                </p>
+      <LocaleProvider locale={locale}>
+        <Card>
+          <div className="grid gap-0 md:grid-cols-[280px_1fr]">
+            {/* Event details */}
+            <div className="border-b border-[var(--color-border)] p-6 md:border-b-0 md:border-r">
+              <div className="flex items-center gap-2">
+                <HostAvatar name={host.name ?? host.handle ?? "?"} image={host.image} size={36} />
+                <span className="text-sm text-[var(--color-muted)]">
+                  {host.name ?? host.handle}
+                </span>
+              </div>
+              {branding.welcomeMessage ? (
+                <p className="mt-3 text-sm text-[var(--color-muted)]">{branding.welcomeMessage}</p>
               ) : null}
-              {priceLabel ? (
-                <p className="flex items-center gap-2 font-medium text-[var(--color-text)]">
-                  <CreditCard size={15} /> {priceLabel}
-                  {isDeposit ? (
-                    <span className="text-xs font-normal text-[var(--color-faint)]">
-                      {t(locale, "deposit")}
-                    </span>
-                  ) : null}
-                </p>
+              <h1 className="font-display mt-4 text-2xl leading-tight tracking-[-0.01em]">
+                {eventType.title}
+              </h1>
+              {eventType.description ? (
+                <p className="mt-2 text-sm text-[var(--color-muted)]">{eventType.description}</p>
               ) : null}
+              <div className="mt-4 space-y-2 text-sm text-[var(--color-muted)]">
+                <p className="flex items-center gap-2">
+                  <Clock size={15} /> <Tr k="minutes" vars={{ n: eventType.durationMinutes }} />
+                </p>
+                <p className="flex items-center gap-2">
+                  <Video size={15} />{" "}
+                  {locationChoices.length > 1
+                    ? locationChoices.map((l) => l.label).join(" · ")
+                    : (LOCATION_LABELS[eventType.location] ?? eventType.location)}
+                </p>
+                {eventType.recurringCount > 1 ? (
+                  <p className="flex items-center gap-2 font-medium text-[var(--color-text)]">
+                    <Repeat size={15} /> Repeats{" "}
+                    {eventType.recurringFrequency === "monthly"
+                      ? "monthly"
+                      : eventType.recurringFrequency === "biweekly"
+                        ? "every 2 weeks"
+                        : "weekly"}{" "}
+                    · {eventType.recurringCount} sessions
+                  </p>
+                ) : null}
+                {priceLabel ? (
+                  <p className="flex items-center gap-2 font-medium text-[var(--color-text)]">
+                    <CreditCard size={15} /> {priceLabel}
+                    {isDeposit ? (
+                      <span className="text-xs font-normal text-[var(--color-faint)]">
+                        <Tr k="deposit" />
+                      </span>
+                    ) : null}
+                  </p>
+                ) : null}
+              </div>
             </div>
-          </div>
 
-          {/* Slot picker */}
-          <CardBody className="p-6">
-            <h2 className="mb-4 text-sm font-semibold">{t(locale, "selectTime")}</h2>
-            {/* Seed the same server-resolved locale into the client slot picker so
-                its copy matches the page and doesn't hydrate from navigator. */}
-            <LocaleProvider locale={locale}>
+            {/* Slot picker */}
+            <CardBody className="p-6">
+              <div className="mb-4 flex items-center justify-between gap-3">
+                <h2 className="text-sm font-semibold">
+                  <Tr k="selectTime" />
+                </h2>
+                <LanguagePicker />
+              </div>
               <SlotPicker
                 eventTypeId={eventType.id}
                 questions={eventType.questions}
@@ -177,10 +184,10 @@ export default async function PublicBookingPage({
                 assistantEnabled={assistantEnabled}
                 locations={locationChoices}
               />
-            </LocaleProvider>
-          </CardBody>
-        </div>
-      </Card>
+            </CardBody>
+          </div>
+        </Card>
+      </LocaleProvider>
       {hideBranding ? null : (
         <p className="mt-6 flex items-center justify-center gap-1.5 text-xs text-[var(--color-faint)]">
           <span className="relative inline-block h-3.5 w-3.5 shrink-0 overflow-hidden rounded-[3px]">

--- a/apps/web/components/language-picker.tsx
+++ b/apps/web/components/language-picker.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { LOCALE_LABELS, type Locale, SUPPORTED_LOCALES } from "@/lib/i18n";
+import { useLocaleContext, useSetLocale } from "@/lib/i18n/locale-provider";
+import { Globe } from "lucide-react";
+
+/**
+ * Lets a booker pick the booking-page language. The initial value is the
+ * server-resolved locale (from Accept-Language); the choice is persisted by the
+ * LocaleProvider. Native-rendered <select> so it stays light and accessible.
+ */
+export function LanguagePicker() {
+  const locale = useLocaleContext();
+  const setLocale = useSetLocale();
+  return (
+    <label className="inline-flex items-center gap-1.5 text-xs text-[var(--color-muted)]">
+      <Globe size={14} aria-hidden />
+      <span className="sr-only">Language</span>
+      <select
+        value={locale}
+        onChange={(e) => setLocale(e.target.value as Locale)}
+        className="cursor-pointer rounded-md border border-[var(--color-border)] bg-transparent py-1 pr-6 pl-2 text-xs text-[var(--color-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+      >
+        {SUPPORTED_LOCALES.map((l) => (
+          <option key={l} value={l}>
+            {LOCALE_LABELS[l]}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/apps/web/components/tr.tsx
+++ b/apps/web/components/tr.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { type BookingKey, t } from "@/lib/i18n/booking";
+import { useBookingLocale } from "@/lib/i18n/use-locale";
+
+/**
+ * Renders one booking-surface string in the *active* locale (context-driven), so
+ * it reacts live when the booker switches language - unlike a server-rendered
+ * `t(locale, …)` call, which is fixed at the request's Accept-Language.
+ */
+export function Tr({
+  k,
+  vars,
+}: {
+  k: BookingKey;
+  vars?: Record<string, string | number>;
+}) {
+  return <>{t(useBookingLocale(), k, vars)}</>;
+}

--- a/apps/web/lib/i18n/index.ts
+++ b/apps/web/lib/i18n/index.ts
@@ -9,6 +9,17 @@ export const SUPPORTED_LOCALES = ["en", "es", "fr", "de", "pt", "it", "nl"] as c
 export type Locale = (typeof SUPPORTED_LOCALES)[number];
 export const DEFAULT_LOCALE: Locale = "en";
 
+/** Each locale's name in its own language, for language pickers. */
+export const LOCALE_LABELS: Record<Locale, string> = {
+  en: "English",
+  es: "Español",
+  fr: "Français",
+  de: "Deutsch",
+  pt: "Português",
+  it: "Italiano",
+  nl: "Nederlands",
+};
+
 /** Map a browser/Accept-Language value (e.g. "es-419,es;q=0.9") to a supported locale. */
 export function resolveLocale(input: string | null | undefined): Locale {
   if (!input) return DEFAULT_LOCALE;

--- a/apps/web/lib/i18n/locale-provider.tsx
+++ b/apps/web/lib/i18n/locale-provider.tsx
@@ -1,27 +1,68 @@
 "use client";
 
-import { type ReactNode, createContext, useContext, useEffect } from "react";
-import { DEFAULT_LOCALE, type Locale } from "./index";
+import { type ReactNode, createContext, useContext, useEffect, useState } from "react";
+import { DEFAULT_LOCALE, type Locale, SUPPORTED_LOCALES } from "./index";
 
 const LocaleContext = createContext<Locale>(DEFAULT_LOCALE);
+const SetLocaleContext = createContext<(locale: Locale) => void>(() => {});
+
+const STORAGE_KEY = "dayotter.locale";
 
 /**
- * Provides the request's locale - resolved on the SERVER from Accept-Language -
- * to client components. Reading it from context (instead of `navigator.language`)
- * keeps SSR and hydration in sync: the server has no `navigator`, so a client
- * component that derived its locale from `navigator` would render English on the
- * server and the user's language on the client, causing a hydration mismatch and
- * a flash of English. Also reflects the locale onto `<html lang>` on the client
- * (the root layout stays static/English so the marketing site isn't forced
- * dynamic; localized subtrees fix `lang` here for screen readers).
+ * Provides the booking surface's locale to client components. It's SEEDED on the
+ * SERVER from Accept-Language (so SSR and first paint match, with no flash of
+ * English), but is also switchable at runtime via the language picker - the choice
+ * is remembered in localStorage so a returning booker keeps their language.
+ *
+ * Reading the locale from context (instead of `navigator.language`) keeps SSR and
+ * hydration in sync: the server has no `navigator`, so a client component that
+ * derived its locale from `navigator` would render English on the server and the
+ * user's language on the client, causing a hydration mismatch. Also reflects the
+ * active locale onto `<html lang>` for screen readers (the root layout stays
+ * static/English so the marketing site isn't forced dynamic; localized subtrees
+ * fix `lang` here).
  */
 export function LocaleProvider({ locale, children }: { locale: Locale; children: ReactNode }) {
+  const [current, setCurrent] = useState<Locale>(locale);
+
+  // On mount, honor a previously chosen language over the server-resolved default.
+  // Done in an effect (not initial state) so server and client first render agree.
   useEffect(() => {
-    document.documentElement.lang = locale;
-  }, [locale]);
-  return <LocaleContext.Provider value={locale}>{children}</LocaleContext.Provider>;
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (saved && (SUPPORTED_LOCALES as readonly string[]).includes(saved)) {
+        setCurrent(saved as Locale);
+      }
+    } catch {
+      /* localStorage unavailable (private mode) - keep the server locale */
+    }
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.lang = current;
+  }, [current]);
+
+  function choose(next: Locale) {
+    setCurrent(next);
+    try {
+      localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      /* ignore persistence failures */
+    }
+  }
+
+  return (
+    <LocaleContext.Provider value={current}>
+      <SetLocaleContext.Provider value={choose}>{children}</SetLocaleContext.Provider>
+    </LocaleContext.Provider>
+  );
 }
 
 export function useLocaleContext(): Locale {
   return useContext(LocaleContext);
+}
+
+/** Set the active booking-surface locale (persisted for return visits). */
+export function useSetLocale(): (locale: Locale) => void {
+  return useContext(SetLocaleContext);
 }


### PR DESCRIPTION
## What
Adds an on-page **language picker** to the public booking page, closing the one real gap the web UI-coverage audit found: all 7 locales + the translation plumbing already shipped, but a booker could only get a non-English page if their browser's `Accept-Language` happened to match — no control to choose.

## How
- **`LocaleProvider` is now stateful** — still seeded on the server from `Accept-Language` (SSR/first-paint match preserved, no flash of English), but switchable at runtime, with the choice persisted to `localStorage` for return visits.
- **`<LanguagePicker>`** — globe icon + a native-language `<select>` (English / Español / Français / Deutsch / Português / Italiano / Nederlands), placed next to "Select a time".
- **`<Tr>` helper** — makes the few server-rendered labels (heading, duration, deposit) react to the switch, alongside the already-client `SlotPicker`.
- Shared `LOCALE_LABELS` moved into `lib/i18n`.

## Verification
Typecheck + Biome clean. Live-verified at mobile width: switching to Español updated the **entire** surface with no reload — "Elige una hora", "30 minutos", "Horas recomendadas", "Superponer mi calendario", the "Encuéntrame una hora" AI button, and Luxon's date/number formatting (`lun, jul 27 · 4:00 p. m.`).

Part of the web/mobile UI-coverage pass.