### PR TITLE
feat(ai): actionable found-bookings + bulk cancel/reschedule (roadmap 3/5)

### DIFF
--- a/apps/web/lib/ai/chat.ts
+++ b/apps/web/lib/ai/chat.ts
@@ -64,6 +64,7 @@ HOW YOU WORK:
 - When a time depends on when the host is actually free ("find me a free 30 min", "my next open afternoon"), call find_free_slots FIRST, then use a real returned slot in the draft. Never invent availability.
 - Resolve every time to an absolute ISO-8601 instant in the host's timezone. Never pick a past time. Interpret vague times locally (morning=09:00, afternoon=14:00, evening=18:00).
 - For reschedule/cancel, set bookingRef to the exact ref of the intended booking. If several could match and you can't tell, DON'T propose - just ask which one in your reply.
+- propose_action works on the bookings listed in context (each has a ref). To act on a booking that ISN'T listed - one from search_bookings, a past or far-future meeting, or when you need its uid - use reschedule_booking (one booking, by uid) or cancel_bookings (one or more uids). For BULK requests ("cancel all my meetings tomorrow", "push everything Friday back an hour") call search_bookings for the window FIRST to get the uids, then cancel_bookings(uids) or shift_bookings(uids, deltaMinutes). To cancel a whole recurring series, use cancel_bookings with scope "series". These are one confirm card for the whole batch.
 - If you're only answering a question (not proposing a change), reply in plain text and do not call propose_action.
 
 BEYOND BOOKINGS - you can also read and control the rest of the host's setup with these tools:

--- a/apps/web/lib/ai/tools/exec.ts
+++ b/apps/web/lib/ai/tools/exec.ts
@@ -1,8 +1,10 @@
 import { searchKnowledge } from "@/lib/ai/catalogue";
 import { computeAnalytics } from "@/lib/booking/analytics";
+import { cancelBooking, cancelBookingSeries } from "@/lib/booking/cancel-booking";
 import { eventTypeInputSchema } from "@/lib/booking/event-type-input";
 import { findFocusBlocks } from "@/lib/booking/focus-suggestions";
 import { notPersonalType } from "@/lib/booking/personal-event-type";
+import { rescheduleBooking } from "@/lib/booking/reschedule-booking";
 import { resolveScheduleId } from "@/lib/booking/schedule";
 import { ensureUserWorkspace } from "@/lib/bootstrap";
 import { getAgenda } from "@/lib/calendar/agenda";
@@ -21,7 +23,7 @@ import {
   logger,
   sha256hex,
 } from "@dayotter/core";
-import { and, asc, desc, eq, getDb, gte, lte, ne, schema } from "@dayotter/db";
+import { and, asc, desc, eq, getDb, gte, inArray, lte, ne, schema } from "@dayotter/db";
 import { availableChannels, dispatchToChannel } from "@dayotter/notifications";
 import type { ChannelConfig, DeliverableChannel } from "@dayotter/notifications";
 import { DateTime } from "luxon";
@@ -709,6 +711,89 @@ export async function executeActionTool(
             ? `${date} is now marked as a day off.`
             : `On ${date} your hours are now ${input.start as string}–${input.end as string}.`,
         };
+      }
+
+      case "reschedule_booking": {
+        const uid = input.uid as string;
+        // Ownership guard: only the host may move their own booking, even though
+        // rescheduleBooking() looks up by uid globally.
+        const owned = await db.query.bookings.findFirst({
+          where: and(eq(schema.bookings.uid, uid), eq(schema.bookings.hostId, userId)),
+          columns: { status: true, title: true },
+        });
+        if (!owned || owned.status === "cancelled") {
+          return { ok: false, message: "I couldn't find that booking." };
+        }
+        try {
+          await rescheduleBooking(uid, input.newStartISO as string);
+          return { ok: true, message: `Moved “${owned.title}” to the new time.` };
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : "that time wasn't available";
+          return { ok: false, message: `Couldn't move “${owned.title}” - ${msg}.` };
+        }
+      }
+
+      case "shift_bookings": {
+        const uids = input.uids as string[];
+        const delta = input.deltaMinutes as number;
+        const owned = await db.query.bookings.findMany({
+          where: and(
+            inArray(schema.bookings.uid, uids),
+            eq(schema.bookings.hostId, userId),
+            ne(schema.bookings.status, "cancelled"),
+          ),
+          columns: { uid: true, title: true, startsAt: true },
+        });
+        if (owned.length === 0) return { ok: false, message: "I couldn't find those bookings." };
+        // Order so the shifted set doesn't collide with itself: moving later,
+        // move the latest first; moving earlier, the earliest first.
+        const ordered = [...owned].sort((a, b) =>
+          delta > 0
+            ? b.startsAt.getTime() - a.startsAt.getTime()
+            : a.startsAt.getTime() - b.startsAt.getTime(),
+        );
+        let moved = 0;
+        const failed: string[] = [];
+        for (const b of ordered) {
+          const newStart = new Date(b.startsAt.getTime() + delta * 60_000).toISOString();
+          try {
+            await rescheduleBooking(b.uid, newStart);
+            moved++;
+          } catch {
+            failed.push(b.title);
+          }
+        }
+        if (moved === 0) {
+          return { ok: false, message: "Couldn't move any of them - the new times weren't free." };
+        }
+        return {
+          ok: true,
+          message: failed.length
+            ? `Moved ${moved}; couldn't move ${failed.length} (${failed.join(", ")}) - those times weren't free.`
+            : `Moved ${moved} booking${moved === 1 ? "" : "s"}.`,
+        };
+      }
+
+      case "cancel_bookings": {
+        const uids = input.uids as string[];
+        const series = input.scope === "series";
+        const reason = input.reason as string | undefined;
+        const owned = await db.query.bookings.findMany({
+          where: and(inArray(schema.bookings.uid, uids), eq(schema.bookings.hostId, userId)),
+          columns: { uid: true },
+        });
+        const ownedUids = new Set(owned.map((b) => b.uid));
+        if (ownedUids.size === 0) return { ok: false, message: "I couldn't find those bookings." };
+        let count = 0;
+        for (const uid of uids) {
+          if (!ownedUids.has(uid)) continue;
+          if (series) count += await cancelBookingSeries(uid, reason);
+          else if (await cancelBooking(uid, reason)) count++;
+        }
+        if (count === 0) {
+          return { ok: false, message: "Nothing to cancel - they may already be cancelled." };
+        }
+        return { ok: true, message: `Cancelled ${count} booking${count === 1 ? "" : "s"}.` };
       }
 
       case "delete_booking_type": {

--- a/apps/web/lib/ai/tools/registry.ts
+++ b/apps/web/lib/ai/tools/registry.ts
@@ -936,8 +936,106 @@ export const TOOLS: AiToolDef[] = [
         ? `Mark ${i.date} as a day off`
         : `Set ${i.date} hours to ${i.start}–${i.end}`,
   },
+  {
+    name: "reschedule_booking",
+    description:
+      "Move ONE booking to a new time by its public id (uid). Use this to act on a specific booking you found with search_bookings - a past, far-future, or otherwise not-in-context meeting, or to resolve which of several you mean. For the common case of moving a booking that's already listed in the context, use propose_action instead. Confirm-first.",
+    kind: "write",
+    confirmLevel: "confirm",
+    schema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        uid: { type: "string", description: "The booking's public id (from search_bookings)." },
+        newStartISO: { type: "string", description: "New start, ISO-8601 instant." },
+      },
+      required: ["uid", "newStartISO"],
+    },
+    zod: z.object({
+      uid: z.string().min(1).max(120),
+      newStartISO: z.string().datetime({ offset: true }),
+    }),
+    title: "Reschedule booking",
+    summarize: () => "Move this booking to the new time",
+  },
+  {
+    name: "shift_bookings",
+    description:
+      "Move SEVERAL bookings by the same relative amount - e.g. 'push everything on Friday back an hour' (deltaMinutes 60) or 'move my morning meetings 30 min earlier' (deltaMinutes -30). Pass the booking uids (from search_bookings). Each move is re-validated against availability; any that can't move are reported. Confirm-first.",
+    kind: "write",
+    confirmLevel: "confirm",
+    schema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        uids: {
+          type: "array",
+          items: { type: "string" },
+          description: "Public ids of the bookings to move (from search_bookings).",
+        },
+        deltaMinutes: {
+          type: "integer",
+          description: "Minutes to shift by; positive = later, negative = earlier.",
+        },
+      },
+      required: ["uids", "deltaMinutes"],
+    },
+    zod: z.object({
+      uids: z.array(z.string().min(1).max(120)).min(1).max(25),
+      deltaMinutes: z
+        .number()
+        .int()
+        .min(-1440)
+        .max(1440)
+        .refine((n) => n !== 0, "non-zero"),
+    }),
+    title: "Shift bookings",
+    summarize: (i) => {
+      const n = (i.uids as unknown[])?.length ?? 0;
+      const mins = Math.abs(i.deltaMinutes as number);
+      const dir = (i.deltaMinutes as number) > 0 ? "later" : "earlier";
+      return `Move ${n} booking${n === 1 ? "" : "s"} ${mins} min ${dir}`;
+    },
+  },
 
   // ---- Destructive (danger confirm; deleting ALWAYS requires confirmation) ----
+  {
+    name: "cancel_bookings",
+    description:
+      "Cancel one or more bookings by their public ids (uids from search_bookings), notifying attendees. Use this for bulk cancellation ('cancel all my meetings tomorrow') or to cancel a specific found/past booking - or pass scope 'series' with a single uid to cancel a whole recurring series. Destructive - requires explicit confirmation. (For cancelling a single booking already in context, propose_action is fine too.)",
+    kind: "destructive",
+    confirmLevel: "danger",
+    schema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        uids: {
+          type: "array",
+          items: { type: "string" },
+          description: "Public ids of the bookings to cancel (from search_bookings).",
+        },
+        scope: {
+          type: "string",
+          enum: ["one", "series"],
+          description: "'series' cancels the whole recurring series of each uid (default 'one').",
+        },
+        reason: { type: "string", description: "Optional cancellation note sent to attendees." },
+      },
+      required: ["uids"],
+    },
+    zod: z.object({
+      uids: z.array(z.string().min(1).max(120)).min(1).max(50),
+      scope: z.enum(["one", "series"]).optional(),
+      reason: z.string().max(500).optional(),
+    }),
+    title: "Cancel bookings",
+    summarize: (i) => {
+      const n = (i.uids as unknown[])?.length ?? 0;
+      return i.scope === "series"
+        ? `Cancel ${n === 1 ? "this recurring series" : `${n} recurring series`}`
+        : `Cancel ${n} booking${n === 1 ? "" : "s"}`;
+    },
+  },
   {
     name: "delete_booking_type",
     description:


### PR DESCRIPTION
**PR 3 of the Otter coverage roadmap.** Fixes the biggest modify-family defect from the audit.

> Stacked on #182 → #181 → #180 → #179. Retargets to `main` as those merge.

## The defect

`propose_action` resolves a booking by a **numeric ref into the ~12 upcoming-confirmed bookings** already in context. `search_bookings` (added earlier) returned booking IDs that were **never made actionable** — so Otter could *find* a past, far-future, or among-many meeting and then had **no way to act on it**. And bulk was structurally impossible (one ref, one action per turn).

## The fix — uid-addressed action tools

Three new tools that route through the **existing confirm-card pathway** — zero change to the shared draft schema or the client:

- **`reschedule_booking { uid, newStartISO }`** — move ONE booking by its public id (from `search_bookings`): a past, far-future, or disambiguated meeting.
- **`cancel_bookings { uids[], scope?, reason? }`** — cancel one or many by uid; `scope: "series"` cancels a whole recurring series. → "cancel all my meetings tomorrow", "cancel the standup series". Destructive (danger confirm).
- **`shift_bookings { uids[], deltaMinutes }`** — move several by the same offset ("push everything Friday back an hour"). Ordered so the shifted set doesn't collide with itself; each move re-validated against availability; any that can't move are reported honestly.

All three **guard host-ownership** before calling the shared cancel/reschedule backends (which look up by uid globally) — a user can't touch another host's booking. One confirm card per batch; execution still only runs from `/api/ai/act` after the user taps Confirm.

The system prompt now instructs the model: `search_bookings` for the uids first, then these tools for **past / far-future / bulk / series** work — while `propose_action` stays the path for the common in-context single booking.

## Use cases moved to ✅ (were ❌ BROKEN)

- "Cancel all my meetings tomorrow" · "Cancel the standup series" · "Push everything Friday back an hour"
- "Reschedule the demo I had in March" / far-future / the-one-of-two-you-meant → now actionable via uid.

## Testing
- web typecheck ✅ · web tests ✅ (159) · biome ✅. Verified `/api/ai/act` executes any non-read registry tool (no allowlist); a bulk op is a single confirmed act call. Server tools + prompt only (no client/RSC change).
