### PR TITLE
fix(ai): let Otter see synced Google/Outlook/Apple calendar events

### DIFF
--- a/apps/web/app/api/bookings/range/route.ts
+++ b/apps/web/app/api/bookings/range/route.ts
@@ -1,5 +1,6 @@
+import { syncedExternalEvents } from "@/lib/calendar/agenda";
 import { jsonError, withUser } from "@/lib/server/http";
-import { and, asc, eq, getDb, gte, inArray, lt, ne, schema } from "@dayotter/db";
+import { and, asc, eq, getDb, gte, lt, ne, schema } from "@dayotter/db";
 import { NextResponse } from "next/server";
 
 export const dynamic = "force-dynamic";
@@ -37,49 +38,12 @@ export const GET = withUser(async (u, request) => {
   });
 
   // Also surface the host's real (synced) calendar events, so the calendar shows
-  // their whole schedule - not just DayOtter bookings. Busy, non-all-day only.
-  const conns = await getDb().query.calendarConnections.findMany({
-    where: eq(schema.calendarConnections.userId, u.id),
-    with: { calendars: { columns: { id: true, checkForConflicts: true } } },
-  });
-  const calIds = conns
-    .flatMap((c) => c.calendars)
-    .filter((c) => c.checkForConflicts)
-    .map((c) => c.id);
-
-  let events: { title: string; startsAt: string; endsAt: string }[] = [];
-  if (calIds.length > 0) {
-    // A DayOtter booking we write to the host's calendar syncs back as an event.
-    // Exclude those mirrors by their external id so a booking doesn't appear
-    // twice (once as a booking, once as a synced event) in the calendar view.
-    const refs = await getDb().query.bookingReferences.findMany({
-      where: inArray(schema.bookingReferences.calendarId, calIds),
-      columns: { externalEventId: true },
-    });
-    const mirrorIds = new Set(refs.map((r) => r.externalEventId));
-
-    const evRows = await getDb().query.calendarEvents.findMany({
-      where: and(
-        inArray(schema.calendarEvents.calendarId, calIds),
-        gte(schema.calendarEvents.endsAt, start),
-        lt(schema.calendarEvents.startsAt, end),
-        ne(schema.calendarEvents.transparency, "transparent"),
-        eq(schema.calendarEvents.allDay, false),
-      ),
-      columns: { title: true, startsAt: true, endsAt: true, externalEventId: true },
-      // Deterministic order so the 500-row cap keeps the EARLIEST events, not an
-      // arbitrary slice, when a host has a very dense window.
-      orderBy: asc(schema.calendarEvents.startsAt),
-      limit: 500,
-    });
-    events = evRows
-      .filter((e) => !mirrorIds.has(e.externalEventId))
-      .map((e) => ({
-        title: e.title ?? "Busy",
-        startsAt: e.startsAt.toISOString(),
-        endsAt: e.endsAt.toISOString(),
-      }));
-  }
+  // their whole schedule - not just DayOtter bookings. Shared with the AI agenda.
+  const events = (await syncedExternalEvents(u.id, start, end)).map((e) => ({
+    title: e.title,
+    startsAt: e.startsAt.toISOString(),
+    endsAt: e.endsAt.toISOString(),
+  }));
 
   return NextResponse.json({
     bookings: rows.map((b) => ({

--- a/apps/web/lib/ai/chat.ts
+++ b/apps/web/lib/ai/chat.ts
@@ -56,7 +56,9 @@ Your scope is the host's calendar: answering questions about their schedule, and
 
 HOW YOU WORK:
 - You are CONVERSATIONAL. Reply in a warm, concise, natural voice - usually 1–3 sentences. No markdown headings or bullet dumps; this is a chat.
-- You are given the current time, the host's timezone, their event types, and their upcoming bookings (each with a numeric ref). Use them to answer questions directly ("When's my next meeting?", "How busy is Thursday?").
+- You are given the current time, the host's timezone, their event types, their upcoming DayOtter bookings (each with a numeric ref), AND their synced calendar events (busy time pulled from their connected Google / Outlook / Apple calendars). BOTH are real commitments on the host's calendar - always consider them TOGETHER when answering "When's my next meeting?", "How busy is Thursday?", "What's on my calendar tomorrow?", or "Am I free at 3pm?". A meeting the host sees in their calendar app is a synced event, not a DayOtter booking, so never say your calendar is empty just because there are no DayOtter bookings.
+- The context block shows the next ~2 weeks. If the host asks about a date further out, or you need the definitive merged agenda for a specific window, call get_agenda with an ISO date range to fetch bookings + synced events for that period.
+- Only DayOtter bookings (the numbered ones) can be rescheduled or cancelled. Synced calendar events are read-only - if the host wants to change one, tell them to edit it in the calendar app it came from.
 - You NEVER change anything yourself. When the host wants to create, move, or cancel something, call the propose_action tool with a draft. The host sees an editable card and confirms - only then does it happen. After you call propose_action, add one short sentence telling them to review and confirm.
 - When a time depends on when the host is actually free ("find me a free 30 min", "my next open afternoon"), call find_free_slots FIRST, then use a real returned slot in the draft. Never invent availability.
 - Resolve every time to an absolute ISO-8601 instant in the host's timezone. Never pick a past time. Interpret vague times locally (morning=09:00, afternoon=14:00, evening=18:00).
@@ -64,7 +66,7 @@ HOW YOU WORK:
 - If you're only answering a question (not proposing a change), reply in plain text and do not call propose_action.
 
 BEYOND BOOKINGS - you can also read and control the rest of the host's setup with these tools:
-- Reads (use freely to answer questions, and BEFORE changing something so you know the current values): list_booking_types, get_availability, get_preferences, list_focus_blocks, list_notification_channels, find_focus_time.
+- Reads (use freely to answer questions, and BEFORE changing something so you know the current values): get_agenda, list_booking_types, get_availability, get_preferences, list_focus_blocks, list_notification_channels, find_focus_time.
 - Actions (each shows the host a confirm card - nothing happens until they tap Confirm): create_booking_type, create_focus_block, protect_focus_time, update_preferences, set_weekly_hours, delete_booking_type, delete_focus_block.
 
 PROTECTING TIME (act like a great EA - do the work, don't just advise): when the host wants focus / deep-work / heads-down time, or time set aside for a task ("block 6 hours of focus this week", "I need 4 hours for the deck by Friday", "protect my mornings"), call find_focus_time FIRST (pass hoursNeeded, an optional byDate deadline, and chunkMinutes if they hint at block length). Briefly tell them the specific times you found, then propose protect_focus_time with those exact blocks. For a single quick hold you may still use create_focus_block. Never invent times - only protect blocks that find_focus_time returned.
@@ -102,13 +104,25 @@ async function buildContext(userId: string, latestUserText: string) {
         )
         .join("\n")
     : "(none)";
+  const externalList = ctx.externalEvents.length
+    ? ctx.externalEvents
+        .map((e) => {
+          const start = DateTime.fromJSDate(e.startsAt).setZone(tz);
+          const end = DateTime.fromJSDate(e.endsAt).setZone(tz);
+          return `- "${e.title}" - ${start.toFormat("ccc, LLL d 'at' h:mm a")}–${end.toFormat("h:mm a")}`;
+        })
+        .join("\n")
+    : "(none)";
   const block = `Current time: ${new Date().toISOString()} (timezone: ${tz})
 
 The host's event types:
 ${typeList}
 
-The host's upcoming bookings:
-${bookingList}`;
+The host's upcoming DayOtter bookings (each with a numeric ref you can reschedule/cancel):
+${bookingList}
+
+The host's synced calendar events (busy time from their connected Google / Outlook / Apple calendars, next 2 weeks - read-only, you can't reschedule or cancel these):
+${externalList}`;
   return { ctx, tz, contexts, block };
 }
 

--- a/apps/web/lib/ai/retrieval.ts
+++ b/apps/web/lib/ai/retrieval.ts
@@ -1,4 +1,5 @@
 import { and, asc, eq, getDb, gte, schema } from "@dayotter/db";
+import { syncedExternalEvents } from "../calendar/agenda";
 
 /**
  * Lightweight retrieval ("RAG-lite") for the scheduling assistant. Rather than
@@ -33,6 +34,11 @@ export interface CalendarContext {
   /** Relevance + recency selected, in chronological order. */
   bookings: RetrievedBooking[];
   eventTypes: RetrievedEventType[];
+  /** Busy events synced from the host's connected calendars (Google / Microsoft /
+   * Apple), next ~14 days. Read-only - the AI can see them to answer "how's my
+   * calendar looking" but can't act on them. Without these the assistant is blind
+   * to everything except DayOtter's own bookings. */
+  externalEvents: { title: string; startsAt: Date; endsAt: Date }[];
 }
 
 const STOPWORDS = new Set([
@@ -135,13 +141,15 @@ export async function retrieveCalendarContext(
   const limit = opts.limit ?? 12;
   const db = getDb();
 
-  const [user, upcoming, eventTypeRows] = await Promise.all([
+  const now = new Date();
+  const in14Days = new Date(now.getTime() + 14 * 86_400_000);
+  const [user, upcoming, eventTypeRows, externalEvents] = await Promise.all([
     db.query.users.findFirst({ where: eq(schema.users.id, userId), columns: { timezone: true } }),
     db.query.bookings.findMany({
       where: and(
         eq(schema.bookings.hostId, userId),
         eq(schema.bookings.status, "confirmed"),
-        gte(schema.bookings.startsAt, new Date()),
+        gte(schema.bookings.startsAt, now),
       ),
       orderBy: asc(schema.bookings.startsAt),
       limit: 60,
@@ -152,6 +160,10 @@ export async function retrieveCalendarContext(
       columns: { title: true, slug: true, durationMinutes: true },
       limit: 30,
     }),
+    // The host's real synced calendar (Google/Microsoft/Apple) for the next 2 weeks
+    // - so "how's my calendar looking?" reflects their whole schedule, not just
+    // DayOtter bookings.
+    syncedExternalEvents(userId, now, in14Days, 40),
   ]);
 
   const all: RetrievedBooking[] = upcoming.map((b) => ({
@@ -175,5 +187,5 @@ export async function retrieveCalendarContext(
     .slice(0, 8)
     .map(({ e }) => e);
 
-  return { timezone: user?.timezone ?? "UTC", bookings, eventTypes };
+  return { timezone: user?.timezone ?? "UTC", bookings, eventTypes, externalEvents };
 }

--- a/apps/web/lib/ai/tools/exec.ts
+++ b/apps/web/lib/ai/tools/exec.ts
@@ -4,6 +4,7 @@ import { findFocusBlocks } from "@/lib/booking/focus-suggestions";
 import { notPersonalType } from "@/lib/booking/personal-event-type";
 import { resolveScheduleId } from "@/lib/booking/schedule";
 import { ensureUserWorkspace } from "@/lib/bootstrap";
+import { getAgenda } from "@/lib/calendar/agenda";
 import {
   channelInputSchema,
   configFromInput,
@@ -38,6 +39,32 @@ export async function executeReadTool(
 ): Promise<string> {
   const db = getDb();
   switch (name) {
+    case "get_agenda": {
+      const now = new Date();
+      const fromRaw = input?.fromISO ? new Date(input.fromISO as string) : now;
+      const from = Number.isNaN(fromRaw.getTime()) ? now : fromRaw;
+      const toRaw = input?.toISO ? new Date(input.toISO as string) : null;
+      const to =
+        toRaw && !Number.isNaN(toRaw.getTime()) && toRaw > from
+          ? toRaw
+          : new Date(from.getTime() + 7 * 86_400_000);
+      const items = await getAgenda(userId, from, to, 100);
+      return JSON.stringify({
+        from: from.toISOString(),
+        to: to.toISOString(),
+        count: items.length,
+        items: items.map((i) => ({
+          title: i.title,
+          startsAt: i.startsAt.toISOString(),
+          endsAt: i.endsAt.toISOString(),
+          source: i.source,
+          ...(i.attendees.length ? { attendees: i.attendees } : {}),
+        })),
+        note: items.length
+          ? "'booking' = a DayOtter booking (can be rescheduled/cancelled); 'external' = a synced calendar event (read-only)."
+          : "Nothing scheduled in that window - the host is free.",
+      });
+    }
     case "list_booking_types": {
       const rows = await db.query.eventTypes.findMany({
         where: and(eq(schema.eventTypes.ownerId, userId), notPersonalType),

--- a/apps/web/lib/ai/tools/registry.ts
+++ b/apps/web/lib/ai/tools/registry.ts
@@ -44,6 +44,27 @@ const COLORS = ["violet", "mint", "amber", "coral", "sky"] as const;
 export const TOOLS: AiToolDef[] = [
   // ---- Reads (run immediately) ----
   {
+    name: "get_agenda",
+    description:
+      "Get the host's real agenda for a date range: their DayOtter bookings AND the busy events synced from their connected Google / Outlook / Apple calendars, merged in time order. This is the source of truth for 'what's on my calendar', 'how busy is Tuesday', 'when's my next meeting', or 'am I free on the 14th'. The per-turn context already lists the next ~2 weeks; call this to look further ahead or to double-check a specific window. Times are ISO-8601; omit them to default to the next 7 days.",
+    kind: "read",
+    confirmLevel: "none",
+    schema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        fromISO: { type: "string", description: "ISO-8601 start of the window (default: now)." },
+        toISO: {
+          type: "string",
+          description: "ISO-8601 end of the window (default: 7 days from the start).",
+        },
+      },
+    },
+    zod: z.object({ fromISO: z.string().optional(), toISO: z.string().optional() }),
+    title: "Agenda",
+    summarize: () => "Read agenda",
+  },
+  {
     name: "list_booking_types",
     description:
       "List the host's booking types (event types): title, slug, duration, active state, and public URL.",

--- a/apps/web/lib/calendar/agenda.test.ts
+++ b/apps/web/lib/calendar/agenda.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { mergeAgenda } from "./agenda";
+
+const d = (iso: string) => new Date(iso);
+
+describe("mergeAgenda", () => {
+  it("interleaves bookings and external events in chronological order", () => {
+    const items = mergeAgenda(
+      [
+        {
+          title: "Intro call",
+          startsAt: d("2026-07-30T15:00:00Z"),
+          endsAt: d("2026-07-30T15:30:00Z"),
+          uid: "b1",
+          attendees: ["Dana"],
+        },
+        {
+          title: "Standup",
+          startsAt: d("2026-07-30T09:00:00Z"),
+          endsAt: d("2026-07-30T09:15:00Z"),
+          uid: "b2",
+          attendees: [],
+        },
+      ],
+      [
+        {
+          title: "Dentist",
+          startsAt: d("2026-07-30T11:00:00Z"),
+          endsAt: d("2026-07-30T12:00:00Z"),
+        },
+      ],
+      50,
+    );
+
+    expect(items.map((i) => i.title)).toEqual(["Standup", "Dentist", "Intro call"]);
+  });
+
+  it("tags each item with its source and preserves the booking uid", () => {
+    const items = mergeAgenda(
+      [
+        {
+          title: "Intro call",
+          startsAt: d("2026-07-30T15:00:00Z"),
+          endsAt: d("2026-07-30T15:30:00Z"),
+          uid: "b1",
+          attendees: ["Dana"],
+        },
+      ],
+      [{ title: "Busy", startsAt: d("2026-07-30T16:00:00Z"), endsAt: d("2026-07-30T17:00:00Z") }],
+      50,
+    );
+
+    const booking = items.find((i) => i.title === "Intro call")!;
+    const external = items.find((i) => i.title === "Busy")!;
+    expect(booking.source).toBe("booking");
+    expect(booking.uid).toBe("b1");
+    expect(booking.attendees).toEqual(["Dana"]);
+    expect(external.source).toBe("external");
+    expect(external.uid).toBeUndefined();
+    expect(external.attendees).toEqual([]);
+  });
+
+  it("caps the merged list at the limit, keeping the earliest items", () => {
+    const bookings = Array.from({ length: 5 }, (_, i) => ({
+      title: `B${i}`,
+      startsAt: d(`2026-07-30T${String(10 + i).padStart(2, "0")}:00:00Z`),
+      endsAt: d(`2026-07-30T${String(10 + i).padStart(2, "0")}:30:00Z`),
+      uid: `b${i}`,
+      attendees: [],
+    }));
+    const items = mergeAgenda(bookings, [], 3);
+    expect(items).toHaveLength(3);
+    expect(items.map((i) => i.title)).toEqual(["B0", "B1", "B2"]);
+  });
+});

--- a/apps/web/lib/calendar/agenda.ts
+++ b/apps/web/lib/calendar/agenda.ts
@@ -1,0 +1,134 @@
+import { and, asc, eq, getDb, gte, inArray, lt, ne, schema } from "@dayotter/db";
+
+/**
+ * One item on the host's real agenda - either a DayOtter booking or a busy event
+ * synced from a connected (Google / Microsoft / Apple) calendar. This is what the
+ * calendar views AND the AI assistant should both see: a booking page that only
+ * knows its own bookings is blind to the meetings on the host's actual calendar.
+ */
+export interface AgendaItem {
+  title: string;
+  startsAt: Date;
+  endsAt: Date;
+  /** "booking" = a DayOtter booking (actionable); "external" = a synced calendar event (read-only). */
+  source: "booking" | "external";
+  attendees: string[];
+  /** Public booking id (only for `source: "booking"`), so it can be acted on. */
+  uid?: string;
+}
+
+/**
+ * Busy, non-all-day events synced from the host's conflict-checked calendars in
+ * [from, to). Mirrors of DayOtter bookings we wrote to the calendar are excluded
+ * (by external id) so a booking never shows up twice. Shared by the calendar
+ * range API and the AI agenda so the two can never drift.
+ */
+export async function syncedExternalEvents(
+  userId: string,
+  from: Date,
+  to: Date,
+  limit = 500,
+): Promise<{ title: string; startsAt: Date; endsAt: Date }[]> {
+  const db = getDb();
+  const conns = await db.query.calendarConnections.findMany({
+    where: eq(schema.calendarConnections.userId, userId),
+    with: { calendars: { columns: { id: true, checkForConflicts: true } } },
+  });
+  const calIds = conns
+    .flatMap((c) => c.calendars)
+    .filter((c) => c.checkForConflicts)
+    .map((c) => c.id);
+  if (calIds.length === 0) return [];
+
+  const refs = await db.query.bookingReferences.findMany({
+    where: inArray(schema.bookingReferences.calendarId, calIds),
+    columns: { externalEventId: true },
+  });
+  const mirrorIds = new Set(refs.map((r) => r.externalEventId));
+
+  const rows = await db.query.calendarEvents.findMany({
+    where: and(
+      inArray(schema.calendarEvents.calendarId, calIds),
+      gte(schema.calendarEvents.endsAt, from),
+      lt(schema.calendarEvents.startsAt, to),
+      ne(schema.calendarEvents.transparency, "transparent"),
+      eq(schema.calendarEvents.allDay, false),
+    ),
+    columns: { title: true, startsAt: true, endsAt: true, externalEventId: true },
+    orderBy: asc(schema.calendarEvents.startsAt),
+    limit,
+  });
+  return rows
+    .filter((e) => !mirrorIds.has(e.externalEventId))
+    .map((e) => ({ title: e.title ?? "Busy", startsAt: e.startsAt, endsAt: e.endsAt }));
+}
+
+/**
+ * Merge DayOtter bookings and synced external events into one chronological,
+ * source-tagged agenda, capped at `limit`. Pure (no I/O) so it can be unit-tested.
+ */
+export function mergeAgenda(
+  bookings: { title: string; startsAt: Date; endsAt: Date; uid: string; attendees: string[] }[],
+  external: { title: string; startsAt: Date; endsAt: Date }[],
+  limit: number,
+): AgendaItem[] {
+  const items: AgendaItem[] = [
+    ...bookings.map((b) => ({
+      title: b.title,
+      startsAt: b.startsAt,
+      endsAt: b.endsAt,
+      source: "booking" as const,
+      attendees: b.attendees,
+      uid: b.uid,
+    })),
+    ...external.map((e) => ({
+      title: e.title,
+      startsAt: e.startsAt,
+      endsAt: e.endsAt,
+      source: "external" as const,
+      attendees: [],
+    })),
+  ];
+  items.sort((a, b) => a.startsAt.getTime() - b.startsAt.getTime());
+  return items.slice(0, limit);
+}
+
+/**
+ * The host's real agenda over [from, to): DayOtter bookings + synced external
+ * calendar events, merged chronologically and capped. This is the source of
+ * truth for "what's on my calendar / how busy am I / when's my next meeting".
+ */
+export async function getAgenda(
+  userId: string,
+  from: Date,
+  to: Date,
+  limit = 50,
+): Promise<AgendaItem[]> {
+  const db = getDb();
+  const [bookings, external] = await Promise.all([
+    db.query.bookings.findMany({
+      where: and(
+        eq(schema.bookings.hostId, userId),
+        ne(schema.bookings.status, "cancelled"),
+        gte(schema.bookings.startsAt, from),
+        lt(schema.bookings.startsAt, to),
+      ),
+      orderBy: asc(schema.bookings.startsAt),
+      limit,
+      with: { attendees: { columns: { name: true, email: true } } },
+    }),
+    syncedExternalEvents(userId, from, to, limit),
+  ]);
+
+  return mergeAgenda(
+    bookings.map((b) => ({
+      title: b.title,
+      startsAt: b.startsAt,
+      endsAt: b.endsAt,
+      uid: b.uid,
+      attendees: b.attendees.map((a) => a.name ?? a.email),
+    })),
+    external,
+    limit,
+  );
+}


### PR DESCRIPTION
## The bug

Customers connected Google/Outlook/Apple calendars, then asked Otter simple questions like *"how's my calendar looking?"* or *"when's my next meeting?"* — and got wrong answers. The meetings were **visible in the Calendar tab but invisible to the AI.**

**Root cause:** nothing under `lib/ai/` ever read synced calendar events. Otter's context and tools only saw DayOtter's own `bookings`, so any meeting that lived on the host's connected calendar (the vast majority for most people) simply didn't exist as far as the assistant was concerned. The Calendar tab, meanwhile, merged bookings + synced `calendarEvents` in its range API — so the two surfaces disagreed.

## The fix — one shared agenda source

New `lib/calendar/agenda.ts` is now the single source of truth for "what's actually on the host's calendar", used by **both** the calendar views and the AI:

- **`syncedExternalEvents()`** — extracted from the `/api/bookings/range` route (conflict-checked calendars → busy, non-all-day events in range, minus mirrors of DayOtter-written events so nothing double-counts).
- **`getAgenda()`** — merges non-cancelled bookings + synced events chronologically, capped. Pure `mergeAgenda()` helper is unit-tested.

Wired into the AI:

- **`retrieval.ts`** — `CalendarContext` now carries the next ~2 weeks of synced events.
- **`chat.ts`** — renders synced events in Otter's per-turn context and updates the system prompt: bookings **and** synced events are both real commitments; only bookings can be rescheduled/cancelled, synced events are read-only.
- **`get_agenda` read tool** (`registry.ts` + `exec.ts`) — lets Otter fetch the merged agenda for any window on demand (further out than the 2-week context, or to double-check a specific day).
- **`/api/bookings/range`** refactored onto the shared `syncedExternalEvents()` so the calendar tab and the AI can never drift again.

## Testing

- `apps/web` typecheck ✅
- `apps/web` tests ✅ (145 — added 3 for `mergeAgenda`: chronological interleave, source/uid tagging, limit cap)
- biome ✅

Read-only change to the AI's view; no new write capability (synced events are surfaced, never mutated).
