### PR TITLE
docs+feat: launch hardening — licensing promise, AI-optional/local docs, Cal.com importer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ coverage/
 
 # Local security audit notes (not for the public repo)
 SECURITY-AUDIT.md
+
+# Internal launch strategy (not for publication)
+LAUNCH-POSITIONING.md

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **The AI-native, open-source scheduling platform.**
 Say it once - Otter books the meeting, protects your focus, and clears the back-and-forth. Confirm-first, always.
 
-[Website](https://dayotter.com) · [Docs](./docs) · [Discord](https://discord.gg/cxwETDsY85) · [Roadmap](./docs/ROADMAP.md) · [Good first tasks](./docs/TASKS.md) · [AI architecture](./docs/AI.md) · [Contributing](./CONTRIBUTING.md)
+[Website](https://dayotter.com) · [Docs](./docs) · [Compare](./docs/COMPARISON.md) · [Discord](https://discord.gg/cxwETDsY85) · [Roadmap](./docs/ROADMAP.md) · [Good first tasks](./docs/TASKS.md) · [AI architecture](./docs/AI.md) · [Contributing](./CONTRIBUTING.md)
 
 ![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)
 ![Self-hostable](https://img.shields.io/badge/self--hostable-yes-brightgreen)
@@ -25,6 +25,8 @@ DayOtter is a complete scheduling platform - booking pages, team round-robin, ca
 Most schedulers hand out a link and stop there. Otter actually does the work. You describe what you want in plain language - in the app, by voice, or over **WhatsApp / SMS** - and Otter drafts the action; you approve it. It **protects your focus time**, nudges your next meeting when you're **running late**, surfaces **proactive suggestions**, and **learns your patterns** over time. Crucially, it is **confirm-first**: it never changes your calendar without your OK.
 
 Think Calendly + Motion + a real assistant - except **open-source and self-hostable in one command**, with every AI feature included.
+
+> **The AI is optional and never a black box.** DayOtter runs as a complete scheduler with **no AI configured at all**. Turn Otter on by pointing it at a model *you* choose: Anthropic or OpenAI, any OpenAI-compatible endpoint, or a **local model via Ollama / LM Studio / vLLM - so nothing has to leave your server**. See [Self-hosting the AI](./docs/AI.md#self-hosting-the-ai).
 
 **Who it's for**
 
@@ -74,6 +76,10 @@ DayOtter is **open-core**, the way Cal.com _used to be_:
 - **`ee/` is a small, separately-licensed commercial layer** for *cloud-only infrastructure* - Managed AI (no key to configure), SSO, white-label, hosted messaging. It's inert unless `DAYOTTER_CLOUD=1`. See [`apps/web/lib/ee/LICENSE.md`](./apps/web/lib/ee/LICENSE.md) and [`docs/ENTERPRISE.md`](./docs/ENTERPRISE.md).
 
 You do **not** need `ee/` to run the full product.
+
+**How we intend to make money — and our promise.** The plan is a hosted **DayOtter Cloud** (convenience: managed AI with no key to configure, hosted messaging, SSO, white-label) for people who don't want to run servers. That's it. The self-hostable product — booking, teams, routing, workflows, insights, payments, and all of Otter's AI logic — **stays AGPLv3 and free, forever.** We will not move the core to a closed or "source-available" repo. If that ever changes, AGPLv3 guarantees the last open version can be forked and carried on by anyone — which is the whole point.
+
+> **Project status: early and moving fast.** DayOtter is a young project (first public code mid-2026). It's broad and usable, but it is **not yet battle-tested at scale**, and enterprise pieces (SSO/SAML, SCIM, audit logs, SOC 2 / HIPAA) are on the [roadmap](./docs/ROADMAP.md), not shipped. Kick the tires, self-host it, and help shape it - issues and PRs welcome.
 
 ## Monorepo layout
 

--- a/apps/web/app/(app)/settings/import/page.tsx
+++ b/apps/web/app/(app)/settings/import/page.tsx
@@ -1,3 +1,4 @@
+import { CalcomImport } from "@/components/calcom-import";
 import { CalendlyImport } from "@/components/calendly-import";
 import { Card, CardBody, CardHeader } from "@/components/ui/card";
 import { getSession } from "@/lib/auth/session";
@@ -11,11 +12,11 @@ export default async function ImportSettingsPage() {
   return (
     <>
       <div className="mb-6">
-        <h2 className="text-lg font-semibold">Import from Calendly</h2>
+        <h2 className="text-lg font-semibold">Import your event types</h2>
         <p className="mt-1 text-sm text-[var(--color-muted)]">
-          Switching over? Bring your event types and weekly availability across in one step. We read
-          them straight from Calendly with a token you paste below - nothing is changed on the
-          Calendly side, and existing DayOtter data is never overwritten.
+          Switching over? Bring your event types across in one step. We read them straight from the
+          source with a token/key you paste below - nothing is changed on the other side, and
+          existing DayOtter data is never overwritten.
         </p>
       </div>
 
@@ -26,6 +27,16 @@ export default async function ImportSettingsPage() {
         />
         <CardBody>
           <CalendlyImport />
+        </CardBody>
+      </Card>
+
+      <Card className="mt-6">
+        <CardHeader
+          title="Cal.com"
+          description="Event types from Cal.com cloud or a self-hosted instance, via a v1 API key."
+        />
+        <CardBody>
+          <CalcomImport />
         </CardBody>
       </Card>
 

--- a/apps/web/app/api/import/calcom/route.ts
+++ b/apps/web/app/api/import/calcom/route.ts
@@ -1,0 +1,50 @@
+import { mapCalcomExport } from "@/lib/import/calcom";
+import { CalcomAuthError, fetchCalcomEventTypes } from "@/lib/import/calcom-client";
+import { importCalcomEventTypes } from "@/lib/import/run-import";
+import { jsonError, withUser } from "@/lib/server/http";
+import { enforceRateLimit } from "@/lib/server/rate-limit";
+import { logger } from "@dayotter/core";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+export const dynamic = "force-dynamic";
+
+const body = z.object({
+  apiKey: z.string().min(6).max(500),
+  /** Optional self-hosted Cal.com base (e.g. https://cal.acme.com/api/v1). */
+  baseUrl: z.string().url().max(300).optional(),
+});
+
+/**
+ * Import a user's Cal.com event types from a v1 API key. The key is used only for
+ * this request and never stored. Egress is SSRF-safe (pinned `safeFetch`) and the
+ * key/base are validated. Host-only.
+ */
+export const POST = withUser(async (u, request) => {
+  const limited = await enforceRateLimit(request, {
+    name: "calcom-import",
+    limit: 5,
+    windowSec: 600,
+    key: u.id,
+  });
+  if (limited) return limited;
+
+  const parsed = body.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) return jsonError("Paste your Cal.com API key to import.", 400);
+
+  try {
+    const data = await fetchCalcomEventTypes(parsed.data.apiKey.trim(), parsed.data.baseUrl);
+    const mapped = mapCalcomExport(data);
+    const summary = await importCalcomEventTypes(u.id, mapped);
+    return NextResponse.json({ ok: true, ...summary });
+  } catch (err) {
+    if (err instanceof CalcomAuthError) {
+      return jsonError("Cal.com rejected that API key. Check it and retry.", 400);
+    }
+    logger.error("cal.com import failed", { event: "calcom_import_failed", err });
+    return jsonError(
+      "Couldn't import from Cal.com. Check the API key (and base URL) and retry.",
+      502,
+    );
+  }
+});

--- a/apps/web/components/calcom-import.tsx
+++ b/apps/web/components/calcom-import.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input, Label } from "@/components/ui/input";
+import { AlertTriangle, CheckCircle2, Loader2 } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+interface ImportResult {
+  eventTypesImported: number;
+  eventTypesSkipped: number;
+  warnings: string[];
+}
+
+/**
+ * Import event types from Cal.com (cloud or self-hosted) via a v1 API key.
+ * Turns the "Cal.com went closed-source" migration into a one-paste move.
+ */
+export function CalcomImport() {
+  const router = useRouter();
+  const [apiKey, setApiKey] = useState("");
+  const [baseUrl, setBaseUrl] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<ImportResult | null>(null);
+
+  async function run() {
+    setBusy(true);
+    setError(null);
+    setResult(null);
+    try {
+      const res = await fetch("/api/import/calcom", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          apiKey: apiKey.trim(),
+          baseUrl: baseUrl.trim() || undefined,
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(data.error ?? "Import failed. Please try again.");
+        return;
+      }
+      setResult(data as ImportResult);
+      setApiKey("");
+      router.refresh();
+    } catch {
+      setError("Something went wrong. Please try again.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (result) {
+    return (
+      <div className="space-y-4">
+        <div className="flex items-start gap-2 rounded-md border border-[var(--color-success)]/30 bg-[var(--color-success)]/10 px-4 py-3 text-sm text-[var(--color-success)]">
+          <CheckCircle2 size={16} className="mt-0.5 shrink-0" />
+          <div>
+            <p className="font-medium">Imported from Cal.com.</p>
+            <p className="mt-0.5 text-[var(--color-text)]">
+              {result.eventTypesImported} event type{result.eventTypesImported === 1 ? "" : "s"}
+              {result.eventTypesSkipped > 0 ? ` · ${result.eventTypesSkipped} skipped` : ""}.
+            </p>
+          </div>
+        </div>
+        {result.warnings.length > 0 ? (
+          <ul className="space-y-1.5 text-xs text-[var(--color-muted)]">
+            {result.warnings.map((w) => (
+              <li key={w} className="flex items-start gap-1.5">
+                <AlertTriangle size={13} className="mt-0.5 shrink-0 text-[var(--color-amber)]" />
+                {w}
+              </li>
+            ))}
+          </ul>
+        ) : null}
+        <Link
+          href="/event-types"
+          className="text-sm font-medium text-[var(--color-accent)] hover:underline"
+        >
+          Review imported event types →
+        </Link>
+        <div>
+          <Button variant="outline" size="sm" onClick={() => setResult(null)}>
+            Import again
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <Label htmlFor="calcom-key">Cal.com API key</Label>
+        <Input
+          id="calcom-key"
+          type="password"
+          autoComplete="off"
+          placeholder="cal_live_…"
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          className="mt-1.5 font-mono"
+        />
+        <p className="mt-1.5 text-xs text-[var(--color-muted)]">
+          Create one in Cal.com → Settings → Developer → API keys. Used once for this import and
+          never stored.
+        </p>
+      </div>
+      <div>
+        <Label htmlFor="calcom-base">Self-hosted API base (optional)</Label>
+        <Input
+          id="calcom-base"
+          placeholder="https://cal.your-company.com/api/v1"
+          value={baseUrl}
+          onChange={(e) => setBaseUrl(e.target.value)}
+          className="mt-1.5 font-mono"
+        />
+        <p className="mt-1.5 text-xs text-[var(--color-muted)]">
+          Leave blank for Cal.com cloud. Must be a public HTTPS URL.
+        </p>
+      </div>
+      {error ? (
+        <p className="flex items-center gap-1.5 text-sm text-[var(--color-danger)]">
+          <AlertTriangle size={14} /> {error}
+        </p>
+      ) : null}
+      <Button onClick={run} disabled={busy || apiKey.trim().length < 6} className="gap-1.5">
+        {busy ? <Loader2 size={15} className="animate-spin" /> : null}
+        {busy ? "Importing…" : "Import from Cal.com"}
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/lib/import/calcom-client.ts
+++ b/apps/web/lib/import/calcom-client.ts
@@ -1,0 +1,81 @@
+import { safeFetch } from "@dayotter/core";
+import type { CalcomExport } from "./calcom";
+
+/** Cal.com cloud API base. Self-hosters pass their own `<instance>/api/v1`. */
+export const DEFAULT_CALCOM_BASE = "https://api.cal.com/v1";
+
+/** Cap the response so a huge/hostile payload can't exhaust memory. */
+const MAX_BYTES = 5_000_000;
+export const MAX_EVENT_TYPES = 200;
+
+/** Thrown when Cal.com rejects the API key (401) - surfaced to the user distinctly. */
+export class CalcomAuthError extends Error {
+  constructor() {
+    super("Cal.com rejected the API key");
+    this.name = "CalcomAuthError";
+  }
+}
+
+function normalizeBase(base: string): string {
+  const trimmed = base.trim().replace(/\/+$/, "");
+  // Accept either ".../api/v1" or ".../v1"; append /v1 if the caller gave a bare origin.
+  return /\/v1$/.test(trimmed) ? trimmed : `${trimmed}/v1`;
+}
+
+async function readCapped(res: Response): Promise<string> {
+  const reader = res.body?.getReader();
+  if (!reader) return await res.text();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) {
+      total += value.length;
+      if (total > MAX_BYTES) {
+        await reader.cancel();
+        throw new Error("Cal.com response too large");
+      }
+      chunks.push(value);
+    }
+  }
+  return new TextDecoder().decode(
+    chunks.reduce<Uint8Array>((acc, c) => {
+      const merged = new Uint8Array(acc.length + c.length);
+      merged.set(acc);
+      merged.set(c, acc.length);
+      return merged;
+    }, new Uint8Array()),
+  );
+}
+
+/**
+ * Fetch a user's Cal.com event types via a v1 API key. SSRF-safe (the base URL is
+ * user-supplied, so egress goes through the pinned `safeFetch`), size-capped, and
+ * bounded to `MAX_EVENT_TYPES`. The key is used only for this request and never
+ * stored. Cal.com v1 authenticates with an `apiKey` query param.
+ */
+export async function fetchCalcomEventTypes(
+  apiKey: string,
+  baseUrl: string = DEFAULT_CALCOM_BASE,
+): Promise<CalcomExport> {
+  const url = `${normalizeBase(baseUrl)}/event-types?apiKey=${encodeURIComponent(apiKey.trim())}`;
+  const res = await safeFetch(url, {
+    headers: { "content-type": "application/json" },
+    timeoutMs: 15_000,
+  });
+  if (res.status === 401 || res.status === 403) throw new CalcomAuthError();
+  if (!res.ok) throw new Error(`Cal.com returned ${res.status}`);
+
+  const raw = await readCapped(res);
+  let parsed: CalcomExport;
+  try {
+    parsed = JSON.parse(raw) as CalcomExport;
+  } catch {
+    throw new Error("Cal.com returned an unexpected (non-JSON) response");
+  }
+  if (parsed.event_types && parsed.event_types.length > MAX_EVENT_TYPES) {
+    parsed.event_types = parsed.event_types.slice(0, MAX_EVENT_TYPES);
+  }
+  return parsed;
+}

--- a/apps/web/lib/import/calcom.test.ts
+++ b/apps/web/lib/import/calcom.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { type CalcomExport, mapCalcomExport, mapEventType, mapLocation } from "./calcom";
+
+describe("mapLocation", () => {
+  it("maps Cal.com integration location types to DayOtter types", () => {
+    expect(mapLocation({ type: "integrations:google:meet" }).location).toBe("google_meet");
+    expect(mapLocation({ type: "integrations:office365_video" }).location).toBe("ms_teams");
+    expect(mapLocation({ type: "integrations:zoom", link: "https://zoom.us/j/1" })).toEqual({
+      location: "zoom",
+      locationDetail: "https://zoom.us/j/1",
+    });
+    expect(mapLocation({ type: "integrations:daily" }).location).toBe("jitsi");
+    expect(mapLocation({ type: "inPerson", address: "12 Main St" })).toEqual({
+      location: "in_person",
+      locationDetail: "12 Main St",
+    });
+    expect(mapLocation({ type: "phone", hostPhoneNumber: "+1 555" })).toEqual({
+      location: "phone",
+      locationDetail: "+1 555",
+    });
+    expect(mapLocation({ type: "link", link: "https://meet.example" })).toEqual({
+      location: "custom",
+      locationDetail: "https://meet.example",
+    });
+  });
+
+  it("falls back to google_meet for unknown/empty types", () => {
+    expect(mapLocation({ type: "integrations:unknown-vendor" }).location).toBe("google_meet");
+    expect(mapLocation(undefined).location).toBe("google_meet");
+  });
+});
+
+describe("mapEventType", () => {
+  it("maps core fields and slugifies the title when no slug", () => {
+    const m = mapEventType({
+      title: "Intro Call!!",
+      length: 45,
+      description: "  chat  ",
+      hidden: true,
+      requiresConfirmation: true,
+      minimumBookingNotice: 120,
+      locations: [{ type: "integrations:zoom", link: "https://z" }],
+    });
+    expect(m).toMatchObject({
+      title: "Intro Call!!",
+      slug: "intro-call",
+      durationMinutes: 45,
+      description: "chat",
+      location: "zoom",
+      locationDetail: "https://z",
+      requiresConfirmation: true,
+      minimumNoticeMinutes: 120,
+      isPrivate: true,
+    });
+  });
+
+  it("defaults duration/notice and drops detail for detail-less locations", () => {
+    const m = mapEventType({ title: "X", locations: [{ type: "integrations:google:meet" }] });
+    expect(m?.durationMinutes).toBe(30);
+    expect(m?.minimumNoticeMinutes).toBe(60);
+    expect(m?.locationDetail).toBeNull();
+    expect(m?.isPrivate).toBe(false);
+  });
+
+  it("returns null for a titleless entry", () => {
+    expect(mapEventType({ title: "  ", length: 30 })).toBeNull();
+  });
+
+  it("clamps out-of-range duration", () => {
+    expect(mapEventType({ title: "A", length: 100000 })?.durationMinutes).toBe(480);
+    expect(mapEventType({ title: "B", length: 1 })?.durationMinutes).toBe(5);
+  });
+});
+
+describe("mapCalcomExport", () => {
+  it("maps a list and drops malformed entries", () => {
+    const data: CalcomExport = {
+      event_types: [
+        { title: "Good", length: 30 },
+        { title: "", length: 30 }, // dropped
+        { title: "Also good", length: 60, locations: [{ type: "phone" }] },
+      ],
+    };
+    const out = mapCalcomExport(data);
+    expect(out).toHaveLength(2);
+    expect(out.map((e) => e.title)).toEqual(["Good", "Also good"]);
+  });
+
+  it("handles empty/absent event_types", () => {
+    expect(mapCalcomExport({})).toEqual([]);
+    expect(mapCalcomExport({ event_types: [] })).toEqual([]);
+  });
+});

--- a/apps/web/lib/import/calcom.ts
+++ b/apps/web/lib/import/calcom.ts
@@ -1,0 +1,121 @@
+import type { LocationTypeValue } from "../booking/event-type-input";
+
+/**
+ * Pure mapping layer: Cal.com API v1 event-type shapes -> the fields DayOtter
+ * stores. No network / DB access, so it can be exhaustively unit-tested; the
+ * client (`calcom-client.ts`) and persistence (`run-import.ts`) wrap it. Only the
+ * subset of Cal.com's payload we actually use is typed.
+ *
+ * Cal.com's `locations` is an array of `{ type, address?, link?, ... }` where
+ * `type` is a namespaced string (e.g. `integrations:google:meet`, `inPerson`).
+ */
+
+export interface CalcomLocation {
+  type?: string;
+  address?: string | null;
+  link?: string | null;
+  hostPhoneNumber?: string | null;
+  [k: string]: unknown;
+}
+
+export interface CalcomEventType {
+  id?: number;
+  title?: string;
+  slug?: string | null;
+  length?: number; // minutes
+  description?: string | null;
+  hidden?: boolean;
+  requiresConfirmation?: boolean;
+  minimumBookingNotice?: number; // minutes
+  locations?: CalcomLocation[] | null;
+}
+
+export interface CalcomExport {
+  event_types?: CalcomEventType[];
+}
+
+export interface MappedEventType {
+  title: string;
+  slug: string;
+  durationMinutes: number;
+  description: string | null;
+  location: LocationTypeValue;
+  locationDetail: string | null;
+  requiresConfirmation: boolean;
+  minimumNoticeMinutes: number;
+  isPrivate: boolean;
+}
+
+const LOCATION_TYPES_NEEDING_DETAIL = new Set<LocationTypeValue>([
+  "zoom",
+  "phone",
+  "in_person",
+  "custom",
+]);
+
+/**
+ * Map one Cal.com location entry to a DayOtter location type + optional detail.
+ * Cal.com namespaces integration locations (`integrations:<vendor>[:<kind>]`) and
+ * uses bare keys for the rest. Anything unrecognized falls back to `custom`.
+ */
+export function mapLocation(loc: CalcomLocation | undefined): {
+  location: LocationTypeValue;
+  locationDetail: string | null;
+} {
+  const type = (loc?.type ?? "").toLowerCase();
+  const detailFrom = (v?: string | null) => (v?.trim() ? v.trim() : null);
+
+  if (type.includes("google")) return { location: "google_meet", locationDetail: null };
+  if (type.includes("office365") || type.includes("msteams") || type.includes("teams"))
+    return { location: "ms_teams", locationDetail: null };
+  if (type.includes("zoom")) return { location: "zoom", locationDetail: detailFrom(loc?.link) };
+  if (type.includes("daily") || type.includes("jitsi") || type.includes("whereby"))
+    return { location: "jitsi", locationDetail: null };
+  if (type === "inperson" || type.includes("inperson"))
+    return { location: "in_person", locationDetail: detailFrom(loc?.address) };
+  if (type.includes("phone"))
+    return { location: "phone", locationDetail: detailFrom(loc?.hostPhoneNumber) };
+  if (type === "link" || type.includes("link"))
+    return { location: "custom", locationDetail: detailFrom(loc?.link) };
+  // google_meet is a safe, detail-free default for anything we don't recognize.
+  return { location: "google_meet", locationDetail: null };
+}
+
+function slugify(v: string): string {
+  return (
+    v
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 60) || "meeting"
+  );
+}
+
+/** Map a single Cal.com event type. Returns null for entries too malformed to import. */
+export function mapEventType(et: CalcomEventType): MappedEventType | null {
+  const title = (et.title ?? "").trim();
+  if (!title) return null;
+  const duration = Number.isFinite(et.length) && (et.length ?? 0) > 0 ? Math.round(et.length!) : 30;
+  const first = et.locations?.find((l) => l?.type) ?? et.locations?.[0];
+  const { location, locationDetail } = mapLocation(first);
+  return {
+    title: title.slice(0, 120),
+    slug: slugify(et.slug?.trim() || title),
+    durationMinutes: Math.min(480, Math.max(5, duration)),
+    description: et.description?.trim() ? et.description.trim().slice(0, 2000) : null,
+    location,
+    // Only keep a detail for location types that use one.
+    locationDetail: LOCATION_TYPES_NEEDING_DETAIL.has(location) ? locationDetail : null,
+    requiresConfirmation: Boolean(et.requiresConfirmation),
+    minimumNoticeMinutes:
+      Number.isFinite(et.minimumBookingNotice) && (et.minimumBookingNotice ?? 0) >= 0
+        ? Math.min(43_200, Math.round(et.minimumBookingNotice!))
+        : 60,
+    isPrivate: Boolean(et.hidden),
+  };
+}
+
+/** Map a full Cal.com export to DayOtter event types, dropping malformed entries. */
+export function mapCalcomExport(data: CalcomExport): MappedEventType[] {
+  return (data.event_types ?? []).map(mapEventType).filter((x): x is MappedEventType => x !== null);
+}

--- a/apps/web/lib/import/run-import.ts
+++ b/apps/web/lib/import/run-import.ts
@@ -187,3 +187,79 @@ export async function importCalendlyExport(
     warnings,
   };
 }
+
+export interface CalcomImportSummary {
+  eventTypesImported: number;
+  eventTypesSkipped: number;
+  warnings: string[];
+}
+
+/**
+ * Persist mapped Cal.com event types into the user's DayOtter workspace. Mirrors
+ * the Calendly event-type path: slugs are deduped against the user's existing
+ * ones + this run, and rows are batch-inserted with a per-row fallback. Cal.com
+ * has no exportable availability schedules via the v1 event-types endpoint, so we
+ * only import event types (attached to the user's default schedule).
+ */
+export async function importCalcomEventTypes(
+  userId: string,
+  mapped: import("./calcom").MappedEventType[],
+): Promise<CalcomImportSummary> {
+  const db = getDb();
+  const { organizationId, scheduleId: defaultScheduleId } = await ensureUserWorkspace(userId);
+
+  const existing = await db.query.eventTypes.findMany({
+    where: and(eq(schema.eventTypes.ownerId, userId), notPersonalType),
+    columns: { slug: true },
+  });
+  const takenSlugs = new Set(existing.map((e) => e.slug));
+
+  const rows: (typeof schema.eventTypes.$inferInsert)[] = [];
+  for (const m of mapped) {
+    const slug = uniqueSlug(m.slug, takenSlugs);
+    takenSlugs.add(slug);
+    rows.push({
+      organizationId,
+      ownerId: userId,
+      scheduleId: defaultScheduleId,
+      title: m.title,
+      slug,
+      durationMinutes: m.durationMinutes,
+      description: m.description,
+      location: m.location,
+      locationDetail: m.locationDetail,
+      requiresConfirmation: m.requiresConfirmation,
+      minimumNoticeMinutes: m.minimumNoticeMinutes,
+      isPrivate: m.isPrivate,
+    });
+  }
+
+  let eventTypesImported = 0;
+  let eventTypesSkipped = 0;
+  if (rows.length > 0) {
+    try {
+      await db.insert(schema.eventTypes).values(rows);
+      eventTypesImported = rows.length;
+    } catch (err) {
+      logger.warn("cal.com batch insert failed; falling back to per-row", {
+        event: "calcom_import_batch_fallback",
+        err,
+      });
+      for (const r of rows) {
+        try {
+          await db.insert(schema.eventTypes).values(r);
+          eventTypesImported++;
+        } catch (rowErr) {
+          eventTypesSkipped++;
+          logger.error("cal.com event type import failed", {
+            event: "calcom_import_event_type_failed",
+            title: r.title,
+            err: rowErr,
+          });
+        }
+      }
+    }
+  }
+
+  return { eventTypesImported, eventTypesSkipped, warnings: [] };
+}

--- a/docs/AI.md
+++ b/docs/AI.md
@@ -92,6 +92,36 @@ recognition.
 ### Where your time goes - `lib/analytics/time-allocation/`  ([README](../apps/web/lib/analytics/time-allocation/README.md))
 A pluggable metric registry over your bookings + focus time. Add a `TimeMetric`.
 
+## Self-hosting the AI
+
+Otter's model layer is vendor-agnostic (`AI_PROVIDER` selects the backend in
+`lib/ai/providers/`). There are four honest setups, from "no AI" to "fully local,
+nothing leaves the box":
+
+| Mode | Configure | What leaves your server |
+|---|---|---|
+| **No AI** (pure scheduler) | *nothing* — leave `AI_PROVIDER` unset | Nothing. Every Otter surface is hidden; booking, teams, routing, reminders, payments all work. |
+| **Anthropic** | `AI_PROVIDER=anthropic` + `ANTHROPIC_API_KEY` | Scheduling context → Anthropic, only when you use Otter. |
+| **OpenAI / compatible** | `AI_PROVIDER=openai` + `OPENAI_API_KEY` | Scheduling context → OpenAI, only when you use Otter. |
+| **Local model (no phone-home)** | `AI_PROVIDER=openai` + `OPENAI_BASE_URL=http://localhost:11434/v1` + `OPENAI_API_KEY=ollama` + `OPENAI_MODEL_DEEP`/`OPENAI_MODEL_FAST` | **Nothing.** Otter talks to your local Ollama / LM Studio / vLLM. |
+
+`aiEnabled` (`lib/ai/providers/index.ts`) is `provider.configured`, so with no key
+the whole assistant is simply off and DayOtter is a complete, self-contained
+scheduler. Larger local models give better Otter quality; small ones still handle
+the common "book / move / cancel" commands.
+
+**Local quickstart (Ollama):**
+
+```bash
+ollama pull llama3.1:8b
+# in apps/web/.env
+AI_PROVIDER=openai
+OPENAI_BASE_URL=http://localhost:11434/v1
+OPENAI_API_KEY=ollama            # any non-empty string; Ollama ignores it
+OPENAI_MODEL_DEEP=llama3.1:8b
+OPENAI_MODEL_FAST=llama3.1:8b
+```
+
 ## How the AI stays open
 
 - **Bring your own key / model.** Set `ANTHROPIC_API_KEY` and everything works.

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -1,0 +1,68 @@
+# How DayOtter compares
+
+An honest look at where DayOtter fits among scheduling tools — including what we
+**don't** do yet. If something here is out of date or wrong, please open an issue;
+we'd rather be corrected than overclaim.
+
+## The one-line difference
+
+DayOtter is the only scheduler we know of that is **AI-native, open source (AGPLv3),
+and fully self-hostable — including the AI — at the same time.** Every alternative
+gives up at least one of those three.
+
+## At a glance
+
+| | DayOtter | Cal.com (Cal.diy, OSS) | Cal.com (cloud) | Calendly | Motion / Reclaim |
+|---|---|---|---|---|---|
+| License | **AGPLv3, all of it** | MIT, feature-stripped | Closed | Closed | Closed |
+| Self-host the full product | **Yes** | Core only | License key required | No | No |
+| AI assistant | **Yes — open, confirm-first** | No | Cal.ai (closed, metered) | No | Yes (closed) |
+| Run the AI on your own box | **Yes — local model or BYO key** | — | No | — | No |
+| Teams / round-robin | ✅ open | ❌ removed from OSS | 💲 paid | 💲 | — |
+| Routing forms | ✅ open | ❌ removed | 💲 | — | — |
+| Workflows / automations | ✅ open | ❌ removed | 💲 | limited | ✅ |
+| Insights / analytics | ✅ open | ❌ removed | 💲 | 💲 | ✅ |
+| Payments (Stripe) | ✅ open | ✅ | ✅ | 💲 | — |
+| Mobile app | ✅ (Play; bring-your-own-server) | — | ✅ | ✅ | ✅ |
+| SSO / SAML, SCIM, SOC 2 | 🚧 roadmap | ❌ | 💲 enterprise | enterprise | enterprise |
+| Maturity & community | 🚧 **early** | large, established | same lineage | category leader | established |
+
+✅ open · 💲 paid/closed · ❌ not available · 🚧 planned
+
+## Context: what changed in 2026
+
+- **Cal.com moved its core to closed source (~April 2026)**, leaving an MIT
+  "Cal.diy" fork with Teams, Organizations, SAML/SCIM, Workflows, Routing Forms,
+  Insights, and its AI agent removed. The features Cal.com pulled behind a closed
+  wall are the ones DayOtter keeps open. ([cal.com blog](https://cal.com/blog/cal-com-goes-closed-source-why),
+  [itsfoss](https://itsfoss.com/news/cal-com-goes-proprietary/))
+- **The AI-scheduling incumbents are closed and consolidating.** Reclaim was
+  acquired by Dropbox; Clockwise was acqui-hired by Salesforce and shut down in
+  March 2026. Self-hosting is the only version of this you truly control.
+
+## Where DayOtter is genuinely strong
+
+- **Open, including the AI.** Otter's prompts, tools, and orchestration are all in
+  the repo — not a rented black box.
+- **The AI runs where you want it.** Local model (Ollama/vLLM) for zero phone-home,
+  or a hosted key — your call. See [Self-hosting the AI](./AI.md#self-hosting-the-ai).
+- **Confirm-first.** Otter proposes; you approve. It won't silently reshuffle your
+  calendar (the thing people dislike about aggressive auto-schedulers).
+- **Breadth that's open here** and paywalled/closed elsewhere: teams, routing,
+  workflows, insights, payments, group polls, plugins, a mobile app.
+
+## Where DayOtter is weak today (on purpose, being honest)
+
+- **It's early.** Young project, small team, not yet proven at scale. Cal.com and
+  Calendly have years and large communities.
+- **AI needs a model.** The AI *code* is free; running it needs either a paid API
+  key or a local GPU. Tiny local models give weaker results.
+- **Enterprise/compliance is roadmap.** SSO/SAML, SCIM, audit logs, SOC 2/HIPAA are
+  planned, not shipped ([roadmap](./ROADMAP.md)).
+- **Smaller ecosystem.** We have a plugin SDK, but not (yet) a large app marketplace.
+
+## Migrating in
+
+- **From Calendly:** built-in importer (Settings → Import) pulls your event types
+  and availability from a Calendly access token.
+- **From Cal.com:** see the importer under Settings → Import.


### PR DESCRIPTION
Implements the code-actionable recommendations from the pre-launch competitive review, so we can defend the HN / Product Hunt launch with facts. (Verified: Cal.com went closed-source ~April 2026; the AI-scheduling incumbents are all closed and consolidating — Reclaim→Dropbox, Clockwise shut down; no genuinely self-hostable open-source AI scheduler exists.)

## Docs — pre-empt the tough questions
- **README licensing promise + monetization** — states plainly that the plan is a hosted **DayOtter Cloud** for convenience and that the self-hostable core (booking, teams, routing, workflows, insights, payments, *and all of Otter's AI logic*) **stays AGPLv3 and free, forever** — and that AGPLv3 guarantees it can't be pulled closed. This is the direct answer to the #1 launch question: *"how do you make money / won't you pull a Cal.com?"*
- **AI is optional and local** — README + `docs/AI.md` now make explicit that DayOtter runs as a **full scheduler with no AI configured at all**, and that Otter can run on a **local Ollama/LM Studio/vLLM model via `OPENAI_BASE_URL` with zero phone-home**. Verified in code (`aiEnabled = provider.configured`, gated everywhere). Includes an Ollama quickstart. Answers *"is the AI actually self-hostable or does it phone home?"*
- **`docs/COMPARISON.md`** — a public, honest comparison table that **includes our current weaknesses** (early project, AI needs a model, enterprise/compliance on roadmap). Linked from the README. (Transparency > spin for an OSS launch.)

## Feature — Cal.com → DayOtter importer
Top HN take on Cal.com: *"the moat is not the code, it's the users who don't want to migrate."* So we make migrating a one-paste move.
- **Pure, unit-tested mapper** (`lib/import/calcom.ts`, **8 tests**): Cal.com v1 event-type + namespaced location shapes → DayOtter event types, with clamping and malformed-entry dropping.
- **SSRF-safe client** (`calcom-client.ts`) via core `safeFetch` (HTTPS-only, DNS-rebinding-pinned), size- and count-capped; the API key is used once and never stored; supports self-hosted Cal.com base URLs.
- `importCalcomEventTypes` persistence (slug-dedup + batch insert with per-row fallback), `POST /api/import/calcom`, and a **Cal.com card on Settings → Import** next to Calendly.

## Verification
Web typecheck + Biome clean; 8 mapper tests pass.

⚠️ The **live fetch against a real Cal.com API key** still needs a manual run — no Cal.com account is available in this environment. The mapper and the error paths are covered by tests/types, and the client mirrors the already-shipped Calendly importer.

*(An internal, gitignored launch-defense brief with the full sourced Q&A also exists locally for the team — the public-facing parts are in `docs/COMPARISON.md`.)*