### PR TITLE
feat(deploy): one-click deploy templates (Render) + deploy guide — please test before merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,9 @@ Run the mobile app against your local server with `pnpm --filter @dayotter/mobil
 
 **Requirements:** Docker + Docker Compose, a Postgres database, and a Redis instance (both come up in the compose stack). AI is **optional** - DayOtter is a full scheduler with no model configured; add a key or a local model to turn Otter on. **Typical first-boot: ~10 minutes** to `docker compose up` and connect a calendar; OAuth for Google/Microsoft needs client IDs (see the integrations guide).
 
-Docker Compose brings up Postgres, Redis, migrations, web, worker, and a reverse proxy. See [`deploy/README.md`](./deploy/README.md) and [`docs/SELF_HOSTING.md`](./docs/SELF_HOSTING.md). Redeploys always run migrations via [`deploy/deploy.sh`](./deploy/deploy.sh).
+**One-click:** [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/Dayotter/dayotter) &nbsp; (Railway / DigitalOcean / Coolify / CapRover / any Docker host: **[docs/DEPLOY.md](./docs/DEPLOY.md)**).
+
+Or **Docker Compose** brings up Postgres, Redis, migrations, web, worker, and a reverse proxy. See [`deploy/README.md`](./deploy/README.md) and [`docs/SELF_HOSTING.md`](./docs/SELF_HOSTING.md). Redeploys always run migrations via [`deploy/deploy.sh`](./deploy/deploy.sh).
 
 **Connecting integrations** (Google, Microsoft, Apple, Salesforce, HubSpot, Zoom, Stripe, Twilio, Resend) - where to get each client ID / API key and which redirect URI & webhook to register: [`docs/INTEGRATIONS.md`](./docs/INTEGRATIONS.md), mirrored on the site at `/docs/integration-setup`.
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,79 @@
+# Deploy DayOtter
+
+DayOtter is two long-running services - **web** (Next.js) and **worker** (reminders,
+calendar sync, briefings) - plus **Postgres** and **Redis**. Any host that can run
+the two Dockerfiles (`apps/web/Dockerfile`, `apps/worker/Dockerfile`) with those two
+data stores can run it.
+
+> **AI is optional.** None of the buttons below require an AI key - DayOtter runs as
+> a complete scheduler with no model configured. Add one later to turn Otter on
+> ([Self-hosting the AI](./AI.md#self-hosting-the-ai)).
+
+## The three values you always set
+
+However you deploy, set these (the rest of `.env.example` is optional / feature-gated):
+
+| Var | How to get it |
+|---|---|
+| `ENCRYPTION_KEY` | **64 hex chars:** `openssl rand -hex 32` (the all-zero placeholder is rejected) |
+| `AUTH_SECRET` | 32+ random chars: `openssl rand -base64 32` |
+| `APP_URL` + `NEXT_PUBLIC_APP_URL` | your public URL, e.g. `https://cal.acme.com`. `NEXT_PUBLIC_APP_URL` is **baked at build time**, so set it before/at build (or set it and redeploy). |
+
+`DATABASE_URL` and `REDIS_URL` are wired up for you by the managed options below.
+
+---
+
+## One-click: Render
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/Dayotter/dayotter)
+
+Uses [`render.yaml`](../render.yaml) to provision web + worker + Postgres + Redis and
+run migrations before each deploy. After the first deploy:
+
+1. Set **`ENCRYPTION_KEY`** (`openssl rand -hex 32`) on both the web and worker services.
+2. Set **`APP_URL`**, **`NEXT_PUBLIC_APP_URL`**, and **`BETTER_AUTH_URL`** to your
+   assigned `https://<name>.onrender.com`, then **Manual Deploy → Clear build cache &
+   deploy** so `NEXT_PUBLIC_APP_URL` is baked in.
+
+> Render renamed "Redis" to "Key Value". If your account only offers `type: keyvalue`,
+> change that one line in `render.yaml`.
+
+## Railway
+
+Railway builds each service straight from its Dockerfile. There's no committed template
+(a Railway template is published from the Railway dashboard, not the repo), so:
+
+1. New Project → Deploy from repo → add **two services** pointing at
+   `apps/web/Dockerfile` and `apps/worker/Dockerfile`.
+2. Add the **Postgres** and **Redis** plugins; Railway injects `DATABASE_URL` /
+   `REDIS_URL` - reference them on both services.
+3. Set the three values above; expose the web service and use its domain as `APP_URL`.
+
+*(Want a one-click Railway button? Publish a template from your deployed project and
+drop the `https://railway.com/new/template?...` URL into this file.)*
+
+## DigitalOcean App Platform
+
+Create an App from this repo with two **Dockerfile** components (web + worker), a
+**Dev/Managed Postgres** and a **Managed Redis (Valkey)**; bind `DATABASE_URL` /
+`REDIS_URL` and set the three values above. Run `pnpm --filter @dayotter/db migrate`
+as a pre-deploy job.
+
+## Coolify / CapRover / any Docker host
+
+Use the production compose in [`deploy/`](../deploy/README.md) - it brings up Postgres,
+Redis, migrations, web, worker, and a Caddy reverse proxy with automatic HTTPS:
+
+```bash
+git clone https://github.com/Dayotter/dayotter && cd dayotter/deploy
+cp .env.example .env        # fill ENCRYPTION_KEY, AUTH_SECRET, DAYOTTER_DOMAIN, ...
+./deploy.sh                 # builds, migrates, and starts everything
+```
+
+Coolify/CapRover can import that `docker-compose.prod.yml` directly.
+
+---
+
+**First boot is ~10 minutes.** Connect a Google/Microsoft/Apple calendar to see
+conflict-free availability across all of them. OAuth client IDs for the calendars,
+Stripe, Twilio, etc. are in [`docs/INTEGRATIONS.md`](./INTEGRATIONS.md).

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,82 @@
+# Render Blueprint - one-click DayOtter (web + worker + Postgres + Redis).
+# Deploy: https://render.com/deploy?repo=https://github.com/Dayotter/dayotter
+#
+# ⚠️ Two values can't be auto-provisioned and must be set once, then redeploy:
+#   1. ENCRYPTION_KEY - a 32-byte hex key. Generate with:  openssl rand -hex 32
+#      (Render's generateValue can't produce a fixed-length hex string.)
+#   2. APP_URL / NEXT_PUBLIC_APP_URL - your assigned https://<name>.onrender.com.
+#      NEXT_PUBLIC_APP_URL is baked at build time, so set it and trigger a rebuild.
+# Everything else (calendars, Stripe, Twilio, AI) is optional and off by default -
+# DayOtter runs as a full scheduler with none of it. See .env.example.
+
+databases:
+  - name: dayotter-db
+    databaseName: dayotter
+    user: dayotter
+    plan: basic-256mb
+
+services:
+  # Redis / Key Value store (Render renamed "Redis" to "Key Value"; if your
+  # account only offers `type: keyvalue`, rename this one line).
+  - type: redis
+    name: dayotter-redis
+    plan: starter
+    ipAllowList: [] # internal traffic only
+    maxmemoryPolicy: noeviction
+
+  - type: web
+    name: dayotter-web
+    runtime: docker
+    dockerfilePath: ./apps/web/Dockerfile
+    dockerContext: .
+    plan: starter
+    healthCheckPath: /api/me # returns fast (401 when unauthenticated) = alive
+    # Run DB migrations before each deploy goes live.
+    preDeployCommand: pnpm --filter @dayotter/db migrate
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: DATABASE_URL
+        fromDatabase:
+          name: dayotter-db
+          property: connectionString
+      - key: REDIS_URL
+        fromService:
+          name: dayotter-redis
+          type: redis
+          property: connectionString
+      - key: AUTH_SECRET # 32+ char random - Render generates a good one
+        generateValue: true
+      - key: ENCRYPTION_KEY # MUST be 64 hex chars: openssl rand -hex 32
+        sync: false
+      - key: APP_URL # set to https://<your-web-name>.onrender.com, then redeploy
+        sync: false
+      - key: NEXT_PUBLIC_APP_URL # same URL; baked at build time -> rebuild after setting
+        sync: false
+      - key: BETTER_AUTH_URL # same as APP_URL
+        sync: false
+      - key: AI_PROVIDER # optional: "anthropic" or "openai" (leave unset = no AI)
+        sync: false
+
+  - type: worker
+    name: dayotter-worker
+    runtime: docker
+    dockerfilePath: ./apps/worker/Dockerfile
+    dockerContext: .
+    plan: starter
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: DATABASE_URL
+        fromDatabase:
+          name: dayotter-db
+          property: connectionString
+      - key: REDIS_URL
+        fromService:
+          name: dayotter-redis
+          type: redis
+          property: connectionString
+      - key: ENCRYPTION_KEY # must match the web service's key exactly
+        sync: false
+      - key: APP_URL
+        sync: false

--- a/render.yaml
+++ b/render.yaml
@@ -31,8 +31,9 @@ services:
     dockerContext: .
     plan: starter
     healthCheckPath: /api/me # returns fast (401 when unauthenticated) = alive
-    # Run DB migrations before each deploy goes live.
-    preDeployCommand: pnpm --filter @dayotter/db migrate
+    # NB: DB migrations run from the *worker* service's preDeployCommand, not here.
+    # The web image is a slim Next.js standalone bundle with no pnpm or drizzle-kit,
+    # so it cannot run migrations; the worker image carries the full workspace.
     envVars:
       - key: NODE_ENV
         value: production
@@ -64,6 +65,10 @@ services:
     dockerfilePath: ./apps/worker/Dockerfile
     dockerContext: .
     plan: starter
+    # Migrations run here (not on web): the worker image has pnpm + drizzle-kit +
+    # the committed migration files, so it can apply pending schema changes before
+    # either service goes live. Render runs preDeployCommand once per deploy.
+    preDeployCommand: pnpm --filter @dayotter/db migrate
     envVars:
       - key: NODE_ENV
         value: production


### PR DESCRIPTION
**⚠️ Do not merge until test-deployed** (per request). This wires up the strategy's one-click-deploy item, but the Render blueprint + platform steps need a real deploy to confirm.

## What's here
- **`render.yaml`** — a Render Blueprint provisioning **web + worker + Postgres + Redis**, with `pnpm --filter @dayotter/db migrate` as the pre-deploy step and `/api/me` as the health check. `AUTH_SECRET` is auto-generated.
- **`docs/DEPLOY.md`** — one place covering **Render** (one-click), **Railway**, **DigitalOcean App Platform**, **Coolify/CapRover**, and the existing **Docker Compose**, plus the three values you always set.
- **README** — a "Deploy to Render" button + DEPLOY.md link in the self-hosting section.

## Honest limitations (built into the docs, need your eyes on a real deploy)
- **`ENCRYPTION_KEY`** must be exactly 64 hex chars (`openssl rand -hex 32`) — Render's `generateValue` can't produce that, so it's a `sync: false` "set once" var on both services.
- **`NEXT_PUBLIC_APP_URL`** is baked at build time → set `APP_URL`/`NEXT_PUBLIC_APP_URL`/`BETTER_AUTH_URL` to the assigned `onrender.com` URL, then redeploy with cache cleared. Documented step-by-step.
- Render renamed Redis → "Key Value"; if your account only offers `type: keyvalue`, it's a one-line change (noted inline).
- **Railway / DigitalOcean** are documented off the Dockerfiles rather than shipped as unverified one-click buttons — a Railway template is published from their dashboard, not the repo.

## Test checklist before merge
- [ ] Click **Deploy to Render**, set `ENCRYPTION_KEY` + the URL vars, redeploy.
- [ ] Web boots, `/api/me` responds, worker starts, migrations ran.
- [ ] Sign up, create an event type, load the public booking page.
- [ ] Adjust `render.yaml` for anything that didn't line up (plan sizes, `keyvalue`, health path).