### PR TITLE
feat(mobile): 2FA sign-in + approve/decline pending requests

### DIFF
--- a/apps/mobile/app/booking/[uid].tsx
+++ b/apps/mobile/app/booking/[uid].tsx
@@ -32,8 +32,9 @@ export default function BookingDetailScreen() {
   const [rescheduling, setRescheduling] = useState(false);
   const [slots, setSlots] = useState<Slot[] | null>(null);
   const [slotsLoading, setSlotsLoading] = useState(false);
-  // Optional note sent to attendees on cancel/reschedule (both endpoints accept it).
+  // Optional note sent to attendees on cancel/reschedule/decline (all accept it).
   const [reason, setReason] = useState("");
+  const [deciding, setDeciding] = useState<"approve" | "decline" | null>(null);
 
   const { data, loading, error, reload } = useAsync<BookingDetail>(async () => {
     const res = await api.get<{ booking: BookingDetail }>(`/api/bookings/${uid}`);
@@ -41,6 +42,32 @@ export default function BookingDetailScreen() {
   }, [uid]);
 
   const isPast = data ? new Date(data.endsAt).getTime() < Date.now() : false;
+
+  // Opt-in (requires-confirmation) requests land as `pending`; the host approves
+  // or declines them here (parity with the web /bookings review).
+  async function approve() {
+    setDeciding("approve");
+    try {
+      await api.post(`/api/bookings/${uid}/confirm`, {});
+      reload();
+    } catch (e) {
+      Alert.alert("Couldn't approve", e instanceof ApiError ? e.message : "Please try again.");
+    } finally {
+      setDeciding(null);
+    }
+  }
+
+  async function decline() {
+    setDeciding("decline");
+    try {
+      await api.post(`/api/bookings/${uid}/decline`, { reason: reason.trim() || undefined });
+      reload();
+    } catch (e) {
+      Alert.alert("Couldn't decline", e instanceof ApiError ? e.message : "Please try again.");
+    } finally {
+      setDeciding(null);
+    }
+  }
 
   function confirmCancel() {
     // Recurring booking: let the host cancel just this one or the whole series.
@@ -202,6 +229,33 @@ export default function BookingDetailScreen() {
               </Pressable>
             ) : null}
           </View>
+
+          {/* Opt-in request awaiting the host's decision: approve or decline. */}
+          {data.status === "pending" && !isPast ? (
+            <>
+              <Text style={styles.pendingNote}>This request is awaiting your confirmation.</Text>
+              <TextInput
+                style={styles.reasonInput}
+                value={reason}
+                onChangeText={setReason}
+                placeholder="Note (optional) — shared if you decline"
+                placeholderTextColor={colors.faint}
+                multiline
+                maxLength={500}
+              />
+              <Pressable style={styles.approve} onPress={approve} disabled={deciding !== null}>
+                <Ionicons name="checkmark-circle-outline" size={16} color={colors.white} />
+                <Text style={styles.approveText}>
+                  {deciding === "approve" ? "Approving…" : "Approve"}
+                </Text>
+              </Pressable>
+              <Pressable style={styles.cancel} onPress={decline} disabled={deciding !== null}>
+                <Text style={styles.cancelText}>
+                  {deciding === "decline" ? "Declining…" : "Decline"}
+                </Text>
+              </Pressable>
+            </>
+          ) : null}
 
           {/* Upcoming confirmed meeting: running-late, reschedule, cancel. */}
           {data.status === "confirmed" && !isPast ? (
@@ -390,6 +444,18 @@ const styles = StyleSheet.create({
     alignItems: "center",
   },
   cancelText: { color: colors.white, fontWeight: "600" },
+  pendingNote: { marginTop: 14, color: colors.muted, fontSize: 13 },
+  approve: {
+    marginTop: 12,
+    flexDirection: "row",
+    gap: 6,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: colors.accent,
+    borderRadius: radius.md,
+    paddingVertical: 14,
+  },
+  approveText: { color: colors.white, fontWeight: "600" },
   back: { marginTop: 14, alignItems: "center" },
   backText: { color: colors.muted },
 });

--- a/apps/mobile/app/sign-in.tsx
+++ b/apps/mobile/app/sign-in.tsx
@@ -1,4 +1,4 @@
-import { useAuth } from "@/auth";
+import { TWO_FACTOR_REQUIRED, useAuth } from "@/auth";
 import { googleAuthEnabled } from "@/auth-client";
 import { BrandMark } from "@/components/brand-mark";
 import { hasOnboarded } from "@/onboarding-state";
@@ -21,7 +21,8 @@ import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function SignInScreen() {
   const router = useRouter();
-  const { signIn, signUp, signInWithGoogle } = useAuth();
+  const { signIn, signUp, signInWithGoogle, twoFactorPending, verifyTwoFactor, cancelTwoFactor } =
+    useAuth();
   const [isSignUp, setIsSignUp] = useState(false);
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
@@ -30,6 +31,10 @@ export default function SignInScreen() {
   const [loading, setLoading] = useState(false);
   const [googleLoading, setGoogleLoading] = useState(false);
   const [ready, setReady] = useState(false);
+  // 2FA step
+  const [code, setCode] = useState("");
+  const [useBackup, setUseBackup] = useState(false);
+  const [verifying, setVerifying] = useState(false);
 
   // First launch → show onboarding before the sign-in form.
   useEffect(() => {
@@ -46,8 +51,26 @@ export default function SignInScreen() {
       ? await signUp(name.trim(), email.trim(), password)
       : await signIn(email.trim(), password);
     setLoading(false);
+    // 2FA account: stay put; the authenticator-code step renders below.
+    if (err === TWO_FACTOR_REQUIRED) return;
     if (err) setError(err);
     else router.replace("/");
+  }
+
+  async function verify2fa() {
+    setVerifying(true);
+    setError(null);
+    const err = await verifyTwoFactor(code, useBackup);
+    setVerifying(false);
+    if (err) setError(err);
+    else router.replace("/");
+  }
+
+  function backFrom2fa() {
+    cancelTwoFactor();
+    setCode("");
+    setUseBackup(false);
+    setError(null);
   }
 
   async function google() {
@@ -60,6 +83,67 @@ export default function SignInScreen() {
   }
 
   if (!ready) return <View style={styles.safe} />;
+
+  // 2FA account mid-sign-in: collect the authenticator (or backup) code.
+  if (twoFactorPending) {
+    return (
+      <SafeAreaView style={styles.safe}>
+        <KeyboardAvoidingView
+          behavior={Platform.OS === "ios" ? "padding" : undefined}
+          style={styles.flex}
+        >
+          <ScrollView contentContainerStyle={styles.scroll} keyboardShouldPersistTaps="handled">
+            <View style={styles.logoRow}>
+              <BrandMark size={48} />
+            </View>
+            <Text style={styles.heading}>Two-factor authentication</Text>
+            <Text style={styles.sub}>
+              {useBackup
+                ? "Enter one of your backup recovery codes."
+                : "Enter the 6-digit code from your authenticator app."}
+            </Text>
+            <View style={styles.form}>
+              {error ? <Text style={styles.error}>{error}</Text> : null}
+              <TextInput
+                style={styles.input}
+                value={code}
+                onChangeText={setCode}
+                placeholder={useBackup ? "Backup code" : "123456"}
+                placeholderTextColor={colors.faint}
+                keyboardType={useBackup ? "default" : "number-pad"}
+                autoCapitalize="none"
+                autoFocus
+                autoComplete={useBackup ? "off" : "one-time-code"}
+                onSubmitEditing={verify2fa}
+                returnKeyType="go"
+              />
+              <Pressable
+                style={[styles.button, { marginTop: 16 }]}
+                onPress={verify2fa}
+                disabled={verifying || code.trim().length === 0}
+              >
+                <Text style={styles.buttonText}>{verifying ? "Verifying…" : "Verify"}</Text>
+              </Pressable>
+              <Pressable
+                onPress={() => {
+                  setUseBackup((v) => !v);
+                  setCode("");
+                  setError(null);
+                }}
+              >
+                <Text style={styles.toggle}>
+                  {useBackup ? "Use an authenticator code" : "Use a backup code instead"}
+                </Text>
+              </Pressable>
+              <Pressable onPress={backFrom2fa}>
+                <Text style={styles.serverLink}>Back to sign in</Text>
+              </Pressable>
+            </View>
+          </ScrollView>
+        </KeyboardAvoidingView>
+      </SafeAreaView>
+    );
+  }
 
   const showGoogle = googleAuthEnabled && Platform.OS !== "ios";
 

--- a/apps/mobile/src/auth-client.ts
+++ b/apps/mobile/src/auth-client.ts
@@ -1,5 +1,5 @@
 import { expoClient } from "@better-auth/expo/client";
-import { phoneNumberClient } from "better-auth/client/plugins";
+import { phoneNumberClient, twoFactorClient } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
 import * as SecureStore from "expo-secure-store";
 import { getServerUrl } from "./server";
@@ -20,6 +20,9 @@ function makeClient(baseURL: string) {
     plugins: [
       expoClient({ scheme: "dayotter", storagePrefix: "dayotter", storage: SecureStore }),
       phoneNumberClient(),
+      // Lets a 2FA account finish sign-in natively (verifyTotp / verifyBackupCode)
+      // instead of being bounced to the web.
+      twoFactorClient(),
     ],
   });
 }

--- a/apps/mobile/src/auth.tsx
+++ b/apps/mobile/src/auth.tsx
@@ -4,6 +4,13 @@ import { clearBetterAuthSession, getAuthClient } from "./auth-client";
 import type { AppUser } from "./models";
 import { loadServerUrl } from "./server";
 
+/**
+ * Sentinel returned by signIn when the account has 2FA on: the password was
+ * accepted but an authenticator code is still needed. The caller shows the code
+ * step (see `twoFactorPending`) instead of treating it as an error or success.
+ */
+export const TWO_FACTOR_REQUIRED = "__2fa_required__";
+
 interface AuthState {
   user: AppUser | null;
   initializing: boolean;
@@ -14,6 +21,12 @@ interface AuthState {
   sendPhoneOtp: (phone: string) => Promise<string | null>;
   /** Verify the OTP; on success a session is established and the user is set. */
   verifyPhoneOtp: (phone: string, code: string) => Promise<string | null>;
+  /** True while a 2FA account is mid-sign-in and owes an authenticator code. */
+  twoFactorPending: boolean;
+  /** Complete a 2FA sign-in with a TOTP (or backup) code. */
+  verifyTwoFactor: (code: string, useBackup: boolean) => Promise<string | null>;
+  /** Abandon the 2FA step and return to the sign-in form. */
+  cancelTwoFactor: () => void;
   signOut: () => Promise<void>;
 }
 
@@ -48,6 +61,7 @@ async function loadMeWithRetry(attempts = 6, delayMs = 250): Promise<AppUser | n
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<AppUser | null>(null);
   const [initializing, setInitializing] = useState(true);
+  const [twoFactorPending, setTwoFactorPending] = useState(false);
 
   useEffect(() => {
     (async () => {
@@ -69,11 +83,23 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   async function authenticate(path: string, body: unknown): Promise<string | null> {
     try {
       const data = await api.post<AuthResponse & { twoFactorRedirect?: boolean }>(path, body);
-      // The account has 2FA on. Native TOTP entry isn't wired yet, so point the
-      // user at a path that works today rather than a bare "failed" (they can
-      // still use Google / phone / the web).
+      // The account has 2FA on: the password was accepted but an authenticator
+      // code is still required. Re-run the sign-in through the Better Auth Expo
+      // client so it captures the 2FA challenge cookie (the raw bearer POST above
+      // can't), then hand off to the code step via `twoFactorPending`. Only 2FA
+      // accounts take this path - everyone else stays on the bearer flow below.
       if (data.twoFactorRedirect) {
-        return "This account uses two-factor authentication. Sign in with Google, a phone number, or on the web for now.";
+        const creds = body as { email?: string; password?: string };
+        if (creds.email && creds.password) {
+          try {
+            await getAuthClient().signIn.email({ email: creds.email, password: creds.password });
+          } catch {
+            /* the client call also 2FA-redirects; we only need the cookie it sets */
+          }
+          setTwoFactorPending(true);
+          return TWO_FACTOR_REQUIRED;
+        }
+        return "This account uses two-factor authentication. Sign in on the web for now.";
       }
       if (!data.token) return "Authentication failed";
       await setToken(data.token);
@@ -130,8 +156,35 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   }
 
+  /**
+   * Finish a 2FA sign-in with an authenticator (or backup) code. The 2FA cookie
+   * was set on the Expo client during `authenticate`; verify against it, then load
+   * the profile over that session (like Google / phone - no bearer token).
+   */
+  async function verifyTwoFactor(code: string, useBackup: boolean): Promise<string | null> {
+    try {
+      const client = getAuthClient();
+      const res = useBackup
+        ? await client.twoFactor.verifyBackupCode({ code: code.trim() })
+        : await client.twoFactor.verifyTotp({ code: code.trim() });
+      if (res.error) {
+        return (
+          res.error.message ??
+          (useBackup ? "That recovery code didn't match." : "That code didn't match.")
+        );
+      }
+      const me = await loadMeWithRetry();
+      if (!me) return "Signed in, but couldn't load your profile - please try again.";
+      setUser(me);
+      setTwoFactorPending(false);
+      return null;
+    } catch (err) {
+      return err instanceof Error ? err.message : "Verification failed";
+    }
+  }
+
   // The handler closures are stable enough for our needs; re-memoizing only when
-  // user/initializing change is intentional (adding them would defeat the memo).
+  // user/initializing/twoFactorPending change is intentional.
   // biome-ignore lint/correctness/useExhaustiveDependencies: stable auth closures
   const value = useMemo<AuthState>(
     () => ({
@@ -143,6 +196,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       signInWithGoogle,
       sendPhoneOtp,
       verifyPhoneOtp,
+      twoFactorPending,
+      verifyTwoFactor,
+      cancelTwoFactor: () => setTwoFactorPending(false),
       signOut: async () => {
         // Clear the account before anything else so a stale session can't leak
         // into the next sign-in: server signOut (best-effort), the bearer token,
@@ -155,7 +211,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setUser(null);
       },
     }),
-    [user, initializing],
+    [user, initializing, twoFactorPending],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;


### PR DESCRIPTION
Closes the two **hard blockers** from the mobile UI-coverage audit — both were "web can, mobile can't" dead-ends.

## 2FA native sign-in
Users with 2FA on previously couldn't sign in with email + password on mobile at all (they were bounced to Google/phone/web).
- Wired `twoFactorClient()` into the Expo auth client.
- On a password sign-in that returns `twoFactorRedirect`, we re-run sign-in through the Better Auth **Expo client** so it captures the 2FA challenge cookie (the raw bearer POST can't), then show a native code step — authenticator **or** backup code — calling `twoFactor.verifyTotp` / `verifyBackupCode`.
- **Blast radius is limited to 2FA accounts**: non-2FA sign-in keeps the existing bearer flow unchanged.

## Approve/decline pending bookings
The app could enable "requires confirmation" but gave the host no way to act on the resulting requests.
- The booking-detail screen now shows **Approve / Decline** (with an optional note) when a booking is `pending`, hitting the existing host `/confirm` and `/decline` endpoints, then refreshing.
- Pending requests already appear in the agenda (amber badge — the range endpoint returns everything but cancelled), so they're reachable.

## Verification
`tsc` (mobile) + Biome clean.

⚠️ **Needs a device/emulator smoke test before relying on it** — these are React Native screens and can't be run in this environment. The 2FA auth-path change in particular should be exercised on a real 2FA account (correct code, wrong code, backup code, cancel) prior to release. Everything is typecheck-verified and follows the web + existing-screen patterns.

Part of the mobile UI-coverage pass (track 1 of 3: hard blockers → editor parity → availability features).