### PR TITLE
feat(ai): analyze_schedule tool — aggregate calendar answers (roadmap 1/5)

### DIFF
--- a/apps/web/lib/ai/chat.ts
+++ b/apps/web/lib/ai/chat.ts
@@ -67,7 +67,8 @@ HOW YOU WORK:
 - If you're only answering a question (not proposing a change), reply in plain text and do not call propose_action.
 
 BEYOND BOOKINGS - you can also read and control the rest of the host's setup with these tools:
-- Reads (use freely to answer questions, and BEFORE changing something so you know the current values): get_agenda, search_bookings, check_availability, list_booking_types, get_booking_type, get_availability, list_out_of_office, get_preferences, list_focus_blocks, list_notification_channels, find_focus_time, get_analytics.
+- Reads (use freely to answer questions, and BEFORE changing something so you know the current values): get_agenda, analyze_schedule, search_bookings, check_availability, list_booking_types, get_booking_type, get_availability, list_out_of_office, get_preferences, list_focus_blocks, list_notification_channels, find_focus_time, get_analytics.
+- For counting/aggregate questions ("how many meetings/hours this week", "when do I finish today", "am I double-booked", "longest free stretch") call analyze_schedule rather than counting agenda items yourself.
 - Actions (each shows the host a confirm card - nothing happens until they tap Confirm): create_booking_type, create_focus_block, protect_focus_time, update_preferences, set_weekly_hours, set_out_of_office, delete_booking_type, delete_focus_block, and more (booking types, channels, teams, automations, workflows).
 - Prefer a tool over guessing. To find a specific past or upcoming meeting, use search_bookings (the per-turn context only lists a few). To answer "am I free at X", use check_availability.
 

--- a/apps/web/lib/ai/tools/exec.ts
+++ b/apps/web/lib/ai/tools/exec.ts
@@ -6,6 +6,7 @@ import { notPersonalType } from "@/lib/booking/personal-event-type";
 import { resolveScheduleId } from "@/lib/booking/schedule";
 import { ensureUserWorkspace } from "@/lib/bootstrap";
 import { getAgenda } from "@/lib/calendar/agenda";
+import { type BusyItem, analyzeSchedule } from "@/lib/calendar/analyze";
 import {
   channelInputSchema,
   configFromInput,
@@ -101,6 +102,47 @@ export async function executeReadTool(
           attendees: b.attendees.map((a) => a.name ?? a.email),
         }));
       return JSON.stringify({ count: matched.length, bookings: matched });
+    }
+    case "analyze_schedule": {
+      const from = new Date(input?.fromISO as string);
+      const to = new Date(input?.toISO as string);
+      if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime()) || to <= from) {
+        return JSON.stringify({ error: "Pass a valid fromISO/toISO window (to after from)." });
+      }
+      const [agenda, focus, user] = await Promise.all([
+        getAgenda(userId, from, to, 200),
+        db.query.timeBlocks.findMany({
+          where: and(
+            eq(schema.timeBlocks.userId, userId),
+            gte(schema.timeBlocks.endsAt, from),
+            lte(schema.timeBlocks.startsAt, to),
+          ),
+          columns: { title: true, kind: true, startsAt: true, endsAt: true },
+        }),
+        db.query.users.findFirst({
+          where: eq(schema.users.id, userId),
+          columns: { timezone: true },
+        }),
+      ]);
+      const items: BusyItem[] = [
+        ...agenda.map((i) => ({
+          title: i.title,
+          startsAt: i.startsAt,
+          endsAt: i.endsAt,
+          source: i.source,
+        })),
+        ...focus.map((f) => ({
+          title: f.title,
+          startsAt: f.startsAt,
+          endsAt: f.endsAt,
+          source: f.kind,
+        })),
+      ];
+      const analysis = analyzeSchedule(items, from, to, user?.timezone ?? "UTC");
+      return JSON.stringify({
+        ...analysis,
+        note: "busyHours merges overlaps (double-booked time counted once). 'finish time' = lastEndISO. For bookable openings that respect working hours, use find_free_slots.",
+      });
     }
     case "check_availability": {
       const from = new Date(input?.fromISO as string);

--- a/apps/web/lib/ai/tools/registry.ts
+++ b/apps/web/lib/ai/tools/registry.ts
@@ -93,6 +93,25 @@ export const TOOLS: AiToolDef[] = [
     summarize: () => "Search bookings",
   },
   {
+    name: "analyze_schedule",
+    description:
+      "Compute aggregate stats over a date range instead of counting by hand: how many commitments, total busy hours (double-booked time counted once), the busiest day, first start and last end (the host's 'finish time'), the longest gap between commitments, and any double-booked/overlapping pairs. Use for 'how many meetings this week?', 'how many hours of meetings?', 'when do I finish today?', 'am I double-booked?', 'what's my longest free stretch?'. Covers bookings + synced calendar events + held focus blocks.",
+    kind: "read",
+    confirmLevel: "none",
+    schema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        fromISO: { type: "string", description: "ISO-8601 start of the window." },
+        toISO: { type: "string", description: "ISO-8601 end of the window." },
+      },
+      required: ["fromISO", "toISO"],
+    },
+    zod: z.object({ fromISO: z.string(), toISO: z.string() }),
+    title: "Analyze schedule",
+    summarize: () => "Analyze schedule",
+  },
+  {
     name: "check_availability",
     description:
       "Check whether the host is free over a specific window and list what would conflict - their DayOtter bookings, synced calendar events, and held focus blocks. Use this to answer 'am I free Friday at 2pm?' or 'is Tuesday afternoon open?'. This reports what's ALREADY on the calendar; to find bookable openings that respect working hours, use find_free_slots instead.",

--- a/apps/web/lib/calendar/analyze.test.ts
+++ b/apps/web/lib/calendar/analyze.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { type BusyItem, analyzeSchedule } from "./analyze";
+
+const d = (iso: string) => new Date(iso);
+const item = (title: string, start: string, end: string, source = "booking"): BusyItem => ({
+  title,
+  startsAt: d(start),
+  endsAt: d(end),
+  source,
+});
+
+describe("analyzeSchedule", () => {
+  const from = d("2026-07-30T00:00:00Z");
+  const to = d("2026-07-31T00:00:00Z");
+
+  it("counts commitments, sums busy hours, and breaks down by source", () => {
+    const a = analyzeSchedule(
+      [
+        item("Standup", "2026-07-30T09:00:00Z", "2026-07-30T09:30:00Z"),
+        item("Design review", "2026-07-30T13:00:00Z", "2026-07-30T14:00:00Z", "external"),
+        item("Deep work", "2026-07-30T15:00:00Z", "2026-07-30T16:30:00Z", "focus"),
+      ],
+      from,
+      to,
+      "UTC",
+    );
+    expect(a.commitmentCount).toBe(3);
+    expect(a.busyHours).toBe(3); // 0.5 + 1 + 1.5
+    expect(a.bySource).toEqual({ booking: 1, external: 1, focus: 1 });
+    expect(a.firstStartISO).toBe("2026-07-30T09:00:00.000Z");
+    expect(a.lastEndISO).toBe("2026-07-30T16:30:00.000Z"); // finish time
+  });
+
+  it("merges overlapping time so double-booked hours aren't counted twice", () => {
+    const a = analyzeSchedule(
+      [
+        item("Call A", "2026-07-30T10:00:00Z", "2026-07-30T11:00:00Z"),
+        item("Call B", "2026-07-30T10:30:00Z", "2026-07-30T11:30:00Z", "external"),
+      ],
+      from,
+      to,
+      "UTC",
+    );
+    expect(a.busyHours).toBe(1.5); // union 10:00-11:30, not 2h
+    expect(a.conflicts).toHaveLength(1);
+    expect(a.conflicts[0]).toMatchObject({
+      a: "Call A",
+      b: "Call B",
+      startsAt: "2026-07-30T10:30:00.000Z",
+      endsAt: "2026-07-30T11:00:00.000Z",
+    });
+  });
+
+  it("reports the longest gap between consecutive commitments", () => {
+    const a = analyzeSchedule(
+      [
+        item("Morning", "2026-07-30T09:00:00Z", "2026-07-30T09:30:00Z"),
+        item("Afternoon", "2026-07-30T14:00:00Z", "2026-07-30T15:00:00Z"),
+      ],
+      from,
+      to,
+      "UTC",
+    );
+    expect(a.longestGapMinutes).toBe(270); // 09:30 -> 14:00
+    expect(a.longestGapFromISO).toBe("2026-07-30T09:30:00.000Z");
+    expect(a.longestGapToISO).toBe("2026-07-30T14:00:00.000Z");
+  });
+
+  it("buckets busiest day in the host's timezone", () => {
+    // 23:00 UTC on the 30th is 19:00 in New York (still the 30th locally).
+    const a = analyzeSchedule(
+      [item("Late call", "2026-07-30T23:00:00Z", "2026-07-31T00:00:00Z")],
+      d("2026-07-30T00:00:00Z"),
+      d("2026-07-31T12:00:00Z"),
+      "America/New_York",
+    );
+    expect(a.busiestDay?.date).toBe("2026-07-30");
+  });
+
+  it("handles an empty window", () => {
+    const a = analyzeSchedule([], from, to, "UTC");
+    expect(a.commitmentCount).toBe(0);
+    expect(a.busyHours).toBe(0);
+    expect(a.busiestDay).toBeNull();
+    expect(a.firstStartISO).toBeNull();
+    expect(a.longestGapMinutes).toBeNull();
+    expect(a.conflicts).toEqual([]);
+  });
+
+  it("ignores items outside the window", () => {
+    const a = analyzeSchedule(
+      [
+        item("Before", "2026-07-29T10:00:00Z", "2026-07-29T11:00:00Z"),
+        item("Inside", "2026-07-30T10:00:00Z", "2026-07-30T11:00:00Z"),
+      ],
+      from,
+      to,
+      "UTC",
+    );
+    expect(a.commitmentCount).toBe(1);
+    expect(a.busyHours).toBe(1);
+  });
+});

--- a/apps/web/lib/calendar/analyze.ts
+++ b/apps/web/lib/calendar/analyze.ts
@@ -1,0 +1,167 @@
+import { DateTime } from "luxon";
+
+/**
+ * Pure schedule analytics over a set of calendar commitments. The AI's read
+ * tools return raw agenda items; this turns them into the aggregate answers
+ * people actually ask for - "how many hours of meetings this week?", "when do I
+ * finish today?", "am I double-booked?", "what's my longest free stretch?" -
+ * instead of leaving the model to hand-count JSON (which it does unreliably).
+ *
+ * No I/O: the caller fetches the items (bookings + synced events + focus blocks)
+ * and hands them in, so this is trivially unit-testable and timezone-correct.
+ */
+
+export interface BusyItem {
+  title: string;
+  startsAt: Date;
+  endsAt: Date;
+  /** "booking" | "external" | "focus" | "personal" | ... - for a per-source breakdown. */
+  source: string;
+}
+
+export interface ScheduleConflict {
+  a: string;
+  b: string;
+  startsAt: string;
+  endsAt: string;
+}
+
+export interface ScheduleAnalysis {
+  fromISO: string;
+  toISO: string;
+  commitmentCount: number;
+  bySource: Record<string, number>;
+  /** Total busy time with overlaps merged (so double-booked time isn't counted twice). */
+  busyHours: number;
+  busiestDay: { date: string; hours: number } | null;
+  /** First commitment start and last commitment end in the window (the "finish time"). */
+  firstStartISO: string | null;
+  lastEndISO: string | null;
+  /** Largest gap between consecutive commitments (ignores working hours - a raw calendar gap). */
+  longestGapMinutes: number | null;
+  longestGapFromISO: string | null;
+  longestGapToISO: string | null;
+  /** Overlapping pairs - the host is double-booked across these (capped). */
+  conflicts: ScheduleConflict[];
+}
+
+/** Clamp [s,e) to [from,to); returns null if they don't overlap. */
+function clampInterval(s: Date, e: Date, from: Date, to: Date): [number, number] | null {
+  const start = Math.max(s.getTime(), from.getTime());
+  const end = Math.min(e.getTime(), to.getTime());
+  return end > start ? [start, end] : null;
+}
+
+/** Merge sorted [start,end] ms intervals; returns total covered minutes + merged spans. */
+function mergeMinutes(intervals: [number, number][]): {
+  minutes: number;
+  merged: [number, number][];
+} {
+  if (intervals.length === 0) return { minutes: 0, merged: [] };
+  const sorted = [...intervals].sort((a, b) => a[0] - b[0]);
+  const merged: [number, number][] = [sorted[0]!];
+  for (const [s, e] of sorted.slice(1)) {
+    const last = merged[merged.length - 1]!;
+    if (s <= last[1]) last[1] = Math.max(last[1], e);
+    else merged.push([s, e]);
+  }
+  const minutes = merged.reduce((sum, [s, e]) => sum + (e - s) / 60_000, 0);
+  return { minutes, merged };
+}
+
+const round1 = (n: number) => Math.round(n * 10) / 10;
+
+/**
+ * Analyze the host's commitments in [from, to). `timezone` is used for per-day
+ * bucketing so "busiest day" reflects the host's local calendar, not UTC.
+ */
+export function analyzeSchedule(
+  items: BusyItem[],
+  from: Date,
+  to: Date,
+  timezone: string,
+): ScheduleAnalysis {
+  // Keep only items that actually intersect the window, chronological.
+  const inWindow = items
+    .filter((it) => it.endsAt > from && it.startsAt < to)
+    .sort((a, b) => a.startsAt.getTime() - b.startsAt.getTime());
+
+  const bySource: Record<string, number> = {};
+  for (const it of inWindow) bySource[it.source] = (bySource[it.source] ?? 0) + 1;
+
+  // Busy minutes (overlaps merged), clamped to the window.
+  const clamped = inWindow
+    .map((it) => clampInterval(it.startsAt, it.endsAt, from, to))
+    .filter((x): x is [number, number] => x !== null);
+  const { minutes: busyMinutes } = mergeMinutes(clamped);
+
+  // Per-day busy hours in the host's timezone (split intervals at local midnight).
+  const perDay = new Map<string, number>();
+  for (const [s, e] of clamped) {
+    let cursor = DateTime.fromMillis(s, { zone: timezone });
+    const end = DateTime.fromMillis(e, { zone: timezone });
+    while (cursor < end) {
+      const dayEnd = cursor.plus({ days: 1 }).startOf("day");
+      const chunkEnd = dayEnd < end ? dayEnd : end;
+      const mins = chunkEnd.diff(cursor, "minutes").minutes;
+      const key = cursor.toISODate() ?? "";
+      perDay.set(key, (perDay.get(key) ?? 0) + mins);
+      cursor = chunkEnd;
+    }
+  }
+  let busiestDay: ScheduleAnalysis["busiestDay"] = null;
+  for (const [date, mins] of perDay) {
+    if (!busiestDay || mins > busiestDay.hours * 60)
+      busiestDay = { date, hours: round1(mins / 60) };
+  }
+
+  // Largest gap between consecutive commitments (using merged busy spans).
+  const { merged } = mergeMinutes(clamped);
+  let longestGapMinutes: number | null = null;
+  let longestGapFromISO: string | null = null;
+  let longestGapToISO: string | null = null;
+  for (let i = 1; i < merged.length; i++) {
+    const gap = (merged[i]![0] - merged[i - 1]![1]) / 60_000;
+    if (longestGapMinutes === null || gap > longestGapMinutes) {
+      longestGapMinutes = gap;
+      longestGapFromISO = new Date(merged[i - 1]![1]).toISOString();
+      longestGapToISO = new Date(merged[i]![0]).toISOString();
+    }
+  }
+
+  // Conflicts: overlapping pairs (pre-merge). O(n^2) is fine for a bounded window.
+  const conflicts: ScheduleConflict[] = [];
+  for (let i = 0; i < inWindow.length && conflicts.length < 10; i++) {
+    for (let j = i + 1; j < inWindow.length && conflicts.length < 10; j++) {
+      const a = inWindow[i]!;
+      const b = inWindow[j]!;
+      if (b.startsAt >= a.endsAt) break; // sorted by start: no later item can overlap a
+      if (a.startsAt < b.endsAt && b.startsAt < a.endsAt) {
+        conflicts.push({
+          a: a.title,
+          b: b.title,
+          startsAt: new Date(Math.max(a.startsAt.getTime(), b.startsAt.getTime())).toISOString(),
+          endsAt: new Date(Math.min(a.endsAt.getTime(), b.endsAt.getTime())).toISOString(),
+        });
+      }
+    }
+  }
+
+  return {
+    fromISO: from.toISOString(),
+    toISO: to.toISOString(),
+    commitmentCount: inWindow.length,
+    bySource,
+    busyHours: round1(busyMinutes / 60),
+    busiestDay,
+    firstStartISO: inWindow[0]?.startsAt.toISOString() ?? null,
+    lastEndISO:
+      inWindow.length > 0
+        ? new Date(Math.max(...inWindow.map((it) => it.endsAt.getTime()))).toISOString()
+        : null,
+    longestGapMinutes: longestGapMinutes === null ? null : Math.round(longestGapMinutes),
+    longestGapFromISO,
+    longestGapToISO,
+    conflicts,
+  };
+}


### PR DESCRIPTION
**PR 1 of the Otter coverage roadmap** (from the deep 58-use-case audit). Kills the "query mental-math" gaps: aggregate calendar questions were answered by the model hand-counting agenda JSON — unreliable, and it double-counted overlapping time.

> Stacked on #180 → #179. GitHub retargets to `main` as those merge.

## What it adds

A pure, unit-tested analyzer (`lib/calendar/analyze.ts`) exposed as the **`analyze_schedule`** read tool. Over any window it computes:
- commitment count + per-source breakdown (booking / synced event / focus)
- **total busy hours with overlaps merged** — double-booked time counted once, not twice
- busiest day (bucketed in the host's timezone)
- first start / **last end = "finish time"**
- longest gap between commitments
- **conflicts** — overlapping/double-booked pairs

Covers DayOtter bookings + synced Google/Outlook/Apple events + held focus blocks.

## Use cases this moves to ✅ (were 🟡/❌ in the audit)

- "How many meetings did I have this week?" / "…hours of meetings?"
- "When do I finish today?"
- "Am I double-booked / any conflicts?"
- "What's my longest free stretch tomorrow?"
- "Summarize how busy I am."

The system prompt now steers Otter to call `analyze_schedule` instead of counting agenda items itself.

## Testing
- web typecheck ✅ · web tests ✅ (159; +6 for `analyzeSchedule`: counts, overlap-merge, longest-gap, tz day-bucketing, empty window, out-of-window) · biome ✅
