### PR TITLE
feat(mobile): out-of-office + availability troubleshooter screens

### DIFF
--- a/apps/mobile/app/availability-troubleshooter.tsx
+++ b/apps/mobile/app/availability-troubleshooter.tsx
@@ -1,0 +1,225 @@
+import { ApiError, api } from "@/api";
+import { ErrorText, Loading } from "@/components/ui";
+import { useAsync } from "@/hooks";
+import { colors, radius } from "@/theme";
+import { Ionicons } from "@expo/vector-icons";
+import { Stack } from "expo-router";
+import { useEffect, useState } from "react";
+import { Pressable, ScrollView, StyleSheet, Text, TextInput, View } from "react-native";
+
+interface EventTypeLite {
+  id: string;
+  title: string;
+}
+interface DayDiagnosis {
+  date: string;
+  weekday: string;
+  scheduleWindows: { start: string; end: string }[];
+  dayOff: boolean;
+  beyondBookingWindow: boolean;
+  totalSlots: number;
+  bookableSlots: number;
+  blockedByBusy: number;
+  blockedByNoticeOrRange: number;
+  reasons: string[];
+}
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+function todayISO() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/** Availability troubleshooter (#131): explain why a booking type does (or does
+ *  not) offer times on a given day. Host-only diagnostic, parity with web. */
+export default function TroubleshooterScreen() {
+  const { data: eventTypes, loading: loadingTypes } = useAsync<EventTypeLite[]>(async () => {
+    const res = await api.get<{ eventTypes: EventTypeLite[] }>("/api/event-types");
+    return res.eventTypes ?? [];
+  }, []);
+
+  const [eventTypeId, setEventTypeId] = useState("");
+  const [date, setDate] = useState(todayISO());
+  const [running, setRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<DayDiagnosis | null>(null);
+
+  // Default to the first booking type once loaded.
+  useEffect(() => {
+    if (!eventTypeId && eventTypes && eventTypes[0]) setEventTypeId(eventTypes[0].id);
+  }, [eventTypes, eventTypeId]);
+
+  async function run() {
+    if (!eventTypeId) return;
+    if (!ISO_DATE.test(date)) {
+      setError("Enter the day as YYYY-MM-DD.");
+      return;
+    }
+    setRunning(true);
+    setError(null);
+    setResult(null);
+    try {
+      const res = await api.get<{ diagnosis: DayDiagnosis }>(
+        `/api/availability/troubleshoot?eventTypeId=${eventTypeId}&date=${date}`,
+      );
+      setResult(res.diagnosis);
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : "Couldn't run the check.");
+    } finally {
+      setRunning(false);
+    }
+  }
+
+  return (
+    <View style={styles.safe}>
+      <Stack.Screen options={{ headerShown: true, title: "Troubleshoot" }} />
+      {loadingTypes && !eventTypes ? (
+        <Loading />
+      ) : (
+        <ScrollView contentContainerStyle={styles.scroll} keyboardShouldPersistTaps="handled">
+          <Text style={styles.hint}>
+            See exactly why a booking type does (or doesn't) offer times on a given day.
+          </Text>
+
+          <Text style={styles.label}>Booking type</Text>
+          <View style={styles.pills}>
+            {(eventTypes ?? []).map((et) => (
+              <Pressable
+                key={et.id}
+                onPress={() => setEventTypeId(et.id)}
+                style={[styles.chip, et.id === eventTypeId && styles.chipOn]}
+              >
+                <Text style={[styles.chipText, et.id === eventTypeId && styles.chipTextOn]}>
+                  {et.title}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+          {(eventTypes ?? []).length === 0 ? (
+            <Text style={styles.empty}>Create a booking type first.</Text>
+          ) : null}
+
+          <Text style={styles.label}>Day</Text>
+          <TextInput
+            style={styles.input}
+            value={date}
+            onChangeText={setDate}
+            placeholder="2026-08-01"
+            placeholderTextColor={colors.faint}
+            autoCapitalize="none"
+            maxLength={10}
+          />
+
+          {error ? <Text style={styles.error}>{error}</Text> : null}
+          <Pressable style={styles.save} onPress={run} disabled={running || !eventTypeId}>
+            <Text style={styles.saveText}>{running ? "Checking…" : "Diagnose"}</Text>
+          </Pressable>
+
+          {result ? (
+            <View style={styles.result}>
+              <Text style={styles.resultTitle}>
+                {result.weekday}, {result.date} —{" "}
+                {result.bookableSlots > 0
+                  ? `${result.bookableSlots} bookable`
+                  : "no bookable slots"}
+              </Text>
+              {result.reasons.map((r) => (
+                <View key={r} style={styles.reasonRow}>
+                  <Ionicons
+                    name={result.bookableSlots > 0 ? "checkmark-circle" : "alert-circle"}
+                    size={15}
+                    color={result.bookableSlots > 0 ? colors.success : colors.amber}
+                  />
+                  <Text style={styles.reason}>{r}</Text>
+                </View>
+              ))}
+              <View style={styles.stats}>
+                <Stat
+                  label="Working hours"
+                  value={
+                    result.scheduleWindows.length
+                      ? result.scheduleWindows.map((w) => `${w.start}–${w.end}`).join(", ")
+                      : "—"
+                  }
+                />
+                <Stat label="Schedule capacity" value={`${result.totalSlots} slots`} />
+                <Stat label="Blocked by busy" value={String(result.blockedByBusy)} />
+                <Stat label="Notice / window" value={String(result.blockedByNoticeOrRange)} />
+              </View>
+            </View>
+          ) : null}
+        </ScrollView>
+      )}
+    </View>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <View style={styles.stat}>
+      <Text style={styles.statLabel}>{label}</Text>
+      <Text style={styles.statValue}>{value}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: colors.bg },
+  scroll: { padding: 20, paddingBottom: 40 },
+  hint: { color: colors.muted, fontSize: 13, marginBottom: 16 },
+  empty: { color: colors.muted, fontSize: 13, marginBottom: 8 },
+  label: { fontWeight: "500", fontSize: 14, marginBottom: 8, marginTop: 8, color: colors.text },
+  pills: { flexDirection: "row", flexWrap: "wrap", gap: 8, marginBottom: 8 },
+  chip: {
+    borderWidth: 1,
+    borderColor: colors.borderStrong,
+    borderRadius: 999,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+  },
+  chipOn: { backgroundColor: colors.accent, borderColor: colors.accent },
+  chipText: { color: colors.text, fontSize: 13 },
+  chipTextOn: { color: colors.white, fontWeight: "600" },
+  input: {
+    height: 46,
+    borderWidth: 1,
+    borderColor: colors.borderStrong,
+    borderRadius: radius.md,
+    paddingHorizontal: 14,
+    fontSize: 15,
+    color: colors.text,
+    backgroundColor: colors.surface,
+  },
+  error: { color: colors.danger, marginTop: 14 },
+  save: {
+    marginTop: 18,
+    backgroundColor: colors.accent,
+    borderRadius: radius.md,
+    paddingVertical: 15,
+    alignItems: "center",
+  },
+  saveText: { color: colors.white, fontWeight: "600", fontSize: 15 },
+  result: {
+    marginTop: 22,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.lg,
+    backgroundColor: colors.surface2,
+    padding: 16,
+  },
+  resultTitle: { fontWeight: "700", fontSize: 15, color: colors.text, marginBottom: 12 },
+  reasonRow: { flexDirection: "row", gap: 8, alignItems: "flex-start", marginBottom: 8 },
+  reason: { flex: 1, color: colors.muted, fontSize: 13 },
+  stats: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 16,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+    paddingTop: 14,
+    marginTop: 6,
+  },
+  stat: { minWidth: "40%" },
+  statLabel: { color: colors.faint, fontSize: 11 },
+  statValue: { color: colors.text, fontSize: 13, marginTop: 2 },
+});

--- a/apps/mobile/app/availability.tsx
+++ b/apps/mobile/app/availability.tsx
@@ -3,7 +3,7 @@ import { ErrorText, Loading } from "@/components/ui";
 import type { Schedule } from "@/models";
 import { colors, radius } from "@/theme";
 import { Ionicons } from "@expo/vector-icons";
-import { Stack } from "expo-router";
+import { Stack, useRouter } from "expo-router";
 import { useEffect, useState } from "react";
 import { Pressable, ScrollView, StyleSheet, Switch, Text, TextInput, View } from "react-native";
 
@@ -12,6 +12,7 @@ const LABELS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday"
 type Range = { start: string; end: string };
 
 export default function AvailabilityScreen() {
+  const router = useRouter();
   const [timezone, setTimezone] = useState("UTC");
   const [days, setDays] = useState<Range[][] | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -181,6 +182,22 @@ export default function AvailabilityScreen() {
           <Text style={styles.saveText}>{saving ? "Saving…" : "Save availability"}</Text>
         </Pressable>
         {saved ? <Text style={styles.savedText}>✓ Saved</Text> : null}
+
+        <View style={styles.links}>
+          <Pressable style={styles.linkRow} onPress={() => router.push("/out-of-office")}>
+            <Ionicons name="airplane-outline" size={18} color={colors.accent} />
+            <Text style={styles.linkText}>Out of office</Text>
+            <Ionicons name="chevron-forward" size={18} color={colors.faint} />
+          </Pressable>
+          <Pressable
+            style={styles.linkRow}
+            onPress={() => router.push("/availability-troubleshooter")}
+          >
+            <Ionicons name="help-buoy-outline" size={18} color={colors.accent} />
+            <Text style={styles.linkText}>Troubleshoot availability</Text>
+            <Ionicons name="chevron-forward" size={18} color={colors.faint} />
+          </Pressable>
+        </View>
       </ScrollView>
     </View>
   );
@@ -256,4 +273,12 @@ const styles = StyleSheet.create({
   },
   saveText: { color: colors.white, fontWeight: "600", fontSize: 15 },
   savedText: { color: colors.success, textAlign: "center", marginTop: 10 },
+  links: { marginTop: 28, borderTopWidth: 1, borderTopColor: colors.border, paddingTop: 12 },
+  linkRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    paddingVertical: 14,
+  },
+  linkText: { flex: 1, color: colors.text, fontSize: 15, fontWeight: "500" },
 });

--- a/apps/mobile/app/out-of-office.tsx
+++ b/apps/mobile/app/out-of-office.tsx
@@ -1,0 +1,256 @@
+import { ApiError, api } from "@/api";
+import { ErrorText, Loading } from "@/components/ui";
+import { useAsync } from "@/hooks";
+import { colors, radius } from "@/theme";
+import { Ionicons } from "@expo/vector-icons";
+import { Stack } from "expo-router";
+import { useState } from "react";
+import { Alert, Pressable, ScrollView, StyleSheet, Text, TextInput, View } from "react-native";
+
+interface Teammate {
+  id: string;
+  name: string | null;
+  handle: string | null;
+}
+interface Period {
+  id: string;
+  startDate: string;
+  endDate: string;
+  reason: string | null;
+  delegate: Teammate | null;
+}
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+function delegateName(t: Teammate) {
+  return t.name ?? (t.handle ? `@${t.handle}` : "Teammate");
+}
+
+/** First-class out-of-office (#102): block a date range and optionally redirect
+ *  new bookings to a teammate while away. Mirrors the web Availability panel. */
+export default function OutOfOfficeScreen() {
+  const { data, loading, error, reload } = useAsync<{
+    periods: Period[];
+    teammates: Teammate[];
+  }>(async () => {
+    return api.get<{ periods: Period[]; teammates: Teammate[] }>("/api/out-of-office");
+  }, []);
+
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+  const [reason, setReason] = useState("");
+  const [delegateId, setDelegateId] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  async function add() {
+    setFormError(null);
+    if (!ISO_DATE.test(startDate) || !ISO_DATE.test(endDate) || endDate < startDate) {
+      setFormError("Enter From and To as YYYY-MM-DD, with To on or after From.");
+      return;
+    }
+    setSaving(true);
+    try {
+      await api.post("/api/out-of-office", {
+        startDate,
+        endDate,
+        reason: reason.trim() || undefined,
+        delegateUserId: delegateId || null,
+      });
+      setStartDate("");
+      setEndDate("");
+      setReason("");
+      setDelegateId("");
+      reload();
+    } catch (e) {
+      setFormError(e instanceof ApiError ? e.message : "Couldn't save that period.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function remove(id: string) {
+    Alert.alert("Remove period?", "This unblocks those dates.", [
+      { text: "Keep", style: "cancel" },
+      {
+        text: "Remove",
+        style: "destructive",
+        onPress: async () => {
+          try {
+            await api.del(`/api/out-of-office/${id}`);
+            reload();
+          } catch {
+            Alert.alert("Couldn't remove", "Please try again.");
+          }
+        },
+      },
+    ]);
+  }
+
+  const teammates = data?.teammates ?? [];
+
+  return (
+    <View style={styles.safe}>
+      <Stack.Screen options={{ headerShown: true, title: "Out of office" }} />
+      {loading && !data ? (
+        <Loading />
+      ) : error && !data ? (
+        <ErrorText message={error} />
+      ) : (
+        <ScrollView contentContainerStyle={styles.scroll} keyboardShouldPersistTaps="handled">
+          <Text style={styles.hint}>
+            Mark yourself away for a date range - bookers can't schedule then. Optionally send them
+            to a teammate.
+          </Text>
+
+          {data && data.periods.length > 0 ? (
+            data.periods.map((p) => (
+              <View key={p.id} style={styles.row}>
+                <Ionicons name="airplane-outline" size={18} color={colors.accent} />
+                <View style={{ flex: 1 }}>
+                  <Text style={styles.rowTitle}>
+                    {p.startDate}
+                    {p.endDate !== p.startDate ? ` – ${p.endDate}` : ""}
+                  </Text>
+                  {p.reason || p.delegate ? (
+                    <Text style={styles.rowSub}>
+                      {p.reason ?? ""}
+                      {p.reason && p.delegate ? " · " : ""}
+                      {p.delegate ? `→ ${delegateName(p.delegate)}` : ""}
+                    </Text>
+                  ) : null}
+                </View>
+                <Pressable onPress={() => remove(p.id)} hitSlop={8}>
+                  <Ionicons name="trash-outline" size={18} color={colors.faint} />
+                </Pressable>
+              </View>
+            ))
+          ) : (
+            <Text style={styles.empty}>You're not marked away for any dates.</Text>
+          )}
+
+          <Text style={styles.section}>Add a period</Text>
+          <View style={styles.dateRow}>
+            <View style={{ flex: 1 }}>
+              <Text style={styles.label}>From</Text>
+              <TextInput
+                style={styles.input}
+                value={startDate}
+                onChangeText={setStartDate}
+                placeholder="2026-08-01"
+                placeholderTextColor={colors.faint}
+                autoCapitalize="none"
+                maxLength={10}
+              />
+            </View>
+            <View style={{ flex: 1 }}>
+              <Text style={styles.label}>To</Text>
+              <TextInput
+                style={styles.input}
+                value={endDate}
+                onChangeText={setEndDate}
+                placeholder="2026-08-05"
+                placeholderTextColor={colors.faint}
+                autoCapitalize="none"
+                maxLength={10}
+              />
+            </View>
+          </View>
+          <Text style={styles.label}>Reason (optional)</Text>
+          <TextInput
+            style={styles.input}
+            value={reason}
+            onChangeText={setReason}
+            placeholder="Annual leave"
+            placeholderTextColor={colors.faint}
+            maxLength={200}
+          />
+          {teammates.length > 0 ? (
+            <>
+              <Text style={styles.label}>Redirect bookings to (optional)</Text>
+              <View style={styles.pills}>
+                <Pressable
+                  onPress={() => setDelegateId("")}
+                  style={[styles.chip, delegateId === "" && styles.chipOn]}
+                >
+                  <Text style={[styles.chipText, delegateId === "" && styles.chipTextOn]}>
+                    No redirect
+                  </Text>
+                </Pressable>
+                {teammates.map((t) => (
+                  <Pressable
+                    key={t.id}
+                    onPress={() => setDelegateId(t.id)}
+                    style={[styles.chip, delegateId === t.id && styles.chipOn]}
+                  >
+                    <Text style={[styles.chipText, delegateId === t.id && styles.chipTextOn]}>
+                      {delegateName(t)}
+                    </Text>
+                  </Pressable>
+                ))}
+              </View>
+            </>
+          ) : (
+            <Text style={styles.hint}>Join a team to redirect bookings while you're away.</Text>
+          )}
+          {formError ? <Text style={styles.error}>{formError}</Text> : null}
+          <Pressable style={styles.save} onPress={add} disabled={saving}>
+            <Text style={styles.saveText}>{saving ? "Saving…" : "Add period"}</Text>
+          </Pressable>
+        </ScrollView>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: colors.bg },
+  scroll: { padding: 20, paddingBottom: 40 },
+  hint: { color: colors.muted, fontSize: 13, marginBottom: 16 },
+  empty: { color: colors.muted, fontSize: 14, marginVertical: 8 },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.md,
+    padding: 12,
+    marginBottom: 10,
+  },
+  rowTitle: { color: colors.text, fontWeight: "600", fontSize: 14 },
+  rowSub: { color: colors.muted, fontSize: 12, marginTop: 2 },
+  section: { fontWeight: "700", fontSize: 16, color: colors.text, marginTop: 20, marginBottom: 12 },
+  dateRow: { flexDirection: "row", gap: 12 },
+  label: { fontWeight: "500", fontSize: 14, marginBottom: 6, marginTop: 12, color: colors.text },
+  input: {
+    height: 46,
+    borderWidth: 1,
+    borderColor: colors.borderStrong,
+    borderRadius: radius.md,
+    paddingHorizontal: 14,
+    fontSize: 15,
+    color: colors.text,
+    backgroundColor: colors.surface,
+  },
+  pills: { flexDirection: "row", flexWrap: "wrap", gap: 8 },
+  chip: {
+    borderWidth: 1,
+    borderColor: colors.borderStrong,
+    borderRadius: 999,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+  },
+  chipOn: { backgroundColor: colors.accent, borderColor: colors.accent },
+  chipText: { color: colors.text, fontSize: 13 },
+  chipTextOn: { color: colors.white, fontWeight: "600" },
+  error: { color: colors.danger, marginTop: 14 },
+  save: {
+    marginTop: 20,
+    backgroundColor: colors.accent,
+    borderRadius: radius.md,
+    paddingVertical: 15,
+    alignItems: "center",
+  },
+  saveText: { color: colors.white, fontWeight: "600", fontSize: 15 },
+});


### PR DESCRIPTION
**Track 3 of 3** in the mobile UI-coverage pass — brings the two newest web availability features to the native app, both reachable from new rows on the Availability screen.

- **Out of office (#102)** — `app/out-of-office.tsx`: list periods, add a date range (+ optional reason and delegate teammate, chosen from your teammates), and remove. Uses the existing `/api/out-of-office` routes.
- **Availability troubleshooter (#131)** — `app/availability-troubleshooter.tsx`: pick a booking type + day and get the plain-English diagnosis (reasons, working hours, schedule capacity, blocked-by-busy vs notice/window). Uses `/api/availability/troubleshoot`.
- The **Availability screen** gains two nav rows linking to both.

No server changes — both reuse existing API routes. Dates use `YYYY-MM-DD` text entry, matching the app's existing time-input convention.

## Still web-only (noted for a follow-up)
One-off **time blocks** and per-date **schedule overrides** — these are entangled with the weekly-schedule editor and need date+time entry, so they're better as their own focused change.

## Verification
Mobile `tsc` + Biome clean. ⚠️ RN screens — **need a device smoke test** (add/remove an OOO period; run a diagnosis for a weekday vs a day off) before release; typecheck-verified and follow web parity + existing mobile patterns.