### PR TITLE
feat(ai): expand Otter's tools + add prompt & knowledge catalogues

### DIFF
--- a/apps/web/components/ai-assistant.tsx
+++ b/apps/web/components/ai-assistant.tsx
@@ -3,6 +3,7 @@
 import { Button } from "@/components/ui/button";
 import { FormError } from "@/components/ui/form";
 import { Input, Label } from "@/components/ui/input";
+import { PROMPT_CATEGORIES, promptsByCategory } from "@/lib/ai/catalogue";
 import type { ChatAction, ChatToolAction } from "@/lib/ai/chat";
 import { track } from "@/lib/analytics";
 import type { Locale } from "@/lib/i18n";
@@ -374,18 +375,43 @@ export function AiAssistant({
         {messages.length === 0 ? (
           <div>
             <p className="text-sm text-[var(--color-muted)]">{tOtter(locale, "emptyGreeting")}</p>
-            <div className="mt-3 flex flex-wrap gap-2">
-              {suggestions(locale).map((s) => (
-                <button
-                  key={s}
-                  type="button"
-                  onClick={() => void send(s)}
-                  className="rounded-full border border-[var(--color-border-strong)] px-3 py-1.5 text-xs text-[var(--color-muted)] transition-colors hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]"
-                >
-                  {s}
-                </button>
-              ))}
-            </div>
+            {locale === "en" ? (
+              <div className="mt-3 space-y-3">
+                {PROMPT_CATEGORIES.map((cat) => (
+                  <div key={cat.key}>
+                    <p className="mb-1.5 text-[11px] font-medium uppercase tracking-wide text-[var(--color-faint)]">
+                      {cat.title}
+                    </p>
+                    <div className="flex flex-wrap gap-2">
+                      {promptsByCategory(cat.key).map((p) => (
+                        <button
+                          key={p.id}
+                          type="button"
+                          title={p.prompt}
+                          onClick={() => void send(p.prompt)}
+                          className="rounded-full border border-[var(--color-border-strong)] px-3 py-1.5 text-xs text-[var(--color-muted)] transition-colors hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]"
+                        >
+                          {p.label}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="mt-3 flex flex-wrap gap-2">
+                {suggestions(locale).map((s) => (
+                  <button
+                    key={s}
+                    type="button"
+                    onClick={() => void send(s)}
+                    className="rounded-full border border-[var(--color-border-strong)] px-3 py-1.5 text-xs text-[var(--color-muted)] transition-colors hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]"
+                  >
+                    {s}
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
         ) : (
           <div className="space-y-3">

--- a/apps/web/lib/ai/catalogue/catalogue.test.ts
+++ b/apps/web/lib/ai/catalogue/catalogue.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { searchKnowledge } from "./knowledge";
+import {
+  PROMPT_CATALOGUE,
+  PROMPT_CATEGORIES,
+  capabilitySummary,
+  promptsByCategory,
+} from "./prompts";
+
+describe("prompt catalogue", () => {
+  it("gives every prompt a unique id and a known category", () => {
+    const ids = new Set<string>();
+    const cats = new Set(PROMPT_CATEGORIES.map((c) => c.key));
+    for (const p of PROMPT_CATALOGUE) {
+      expect(ids.has(p.id), `duplicate id ${p.id}`).toBe(false);
+      ids.add(p.id);
+      expect(cats.has(p.category), `unknown category ${p.category}`).toBe(true);
+      expect(p.label.length).toBeGreaterThan(0);
+      expect(p.prompt.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("has at least one prompt in every category", () => {
+    for (const c of PROMPT_CATEGORIES) {
+      expect(promptsByCategory(c.key).length, `category ${c.key} is empty`).toBeGreaterThan(0);
+    }
+  });
+
+  it("summarizes capabilities with real example prompts for the model", () => {
+    const summary = capabilitySummary();
+    for (const c of PROMPT_CATEGORIES) expect(summary).toContain(c.title);
+    // Example phrasings are quoted verbatim from the catalogue.
+    expect(summary).toContain(`"${PROMPT_CATALOGUE[0]!.prompt}"`);
+  });
+});
+
+describe("searchKnowledge", () => {
+  it("finds the out-of-office article for a time-off question", () => {
+    const [top] = searchKnowledge("how do I set myself out of office while on vacation?");
+    expect(top?.id).toBe("availability");
+  });
+
+  it("finds the no-shows article for an attendance question", () => {
+    const [top] = searchKnowledge("what's the best way to cut down on no-shows?");
+    expect(top?.id).toBe("no-shows");
+  });
+
+  it("ranks calendar-sync questions to the calendars article", () => {
+    const [top] = searchKnowledge("connect my google and outlook calendars for conflict checking");
+    expect(top?.id).toBe("calendars");
+  });
+
+  it("returns nothing for an empty / stopword-only query", () => {
+    expect(searchKnowledge("how do I")).toEqual([]);
+    expect(searchKnowledge("")).toEqual([]);
+  });
+
+  it("caps results at the requested limit", () => {
+    expect(
+      searchKnowledge("meeting booking availability calendar team focus", 2).length,
+    ).toBeLessThanOrEqual(2);
+  });
+});

--- a/apps/web/lib/ai/catalogue/index.ts
+++ b/apps/web/lib/ai/catalogue/index.ts
@@ -1,0 +1,15 @@
+export {
+  type CatalogueCategory,
+  type CataloguePrompt,
+  type PromptCategory,
+  PROMPT_CATALOGUE,
+  PROMPT_CATEGORIES,
+  capabilitySummary,
+  promptsByCategory,
+} from "./prompts";
+export {
+  type KnowledgeArticle,
+  type KnowledgeMatch,
+  KNOWLEDGE_ARTICLES,
+  searchKnowledge,
+} from "./knowledge";

--- a/apps/web/lib/ai/catalogue/knowledge.ts
+++ b/apps/web/lib/ai/catalogue/knowledge.ts
@@ -1,0 +1,219 @@
+/**
+ * The Otter knowledge catalogue - a small, curated set of reference documents
+ * the assistant can retrieve to ground how-to and best-practice answers.
+ *
+ * This is DayOtter-specific product knowledge written for grounding, not
+ * marketing: how a capability actually works and how to get the best out of it.
+ * Otter reaches it through the `search_knowledge` tool - when a host asks "how
+ * do I..." or "what's the best way to...", the model pulls the matching
+ * article(s) into context and answers from them instead of guessing.
+ *
+ * Retrieval is keyword + title overlap (a handful of short docs needs nothing
+ * heavier than that). Keep each article concise, accurate to what the product
+ * actually does, and free of anything that would go stale quickly.
+ */
+
+export interface KnowledgeArticle {
+  id: string;
+  title: string;
+  /** Extra match terms beyond the title/body words (synonyms, feature names). */
+  keywords: string[];
+  /** The grounded reference text handed to the model. */
+  body: string;
+}
+
+export const KNOWLEDGE_ARTICLES: KnowledgeArticle[] = [
+  {
+    id: "focus-time",
+    title: "Protecting focus and deep-work time",
+    keywords: [
+      "focus",
+      "deep work",
+      "heads down",
+      "block time",
+      "protect",
+      "concentration",
+      "busy",
+    ],
+    body: `DayOtter can hold focus time so nobody books over it. Ask for what you need ("block 4 hours before Friday", "protect my mornings") and Otter finds concrete open blocks that are already clear of meetings and synced-calendar busy time, then holds them as focus blocks. Held focus blocks count as busy in your availability, so booking pages stop offering those slots. For recurring protection, set a weekly automation rule. Best practice: protect focus in the morning before meetings pile up, and keep blocks to 60-120 minutes so they're easy to place.`,
+  },
+  {
+    id: "no-shows",
+    title: "Reducing no-shows and late cancellations",
+    keywords: ["no-show", "no show", "cancellation", "reminder", "confirm", "attendance", "flake"],
+    body: `The biggest levers on no-shows are reminders and confirmations. Add reminder channels (email is on by default; Slack, SMS and WhatsApp can be added) so invitees get nudged before the meeting. Require confirmation on high-value booking types so a slot is only held once the guest confirms. Add a short buffer before meetings so back-to-back overruns don't cascade. For paid meetings, a deposit sharply cuts no-shows. You can also set up a workflow that emails guests a day before with the details and a reschedule link.`,
+  },
+  {
+    id: "availability",
+    title: "Working hours, days off, and out-of-office",
+    keywords: [
+      "availability",
+      "working hours",
+      "hours",
+      "day off",
+      "vacation",
+      "out of office",
+      "ooo",
+      "away",
+      "date override",
+      "time off",
+      "holiday",
+    ],
+    body: `Your default availability is a weekly grid of working hours in your timezone. Change it with a request like "set my hours to 9-5, Monday to Friday". For one-off changes (a single day off, or extra hours on a specific date) use a date override rather than editing the weekly grid. For a stretch of days away, set an out-of-office period with a start and end date; while you're away DayOtter shows an "away" banner on your booking page and, if you name a delegate you share a team with, redirects new bookings to them. Out-of-office and date overrides both block bookable time automatically.`,
+  },
+  {
+    id: "booking-types",
+    title: "Designing booking types",
+    keywords: [
+      "booking type",
+      "event type",
+      "meeting type",
+      "duration",
+      "buffer",
+      "limit",
+      "group",
+      "capacity",
+      "access code",
+      "price",
+    ],
+    body: `A booking type is a shareable meeting template: title, URL slug, duration, and location (Google Meet, Teams, Zoom, phone, in person, or custom). Tune it with buffers before/after, a minimum notice window, a booking window (how far ahead people can book), and daily or weekly limits to cap how many land per period. Group types allow multiple attendees up to a capacity. Add an access code to keep a type semi-private, or mark it private so it's link-only. Keep durations short by default - a 25 or 50 minute option leaves natural buffers.`,
+  },
+  {
+    id: "automations-workflows",
+    title: "Automations vs workflows",
+    keywords: [
+      "automation",
+      "workflow",
+      "rule",
+      "prep",
+      "buffer",
+      "follow-up",
+      "followup",
+      "email",
+      "trigger",
+      "reminder",
+    ],
+    body: "Two different tools. Automations act on YOUR calendar: when a booking is created they can auto-add a prep block before it, a buffer after it, or a follow-up block; weekly automations can protect a recurring window. Workflows act on your GUESTS: they send templated emails a set time before or after the meeting (reminders, prep instructions, thank-you and next-steps notes), scoped to all or specific booking types. Rule of thumb: reach for an automation to protect your own time, a workflow to communicate with attendees.",
+  },
+  {
+    id: "calendars",
+    title: "Connecting calendars and conflict checking",
+    keywords: [
+      "calendar",
+      "google",
+      "outlook",
+      "microsoft",
+      "apple",
+      "icloud",
+      "caldav",
+      "sync",
+      "conflict",
+      "connect",
+      "two-way",
+    ],
+    body: "Connect Google, Microsoft/Outlook, or Apple (CalDAV) calendars so DayOtter sees your real commitments. Each connected calendar can be toggled for conflict checking - busy events on those calendars block bookable slots, so you never get double-booked across tools. Confirmed DayOtter bookings are written back to your primary calendar (two-way), and mirrored events are de-duplicated so a booking never shows up twice. Connecting more than one calendar is the core advantage: DayOtter treats all of them as one combined schedule.",
+  },
+  {
+    id: "teams",
+    title: "Team scheduling and round-robin",
+    keywords: [
+      "team",
+      "round robin",
+      "round-robin",
+      "collective",
+      "delegate",
+      "member",
+      "assign",
+      "distribute",
+    ],
+    body: `Create a team and add members (they need a DayOtter account). Team booking types can distribute meetings round-robin across members based on availability and priority, so load spreads evenly. Collective types require several members to be free at once. Delegates matter for time off: when you set an out-of-office period you can redirect new bookings to a teammate you share a team with, so coverage continues while you're away.`,
+  },
+];
+
+const STOPWORDS = new Set([
+  "the",
+  "and",
+  "for",
+  "with",
+  "you",
+  "your",
+  "how",
+  "what",
+  "can",
+  "does",
+  "the",
+  "best",
+  "way",
+  "set",
+  "get",
+  "use",
+  "make",
+  "add",
+  "put",
+  "have",
+  "want",
+  "need",
+  "this",
+  "that",
+  "from",
+  "into",
+  "about",
+  "when",
+  "should",
+  "would",
+  "could",
+  "will",
+  "are",
+  "was",
+  "our",
+  "all",
+  "any",
+  "not",
+  "but",
+  "off",
+  "out",
+]);
+
+/** Content terms of a query: lowercased words length ≥ 3 minus stopwords. */
+function terms(text: string): string[] {
+  return [
+    ...new Set(
+      text
+        .toLowerCase()
+        .split(/[^a-z0-9]+/)
+        .filter((w) => w.length >= 3 && !STOPWORDS.has(w)),
+    ),
+  ];
+}
+
+export interface KnowledgeMatch {
+  id: string;
+  title: string;
+  body: string;
+  score: number;
+}
+
+/**
+ * Rank the knowledge base against a query by keyword + title overlap. Title and
+ * explicit keyword hits weigh more than body hits. Returns the top `limit`
+ * scoring articles (score > 0), best first. Pure - unit-tested.
+ */
+export function searchKnowledge(query: string, limit = 2): KnowledgeMatch[] {
+  const q = terms(query);
+  if (q.length === 0) return [];
+  return KNOWLEDGE_ARTICLES.map((a) => {
+    const title = a.title.toLowerCase();
+    const keywordHay = a.keywords.join(" ").toLowerCase();
+    const body = a.body.toLowerCase();
+    let score = 0;
+    for (const t of q) {
+      if (title.includes(t)) score += 3;
+      if (keywordHay.includes(t)) score += 2;
+      else if (body.includes(t)) score += 1;
+    }
+    return { id: a.id, title: a.title, body: a.body, score };
+  })
+    .filter((m) => m.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit);
+}

--- a/apps/web/lib/ai/catalogue/prompts.ts
+++ b/apps/web/lib/ai/catalogue/prompts.ts
@@ -1,0 +1,203 @@
+/**
+ * The Otter prompt catalogue - a curated, categorized library of things the
+ * assistant is genuinely good at, phrased the way a host would actually ask.
+ *
+ * It serves two audiences at once:
+ *  1. The HOST - rendered as suggestion chips in the assistant UI, so people
+ *     discover what Otter can do instead of staring at a blank box.
+ *  2. The MODEL - `capabilitySummary()` distills the catalogue into a compact
+ *     block injected into Otter's system prompt, so it knows its own surface and
+ *     maps fuzzy requests onto the right tool.
+ *
+ * Keep every prompt to something Otter can actually do with a tool it has. If a
+ * capability lands, add a prompt here - this is the single source of truth for
+ * "what can I ask Otter?".
+ */
+
+export type PromptCategory = "plan" | "focus" | "meetings" | "availability" | "setup" | "insights";
+
+export interface CataloguePrompt {
+  /** Stable id (analytics + React keys). */
+  id: string;
+  category: PromptCategory;
+  /** Short label for a suggestion chip. */
+  label: string;
+  /** The full text sent to Otter when the host taps the chip. */
+  prompt: string;
+}
+
+export interface CatalogueCategory {
+  key: PromptCategory;
+  /** Human title for the group header. */
+  title: string;
+  /** One-line description of what this cluster of prompts is for. */
+  blurb: string;
+}
+
+export const PROMPT_CATEGORIES: CatalogueCategory[] = [
+  { key: "plan", title: "Plan your day", blurb: "See what's ahead across all your calendars." },
+  { key: "focus", title: "Protect focus time", blurb: "Carve out and hold deep-work blocks." },
+  { key: "meetings", title: "Manage meetings", blurb: "Book, move, cancel, and find open time." },
+  {
+    key: "availability",
+    title: "Availability & time off",
+    blurb: "Working hours, days off, and out-of-office.",
+  },
+  { key: "setup", title: "Set up & automate", blurb: "Booking types, reminders, and workflows." },
+  { key: "insights", title: "Insights", blurb: "How your time and bookings are trending." },
+];
+
+export const PROMPT_CATALOGUE: CataloguePrompt[] = [
+  // ---- Plan your day ----
+  {
+    id: "plan-today",
+    category: "plan",
+    label: "What's on today?",
+    prompt: "What's on my calendar today?",
+  },
+  {
+    id: "plan-week",
+    category: "plan",
+    label: "How busy is this week?",
+    prompt: "How busy is my week? Give me a day-by-day rundown.",
+  },
+  {
+    id: "plan-next",
+    category: "plan",
+    label: "When's my next meeting?",
+    prompt: "When's my next meeting, and who's it with?",
+  },
+  {
+    id: "plan-day",
+    category: "plan",
+    label: "What does Thursday look like?",
+    prompt: "What does Thursday look like?",
+  },
+
+  // ---- Protect focus time ----
+  {
+    id: "focus-hours",
+    category: "focus",
+    label: "Block 4h of focus",
+    prompt: "Block 4 hours of focus time for me before Friday.",
+  },
+  {
+    id: "focus-mornings",
+    category: "focus",
+    label: "Protect my mornings",
+    prompt: "Protect my mornings this week for deep work.",
+  },
+  {
+    id: "focus-deck",
+    category: "focus",
+    label: "Find time for the deck",
+    prompt: "I need 3 hours for the deck by Thursday - find and hold the time.",
+  },
+
+  // ---- Manage meetings ----
+  {
+    id: "meet-free30",
+    category: "meetings",
+    label: "Find a free 30 min",
+    prompt: "Find me a free 30 minutes this afternoon.",
+  },
+  {
+    id: "meet-move",
+    category: "meetings",
+    label: "Move my 3pm",
+    prompt: "Move my 3pm to tomorrow morning.",
+  },
+  {
+    id: "meet-cancel",
+    category: "meetings",
+    label: "Cancel a meeting",
+    prompt: "Cancel my last meeting on Friday.",
+  },
+  {
+    id: "meet-find",
+    category: "meetings",
+    label: "Find the call with…",
+    prompt: "Find my upcoming call with Dana.",
+  },
+
+  // ---- Availability & time off ----
+  {
+    id: "avail-free",
+    category: "availability",
+    label: "Am I free Friday 2pm?",
+    prompt: "Am I free on Friday at 2pm?",
+  },
+  {
+    id: "avail-ooo",
+    category: "availability",
+    label: "Set me out of office",
+    prompt: "Set me out of office next Monday through Wednesday.",
+  },
+  {
+    id: "avail-hours",
+    category: "availability",
+    label: "Change my working hours",
+    prompt: "Change my working hours to 9am–5pm, Monday to Friday.",
+  },
+
+  // ---- Set up & automate ----
+  {
+    id: "setup-type",
+    category: "setup",
+    label: "Create a booking type",
+    prompt: "Create a 30-minute intro call booking type.",
+  },
+  {
+    id: "setup-followup",
+    category: "setup",
+    label: "Add a follow-up email",
+    prompt: "Send a follow-up email one day after every meeting.",
+  },
+  {
+    id: "setup-slack",
+    category: "setup",
+    label: "Remind me on Slack",
+    prompt: "Remind me on Slack before my meetings.",
+  },
+  {
+    id: "setup-buffer",
+    category: "setup",
+    label: "Add buffers after calls",
+    prompt: "Give me a 15-minute buffer after every booking.",
+  },
+
+  // ---- Insights ----
+  {
+    id: "insights-count",
+    category: "insights",
+    label: "Meetings last week?",
+    prompt: "How many meetings did I have last week?",
+  },
+  {
+    id: "insights-conversion",
+    category: "insights",
+    label: "Booking conversion",
+    prompt: "What's my booking-page conversion this month?",
+  },
+];
+
+/** Prompts in a given category, in catalogue order. */
+export function promptsByCategory(category: PromptCategory): CataloguePrompt[] {
+  return PROMPT_CATALOGUE.filter((p) => p.category === category);
+}
+
+/**
+ * A compact capability summary for Otter's system prompt: one line per category
+ * with a few real example phrasings. Teaches the model the shape of what it can
+ * do so it maps vague asks onto the right tool instead of declining.
+ */
+export function capabilitySummary(): string {
+  const lines = PROMPT_CATEGORIES.map((cat) => {
+    const examples = promptsByCategory(cat.key)
+      .slice(0, 3)
+      .map((p) => `"${p.prompt}"`)
+      .join(", ");
+    return `- ${cat.title} - ${cat.blurb} e.g. ${examples}`;
+  });
+  return `Things hosts commonly ask you for (map fuzzy requests onto these):\n${lines.join("\n")}`;
+}

--- a/apps/web/lib/ai/chat.ts
+++ b/apps/web/lib/ai/chat.ts
@@ -2,6 +2,7 @@ import { logger } from "@dayotter/core";
 import { getPluginTool, pluginTools, runPluginTool } from "@dayotter/plugin-host";
 import { DateTime } from "luxon";
 import { FREE_SLOTS_TOOL, findFreeSlots } from "./agent";
+import { capabilitySummary } from "./catalogue";
 import {
   type BookingContext,
   type CommandDraft,
@@ -66,8 +67,11 @@ HOW YOU WORK:
 - If you're only answering a question (not proposing a change), reply in plain text and do not call propose_action.
 
 BEYOND BOOKINGS - you can also read and control the rest of the host's setup with these tools:
-- Reads (use freely to answer questions, and BEFORE changing something so you know the current values): get_agenda, list_booking_types, get_availability, get_preferences, list_focus_blocks, list_notification_channels, find_focus_time.
-- Actions (each shows the host a confirm card - nothing happens until they tap Confirm): create_booking_type, create_focus_block, protect_focus_time, update_preferences, set_weekly_hours, delete_booking_type, delete_focus_block.
+- Reads (use freely to answer questions, and BEFORE changing something so you know the current values): get_agenda, search_bookings, check_availability, list_booking_types, get_booking_type, get_availability, list_out_of_office, get_preferences, list_focus_blocks, list_notification_channels, find_focus_time, get_analytics.
+- Actions (each shows the host a confirm card - nothing happens until they tap Confirm): create_booking_type, create_focus_block, protect_focus_time, update_preferences, set_weekly_hours, set_out_of_office, delete_booking_type, delete_focus_block, and more (booking types, channels, teams, automations, workflows).
+- Prefer a tool over guessing. To find a specific past or upcoming meeting, use search_bookings (the per-turn context only lists a few). To answer "am I free at X", use check_availability.
+
+KNOWLEDGE: for "how do I...", "what's the best way to...", or "can DayOtter..." questions, call search_knowledge FIRST and answer from the returned article(s) in your own words - don't guess at product behaviour.
 
 PROTECTING TIME (act like a great EA - do the work, don't just advise): when the host wants focus / deep-work / heads-down time, or time set aside for a task ("block 6 hours of focus this week", "I need 4 hours for the deck by Friday", "protect my mornings"), call find_focus_time FIRST (pass hoursNeeded, an optional byDate deadline, and chunkMinutes if they hint at block length). Briefly tell them the specific times you found, then propose protect_focus_time with those exact blocks. For a single quick hold you may still use create_focus_block. Never invent times - only protect blocks that find_focus_time returned.
 Rules for these: propose exactly ONE action at a time. NEVER say you've done, created, changed, or deleted something - you have only proposed it; the host confirms. Deleting always requires the host's explicit confirmation. For set_weekly_hours and update_preferences, call the matching read tool first and carry over the values the host wants to keep (both replace/merge against current state). Use propose_action ONLY for bookings (create/reschedule/cancel a meeting); use these tools for booking types, availability, preferences, and focus blocks.`;
@@ -160,6 +164,7 @@ export async function streamAssistant(params: {
   const system: SystemBlock[] = [
     { text: GUARDRAIL_PREAMBLE, cache: true },
     { text: CHAT_SYSTEM, cache: true },
+    { text: capabilitySummary(), cache: true },
     { text: block },
   ];
   const tools: AgentToolSpec[] = [

--- a/apps/web/lib/ai/tools/exec.ts
+++ b/apps/web/lib/ai/tools/exec.ts
@@ -1,3 +1,4 @@
+import { searchKnowledge } from "@/lib/ai/catalogue";
 import { computeAnalytics } from "@/lib/booking/analytics";
 import { eventTypeInputSchema } from "@/lib/booking/event-type-input";
 import { findFocusBlocks } from "@/lib/booking/focus-suggestions";
@@ -10,6 +11,7 @@ import {
   configFromInput,
   maskChannel,
 } from "@/lib/notifications/channel-input";
+import { listOutOfOffice } from "@/lib/out-of-office";
 import { slugify, uniqueSlug } from "@/lib/slug";
 import {
   DEFAULT_REMINDER_OFFSETS,
@@ -18,7 +20,7 @@ import {
   logger,
   sha256hex,
 } from "@dayotter/core";
-import { and, asc, desc, eq, getDb, gte, schema } from "@dayotter/db";
+import { and, asc, desc, eq, getDb, gte, lte, ne, schema } from "@dayotter/db";
 import { availableChannels, dispatchToChannel } from "@dayotter/notifications";
 import type { ChannelConfig, DeliverableChannel } from "@dayotter/notifications";
 import { DateTime } from "luxon";
@@ -63,6 +65,145 @@ export async function executeReadTool(
         note: items.length
           ? "'booking' = a DayOtter booking (can be rescheduled/cancelled); 'external' = a synced calendar event (read-only)."
           : "Nothing scheduled in that window - the host is free.",
+      });
+    }
+    case "search_bookings": {
+      const q = ((input?.query as string) ?? "").trim().toLowerCase();
+      const includePast = input?.includePast === true;
+      const now = new Date();
+      const fromRaw = input?.fromISO ? new Date(input.fromISO as string) : null;
+      const toRaw = input?.toISO ? new Date(input.toISO as string) : null;
+      const from = fromRaw && !Number.isNaN(fromRaw.getTime()) ? fromRaw : includePast ? null : now;
+      const to = toRaw && !Number.isNaN(toRaw.getTime()) ? toRaw : null;
+      const conds = [eq(schema.bookings.hostId, userId), ne(schema.bookings.status, "cancelled")];
+      if (from) conds.push(gte(schema.bookings.startsAt, from));
+      if (to) conds.push(lte(schema.bookings.startsAt, to));
+      const rows = await db.query.bookings.findMany({
+        where: and(...conds),
+        orderBy: includePast ? desc(schema.bookings.startsAt) : asc(schema.bookings.startsAt),
+        limit: q ? 200 : 40,
+        with: { attendees: { columns: { name: true, email: true } } },
+      });
+      const matched = rows
+        .filter((b) => {
+          if (!q) return true;
+          const hay =
+            `${b.title} ${b.attendees.map((a) => `${a.name ?? ""} ${a.email}`).join(" ")}`.toLowerCase();
+          return hay.includes(q);
+        })
+        .slice(0, 25)
+        .map((b) => ({
+          uid: b.uid,
+          title: b.title,
+          startsAt: b.startsAt.toISOString(),
+          endsAt: b.endsAt.toISOString(),
+          status: b.status,
+          attendees: b.attendees.map((a) => a.name ?? a.email),
+        }));
+      return JSON.stringify({ count: matched.length, bookings: matched });
+    }
+    case "check_availability": {
+      const from = new Date(input?.fromISO as string);
+      const to = new Date(input?.toISO as string);
+      if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime()) || to <= from) {
+        return JSON.stringify({ error: "Pass a valid fromISO/toISO window (to after from)." });
+      }
+      const [agenda, focus] = await Promise.all([
+        // Bookings + synced external calendar events, already merged.
+        getAgenda(userId, from, to, 100),
+        // Held focus / personal blocks (not part of getAgenda) also make the host busy.
+        db.query.timeBlocks.findMany({
+          where: and(
+            eq(schema.timeBlocks.userId, userId),
+            gte(schema.timeBlocks.endsAt, from),
+            lte(schema.timeBlocks.startsAt, to),
+          ),
+          columns: { title: true, kind: true, startsAt: true, endsAt: true },
+        }),
+      ]);
+      const conflicts = [
+        ...agenda.map((i) => ({
+          title: i.title,
+          source: i.source,
+          startsAt: i.startsAt.toISOString(),
+          endsAt: i.endsAt.toISOString(),
+        })),
+        ...focus.map((f) => ({
+          title: f.title,
+          source: f.kind,
+          startsAt: f.startsAt.toISOString(),
+          endsAt: f.endsAt.toISOString(),
+        })),
+      ].sort((a, b) => a.startsAt.localeCompare(b.startsAt));
+      return JSON.stringify({
+        from: from.toISOString(),
+        to: to.toISOString(),
+        free: conflicts.length === 0,
+        conflicts,
+        note:
+          conflicts.length === 0
+            ? "Nothing is on the calendar in that window. (This reflects existing commitments, not working hours - use find_free_slots for bookable openings.)"
+            : "These commitments overlap the window, so the host is not fully free.",
+      });
+    }
+    case "list_out_of_office": {
+      const periods = await listOutOfOffice(userId);
+      return JSON.stringify(
+        periods.map((p) => ({
+          id: p.id,
+          startDate: p.startDate,
+          endDate: p.endDate,
+          reason: p.reason,
+          delegate: p.delegate ? (p.delegate.name ?? p.delegate.handle) : null,
+        })),
+      );
+    }
+    case "get_booking_type": {
+      const id = input?.id as string | undefined;
+      const slug = input?.slug as string | undefined;
+      if (!id && !slug) return JSON.stringify({ error: "Pass an id or slug." });
+      const et = await db.query.eventTypes.findFirst({
+        where: and(
+          eq(schema.eventTypes.ownerId, userId),
+          id ? eq(schema.eventTypes.id, id) : eq(schema.eventTypes.slug, slug as string),
+        ),
+      });
+      if (!et) return JSON.stringify({ error: "No booking type with that id or slug." });
+      return JSON.stringify({
+        id: et.id,
+        title: et.title,
+        slug: et.slug,
+        description: et.description,
+        durationMinutes: et.durationMinutes,
+        location: et.location,
+        color: et.color,
+        isActive: et.isActive,
+        bufferBeforeMinutes: et.bufferBeforeMinutes,
+        bufferAfterMinutes: et.bufferAfterMinutes,
+        minimumNoticeMinutes: et.minimumNoticeMinutes,
+        bookingWindowDays: et.bookingWindowDays,
+        dailyBookingLimit: et.dailyBookingLimit,
+        weeklyBookingLimit: et.weeklyBookingLimit,
+        maxAttendees: et.maxAttendees,
+        requiresConfirmation: et.requiresConfirmation,
+        isPrivate: et.isPrivate,
+        price: et.price,
+        currency: et.currency,
+      });
+    }
+    case "search_knowledge": {
+      const query = (input?.query as string) ?? "";
+      const matches = searchKnowledge(query, 2);
+      if (matches.length === 0) {
+        return JSON.stringify({
+          found: 0,
+          note: "No matching article. Answer from the tools you have, or ask the host to clarify.",
+        });
+      }
+      return JSON.stringify({
+        found: matches.length,
+        articles: matches.map((m) => ({ title: m.title, content: m.body })),
+        note: "Answer the host from these articles, in your own words and concisely.",
       });
     }
     case "list_booking_types": {
@@ -425,6 +566,39 @@ export async function executeActionTool(
           if (rows.length) await tx.insert(schema.availabilityRules).values(rows);
         });
         return { ok: true, message: `Updated working hours for ${days.length} day(s).` };
+      }
+
+      case "set_out_of_office": {
+        const startDate = input.startDate as string;
+        const endDate = input.endDate as string;
+        if (endDate < startDate) {
+          return { ok: false, message: "The end date must be on or after the start date." };
+        }
+        // Cap per user (mirrors the settings route) so a runaway client can't fill
+        // the table - every OOO row is scanned on each availability computation.
+        const existing = await db.query.outOfOfficePeriods.findMany({
+          where: eq(schema.outOfOfficePeriods.userId, userId),
+          columns: { id: true },
+          limit: 200,
+        });
+        if (existing.length >= 100) {
+          return { ok: false, message: "You've hit the maximum of 100 out-of-office periods." };
+        }
+        const reason = (input.reason as string | undefined)?.trim();
+        await db.insert(schema.outOfOfficePeriods).values({
+          userId,
+          startDate,
+          endDate,
+          reason: reason?.length ? reason : null,
+          delegateUserId: null,
+        });
+        return {
+          ok: true,
+          message:
+            startDate === endDate
+              ? `You're set out of office on ${startDate}.`
+              : `You're set out of office from ${startDate} to ${endDate}.`,
+        };
       }
 
       case "delete_booking_type": {

--- a/apps/web/lib/ai/tools/registry.ts
+++ b/apps/web/lib/ai/tools/registry.ts
@@ -65,6 +65,100 @@ export const TOOLS: AiToolDef[] = [
     summarize: () => "Read agenda",
   },
   {
+    name: "search_bookings",
+    description:
+      "Search the host's bookings beyond the handful already in context - by keyword (title or attendee name) and/or a date range, upcoming or past. Use it to find a specific meeting ('my call with Dana next week', 'the demo I had in March') or to list what's booked in a window. Returns each match with its numeric-free public id, time, status, and attendees.",
+    kind: "read",
+    confirmLevel: "none",
+    schema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        query: { type: "string", description: "Keyword to match in title or attendee names." },
+        fromISO: { type: "string", description: "ISO-8601 start of the window (optional)." },
+        toISO: { type: "string", description: "ISO-8601 end of the window (optional)." },
+        includePast: {
+          type: "boolean",
+          description: "Include bookings before now (default false = upcoming only).",
+        },
+      },
+    },
+    zod: z.object({
+      query: z.string().max(200).optional(),
+      fromISO: z.string().optional(),
+      toISO: z.string().optional(),
+      includePast: z.boolean().optional(),
+    }),
+    title: "Search bookings",
+    summarize: () => "Search bookings",
+  },
+  {
+    name: "check_availability",
+    description:
+      "Check whether the host is free over a specific window and list what would conflict - their DayOtter bookings, synced calendar events, and held focus blocks. Use this to answer 'am I free Friday at 2pm?' or 'is Tuesday afternoon open?'. This reports what's ALREADY on the calendar; to find bookable openings that respect working hours, use find_free_slots instead.",
+    kind: "read",
+    confirmLevel: "none",
+    schema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        fromISO: { type: "string", description: "ISO-8601 start of the window to check." },
+        toISO: { type: "string", description: "ISO-8601 end of the window to check." },
+      },
+      required: ["fromISO", "toISO"],
+    },
+    zod: z.object({ fromISO: z.string(), toISO: z.string() }),
+    title: "Check availability",
+    summarize: () => "Check availability",
+  },
+  {
+    name: "list_out_of_office",
+    description:
+      "List the host's out-of-office periods (start date, end date, reason, and any delegate their bookings redirect to while away).",
+    kind: "read",
+    confirmLevel: "none",
+    schema: empty,
+    zod: z.object({}),
+    title: "Out of office",
+    summarize: () => "List out-of-office",
+  },
+  {
+    name: "get_booking_type",
+    description:
+      "Get the full detail of one booking type by id or slug: duration, location, buffers, notice and booking windows, daily/weekly limits, group capacity, price, and active state. Use before updating one so you know the current values.",
+    kind: "read",
+    confirmLevel: "none",
+    schema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        id: { type: "string", description: "Booking type id (from list_booking_types)." },
+        slug: { type: "string", description: "Booking type slug (alternative to id)." },
+      },
+    },
+    zod: z.object({ id: z.string().optional(), slug: z.string().optional() }),
+    title: "Booking type detail",
+    summarize: () => "Read booking type",
+  },
+  {
+    name: "search_knowledge",
+    description:
+      "Search DayOtter's built-in knowledge base for how-to and best-practice guidance (protecting focus time, reducing no-shows, availability & time off, designing booking types, automations vs workflows, connecting calendars, team scheduling). Call this whenever the host asks 'how do I...', 'what's the best way to...', or 'can DayOtter...' - then answer from the returned article(s) instead of guessing.",
+    kind: "read",
+    confirmLevel: "none",
+    schema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        query: { type: "string", description: "What the host wants to know how to do." },
+      },
+      required: ["query"],
+    },
+    zod: z.object({ query: z.string().min(1).max(300) }),
+    title: "Knowledge base",
+    summarize: () => "Search knowledge base",
+  },
+  {
     name: "list_booking_types",
     description:
       "List the host's booking types (event types): title, slug, duration, active state, and public URL.",
@@ -711,6 +805,31 @@ export const TOOLS: AiToolDef[] = [
     }),
     title: "Update working hours",
     summarize: (i) => `Set working hours for ${(i.days as unknown[])?.length ?? 0} day(s)`,
+  },
+  {
+    name: "set_out_of_office",
+    description:
+      "Mark the host out of office for a date range (inclusive), so their booking page shows an away banner and stops offering slots on those days. Dates are YYYY-MM-DD. Optionally add a short reason. Confirm-first.",
+    kind: "write",
+    confirmLevel: "confirm",
+    schema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        startDate: { type: "string", description: "First day away, YYYY-MM-DD." },
+        endDate: { type: "string", description: "Last day away, YYYY-MM-DD (inclusive)." },
+        reason: { type: "string", description: "Optional short note, e.g. 'Vacation'." },
+      },
+      required: ["startDate", "endDate"],
+    },
+    zod: z.object({
+      startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+      endDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+      reason: z.string().max(200).optional(),
+    }),
+    title: "Set out of office",
+    summarize: (i) =>
+      `Out of office ${i.startDate}${i.endDate !== i.startDate ? ` → ${i.endDate}` : ""}${i.reason ? ` (${i.reason})` : ""}`,
   },
 
   // ---- Destructive (danger confirm; deleting ALWAYS requires confirmation) ----

--- a/docs/AI.md
+++ b/docs/AI.md
@@ -73,6 +73,32 @@ destructive actions get a danger confirm.** Execution reuses the app's own
 validated DB writes - the assistant can never do anything the app itself
 couldn't. To give Otter a new capability, add a tool.
 
+Reads cover the whole workspace: the merged agenda (DayOtter bookings **plus**
+synced Google/Outlook/Apple events via `get_agenda`), `search_bookings`,
+`check_availability`, booking types, availability, out-of-office, preferences,
+focus blocks, channels, teams, automations, workflows, and analytics. Writes and
+destructive actions cover booking types, focus time, out-of-office, preferences,
+working hours, channels, teams, automations, and workflows. Bookings themselves
+(create / reschedule / cancel) go through the richer `propose_action` card.
+
+### The prompt & knowledge catalogues - `lib/ai/catalogue/`
+Two curated, pure (no-I/O, unit-tested) data sources that make Otter more capable
+without new model plumbing:
+
+- **`prompts.ts` - the prompt catalogue.** A categorized library of real,
+  useful requests. It powers the suggestion chips in the assistant UI *and*
+  feeds `capabilitySummary()` into the system prompt, so the model knows the
+  shape of what it can do and maps fuzzy asks onto the right tool. **Extension
+  point:** when a capability lands, add a prompt here - it's the single source of
+  truth for "what can I ask Otter?".
+- **`knowledge.ts` - the knowledge catalogue.** A small set of grounded,
+  DayOtter-specific reference articles (protecting focus, reducing no-shows,
+  availability & time off, booking types, automations vs workflows, connecting
+  calendars, team scheduling). Otter retrieves them with the `search_knowledge`
+  tool to answer "how do I..." / "what's the best way to..." questions from
+  fact instead of guesswork. **Extension point:** add an article (title +
+  keywords + body); keyword+title retrieval needs nothing heavier.
+
 ### Memory - `lib/ai/memory/`  ([module README](../apps/web/lib/ai/memory/README.md))
 Long-term, per-user patterns (typical duration, frequent contacts, active hours,
 busiest weekday, meeting load) derived from real history and injected into the


### PR DESCRIPTION
Makes Otter meaningfully more capable and better-grounded, in three parts.

> **Stacked on #179** (`get_agenda` / synced-calendar visibility). The base is `fix/ai-sees-synced-calendar`; GitHub will retarget this to `main` automatically when #179 merges. Review/merge #179 first.

## 1. More tools

All backed by the app's own validated logic — Otter still can't do anything the app itself couldn't.

**Reads**
- **`search_bookings`** — find any past or upcoming meeting by keyword and/or date range. The per-turn context only lists a handful; this reaches the rest ("the demo I had in March", "my call with Dana next week").
- **`check_availability`** — is the host free over a window? Reports conflicts across DayOtter bookings, synced calendar events, and held focus blocks.
- **`list_out_of_office`** — current OOO periods and delegates.
- **`get_booking_type`** — full detail of one type (buffers, limits, notice, price…), so edits carry over current values.
- **`search_knowledge`** — retrieve from the knowledge catalogue (below).

**Write (confirm-first)**
- **`set_out_of_office`** — mark a date range away; mirrors the settings route's validation and 100-period cap.

## 2. Prompt catalogue — `lib/ai/catalogue/prompts.ts`

A categorized library of real, useful requests (Plan · Focus · Meetings · Availability · Setup · Insights). Two consumers:
- **The host** — renders as suggestion chips in the assistant's empty state, so people discover what Otter can do.
- **The model** — `capabilitySummary()` is injected into the system prompt (cached block) so Otter knows its own surface and maps vague asks onto the right tool instead of declining.

Single source of truth for "what can I ask Otter?" — add a prompt when a capability lands.

## 3. Knowledge catalogue — `lib/ai/catalogue/knowledge.ts`

A small set of grounded, DayOtter-specific reference articles (protecting focus, reducing no-shows, availability & time off, designing booking types, automations vs workflows, connecting calendars, team scheduling). Otter retrieves them via `search_knowledge` to answer "how do I…" / "what's the best way to…" questions **from fact instead of guessing.** Mirrors the existing voice `KnowledgeSource` pattern; keyword+title retrieval, unit-tested.

## Testing

- web typecheck ✅ · `next build` (195 pages) ✅ — confirms the catalogue is safe to import into the client assistant component
- web tests ✅ (161 — added 8 for the catalogues: prompt integrity + `searchKnowledge` ranking/limits)
- biome ✅
- Couldn't run the live dev preview (port 3000 is held by another local dev server and the script hardcodes `-p 3000`); the production build is the authoritative client/server-boundary check in its place.

`docs/AI.md` documents all three as extension points.
