### PR TITLE
fix(ai): event-type passthrough on create + guest-email honesty (roadmap 4/5)

### DIFF
--- a/apps/mobile/src/components/otter-launcher.tsx
+++ b/apps/mobile/src/components/otter-launcher.tsx
@@ -38,6 +38,8 @@ interface Draft {
   durationMinutes: number;
   attendees: { name: string; email: string }[];
   notes: string;
+  /** Slug of a matched event type, so the booking maps to the real type. */
+  eventTypeSlug?: string;
   newStartISO: string;
   message: string;
 }
@@ -243,6 +245,9 @@ function OtterSheet({ onClose }: { onClose: () => void }) {
           durationMinutes: draft.durationMinutes,
           notes: draft.notes || undefined,
           attendees: draft.attendees,
+          // Map to the real event type when one was matched, so its location,
+          // workflows and reminders apply (not the hidden Personal type).
+          eventTypeSlug: draft.eventTypeSlug || undefined,
         });
         finish("Added to your calendar.");
       } else if (draft.intent === "reschedule" && target) {

--- a/apps/web/components/ai-assistant.tsx
+++ b/apps/web/components/ai-assistant.tsx
@@ -230,6 +230,9 @@ export function AiAssistant({
         durationMinutes: duration,
         notes: notes || undefined,
         attendees: action.draft.attendees,
+        // Carry the matched event type so the booking maps to the real type (its
+        // location, workflows and reminders apply) instead of the Personal type.
+        eventTypeSlug: action.matchedEventType?.slug,
       }),
     });
     setBusy(false);

--- a/apps/web/lib/ai/command-parse.ts
+++ b/apps/web/lib/ai/command-parse.ts
@@ -62,6 +62,7 @@ Rules:
 - understood: true only if you can produce an actionable draft; false otherwise.
 - Resolve all times to ABSOLUTE ISO-8601 instants using the provided current time and timezone. Interpret vague times in the user's local timezone ("morning"=09:00, "afternoon"=14:00, "evening"=18:00). Never pick a past time.
 - For create: kind, a short title, startISO, durationMinutes, attendees (name + email if given, else empty email), notes.
+- Attendees are only INVITED if you have their email address - an attendee with an empty email is dropped and gets no invite. If the user clearly wants to invite a named person but gives no email (e.g. "book a call with Dana"), don't invent one: either ask for their email (intent "none", put the question in message), or, if they just want the time held, proceed and make clear in message that that person won't be emailed. Never silently imply someone was invited when they weren't.
 - Event types: you are given the user's event types (title + default duration). If a create request clearly matches one (e.g. "book a sync" → the "Sync" type), set eventTypeSlug to its slug and use that type's default duration. Otherwise eventTypeSlug = "" and default durationMinutes to 30 (meeting) / 60 (focus).
 - For reschedule/cancel: set bookingRef to the exact ref of the intended booking. If several bookings could match and you can't tell, use intent "none" and ask which one in message.
 - bookingRef must be 0 for create/none.


### PR DESCRIPTION
**PR 4 of the Otter coverage roadmap.** Two create-path correctness fixes.

> Stacked on #183 → #182 → #181 → #180 → #179. Retargets to `main` as those merge.

## 1. Matched event type was silently dropped on create (data loss)

When Otter matched a request to a real event type ("book an intro call", "schedule a sync"), the web and mobile confirm cards POSTed the new booking **without `eventTypeSlug`**. So `createHostBooking` fell back to the hidden **Personal** type — and the matched type's **location, workflows, buffers, and reminders never applied** (only its duration survived, as a prefill).

The create route and booking engine already accept `eventTypeSlug` — the clients just weren't sending it. Now both forward it:
- web: `action.matchedEventType?.slug`
- mobile: `draft.eventTypeSlug` (added to the mobile `Draft` type, which was omitting it)

→ "Book a sync with the team" now creates a real *Sync* booking on the right link, with its workflows/reminders — not a bare Personal hold.

## 2. Named guests without an email were dropped silently

An attendee with an empty email is filtered out at write time — no invite, no notice. The shared parser prompt now tells the model **not to imply someone was invited when they weren't**: ask for the email, or state plainly in its reply that that person won't be emailed.

## Testing
- web typecheck ✅ · **mobile typecheck ✅** · biome ✅. Client + prompt only — no engine or schema change.
