### PR TITLE
feat(ai): command bar / mobile / SMS can now answer questions (#186)

### DIFF
--- a/apps/mobile/src/components/otter-launcher.tsx
+++ b/apps/mobile/src/components/otter-launcher.tsx
@@ -207,9 +207,15 @@ function OtterSheet({ onClose }: { onClose: () => void }) {
     setDone(null);
     resetDraft();
     try {
-      const data = await api.post<{ draft: Draft; target: Target | null }>("/api/ai/command", {
-        text: input,
-      });
+      const data = await api.post<{ answer?: string; draft: Draft; target: Target | null }>(
+        "/api/ai/command",
+        { text: input },
+      );
+      // A question / out-of-scope ask → a spoken text answer, nothing to confirm.
+      if (data.answer) {
+        finish(data.answer);
+        return;
+      }
       const d = data.draft;
       if (!d.understood || d.intent === "none") {
         setError(d.message || "I can only help with scheduling.");

--- a/apps/web/app/api/ai/command/route.ts
+++ b/apps/web/app/api/ai/command/route.ts
@@ -34,7 +34,13 @@ export const POST = withUser(async (u, request) => {
   if (!parsed.success) return jsonError("Enter a request", 400);
 
   try {
-    const { draft, target, matchedEventType } = await interpretOtterCommand(u.id, parsed.data.text);
+    const { draft, target, matchedEventType, answer } = await interpretOtterCommand(
+      u.id,
+      parsed.data.text,
+    );
+
+    // A question / out-of-scope ask → a plain-text reply, nothing to confirm.
+    if (answer) return NextResponse.json({ answer, draft, target: null });
 
     // Manage intent that couldn't be resolved to a real booking → tell the user.
     if ((draft.intent === "reschedule" || draft.intent === "cancel") && !target) {

--- a/apps/web/lib/ai/answer.ts
+++ b/apps/web/lib/ai/answer.ts
@@ -1,0 +1,171 @@
+import { DateTime } from "luxon";
+import { z } from "zod";
+import { FREE_SLOTS_TOOL, findFreeSlots } from "./agent";
+import { capabilitySummary } from "./catalogue";
+import { GUARDRAIL_PREAMBLE } from "./guardrails";
+import {
+  type AgentToolResult,
+  type AgentToolSpec,
+  type AgentTurn,
+  type SystemBlock,
+  agentStep,
+  extract,
+} from "./llm";
+import { retrieveCalendarContext } from "./retrieval";
+import { executeReadTool } from "./tools/exec";
+import { TOOLS, getTool } from "./tools/registry";
+
+/**
+ * Read-only Q&A for the non-chat surfaces (command bar, mobile Ask bar, inbound
+ * SMS/WhatsApp). Those go through `interpret.ts`, which only ever produced a
+ * create/reschedule/cancel DRAFT - so any question ("how busy am I?", "when's my
+ * next meeting?") was answered with "I only help with scheduling". This adds a
+ * text answer path: a compact, read-only agentic loop that grounds its reply in
+ * the same tools the chat assistant uses, then returns plain text.
+ *
+ * Read-only by construction: only read tools + find_free_slots are offered, so a
+ * one-shot ask can never mutate anything (no confirm step exists on these
+ * surfaces).
+ */
+
+/** How the interpret layer should handle a request. */
+export type RequestClass = "action" | "question" | "other";
+
+const classifySchema = z.object({ label: z.enum(["action", "question", "other"]) });
+
+const CLASSIFY_SYSTEM = `${GUARDRAIL_PREAMBLE}
+
+Classify the user's message into exactly one label:
+- "action": they want to CREATE, MOVE / RESCHEDULE, or CANCEL something on their calendar (book a meeting, hold focus time, move their 3pm, cancel a booking, set out of office, change a setting).
+- "question": they are ASKING about their schedule, availability, bookings, analytics, or how DayOtter works, with NO change requested (e.g. "how busy am I this week?", "when's my next meeting?", "am I free Friday at 2pm?", "how do I reduce no-shows?").
+- "other": not about the user's calendar or scheduling at all.
+Return only the label.`;
+
+/**
+ * Decide whether a request is an action to draft, a question to answer, or out
+ * of scope. One cheap classification call; keeps the answer path off the shared
+ * command-draft schema (so the chat/action path is untouched).
+ */
+export async function classifyRequest(text: string): Promise<RequestClass> {
+  try {
+    const { label } = await extract({
+      feature: "otter-classify",
+      system: CLASSIFY_SYSTEM,
+      user: text,
+      tier: "fast",
+      maxTokens: 8,
+      inputSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: { label: { type: "string", enum: ["action", "question", "other"] } },
+        required: ["label"],
+      },
+      parse: (i) => classifySchema.parse(i),
+    });
+    return label;
+  } catch {
+    // If the classifier fails, fall back to treating it as an action (the
+    // existing, safe, confirm-first path) rather than guessing an answer.
+    return "action";
+  }
+}
+
+const ANSWER_SYSTEM = `You are Otter, DayOtter's friendly scheduling assistant, answering the host's question about their own calendar. Reply in a warm, natural voice - usually one or two sentences, no markdown.
+
+You are READ-ONLY here: look things up with the tools, but you never change anything (this surface has no confirm step). NEVER guess times, counts, or availability - call a tool to get real data:
+- get_agenda / search_bookings for what's on the calendar; analyze_schedule for counts, hours, "when do I finish", conflicts, longest gap.
+- check_availability for "am I free at X"; find_free_slots for bookable openings.
+- list_booking_types, get_availability, get_preferences, list_out_of_office, get_analytics for setup/analytics questions; search_knowledge for how-to questions.
+If the request isn't about the host's calendar or scheduling, briefly say you only help with their schedule. If they want to CHANGE something, tell them to ask directly (e.g. "book…", "move…", "cancel…") - you can't make changes from here.`;
+
+/** Read tools only (never write/destructive), so this loop can't mutate anything. */
+function readToolSpecs(): AgentToolSpec[] {
+  return TOOLS.filter((t) => t.kind === "read").map((t) => ({
+    name: t.name,
+    description: t.description,
+    schema: t.schema,
+  }));
+}
+
+const MAX_STEPS = 4;
+
+/**
+ * Answer a calendar question as plain text, grounded in real reads. Returns a
+ * short natural-language reply (never mutates). Used by the non-chat surfaces.
+ */
+export async function answerCalendarQuestion(userId: string, text: string): Promise<string> {
+  const ctx = await retrieveCalendarContext(userId, text);
+  const tz = ctx.timezone;
+  const bookingList = ctx.bookings.length
+    ? ctx.bookings
+        .map((b) => {
+          const when = DateTime.fromJSDate(b.startsAt)
+            .setZone(tz)
+            .toFormat("ccc, LLL d 'at' h:mm a");
+          return `- "${b.title}" - ${when}${b.attendees.length ? ` (with ${b.attendees.join(", ")})` : ""}`;
+        })
+        .join("\n")
+    : "(none)";
+  const externalList = ctx.externalEvents.length
+    ? ctx.externalEvents
+        .map((e) => {
+          const s = DateTime.fromJSDate(e.startsAt).setZone(tz);
+          const en = DateTime.fromJSDate(e.endsAt).setZone(tz);
+          return `- "${e.title}" - ${s.toFormat("ccc, LLL d 'at' h:mm a")}–${en.toFormat("h:mm a")}`;
+        })
+        .join("\n")
+    : "(none)";
+  const block = `Current time: ${new Date().toISOString()} (timezone: ${tz})
+
+The host's upcoming DayOtter bookings:
+${bookingList}
+
+The host's synced calendar events (busy time from connected calendars, read-only):
+${externalList}`;
+
+  const system: SystemBlock[] = [
+    { text: GUARDRAIL_PREAMBLE, cache: true },
+    { text: ANSWER_SYSTEM, cache: true },
+    { text: capabilitySummary(), cache: true },
+    { text: block },
+  ];
+  const tools: AgentToolSpec[] = [FREE_SLOTS_TOOL, ...readToolSpecs()];
+  const history: AgentTurn[] = [{ role: "user", text }];
+
+  let fullText = "";
+  for (let step = 0; step < MAX_STEPS; step++) {
+    const res = await agentStep({
+      system,
+      history,
+      tools,
+      tier: "deep",
+      effort: "low",
+      maxTokens: 800,
+      onToken: (t) => {
+        fullText += t;
+      },
+    });
+    const reads = res.toolCalls.filter(
+      (c) => c.name === "find_free_slots" || getTool(c.name)?.kind === "read",
+    );
+    if (reads.length === 0) break;
+    history.push({ role: "assistant_raw", raw: res.assistant });
+    const results: AgentToolResult[] = [];
+    for (const call of reads) {
+      const content =
+        call.name === "find_free_slots"
+          ? await findFreeSlots(
+              userId,
+              call.input as { durationMinutes: number; fromISO: string; toISO: string },
+              tz,
+            ).catch(() => "Could not look up availability.")
+          : await executeReadTool(userId, call.name, call.input).catch(
+              () => "Could not read that.",
+            );
+      results.push({ id: call.id, content });
+    }
+    history.push({ role: "tool_results", results });
+  }
+
+  return fullText.trim() || "I couldn't work that out - try asking a bit differently.";
+}

--- a/apps/web/lib/ai/interpret.ts
+++ b/apps/web/lib/ai/interpret.ts
@@ -1,5 +1,7 @@
+import { eq, getDb, schema } from "@dayotter/db";
 import { DateTime } from "luxon";
 import { runSchedulingAgent } from "./agent";
+import { answerCalendarQuestion, classifyRequest } from "./answer";
 import { type BookingContext, type CommandDraft, parseCommand } from "./command-parse";
 import { recallFreshMemory, summarizeMemory } from "./memory";
 import { retrieveCalendarContext } from "./retrieval";
@@ -25,6 +27,35 @@ export interface OtterInterpretation {
   target: OtterTarget | null;
   /** For create: the matched event type, when the request named one. */
   matchedEventType: { title: string; slug: string; durationMinutes: number } | null;
+  /** A plain-text reply for a question / out-of-scope request (no draft to confirm). */
+  answer: string | null;
+}
+
+/** A benign "nothing to confirm" draft, returned alongside a text `answer`. */
+function noneDraft(message: string): CommandDraft {
+  return {
+    reasoning: "",
+    understood: false,
+    intent: "none",
+    kind: "meeting",
+    title: "",
+    startISO: "",
+    durationMinutes: 30,
+    attendees: [],
+    notes: "",
+    eventTypeSlug: "",
+    bookingRef: 0,
+    newStartISO: "",
+    message,
+  };
+}
+
+async function userTimezone(userId: string): Promise<string> {
+  const u = await getDb().query.users.findFirst({
+    where: eq(schema.users.id, userId),
+    columns: { timezone: true },
+  });
+  return u?.timezone ?? "UTC";
 }
 
 /**
@@ -42,6 +73,22 @@ export async function interpretOtterCommand(
   userId: string,
   text: string,
 ): Promise<OtterInterpretation> {
+  // First decide what kind of request this is. Questions and out-of-scope asks
+  // get a text answer (these surfaces have no chat, so historically they could
+  // only ever return "I help with scheduling"); only actions go on to drafting.
+  const cls = await classifyRequest(text);
+  if (cls !== "action") {
+    const [answer, tz] = await Promise.all([
+      cls === "question"
+        ? answerCalendarQuestion(userId, text)
+        : Promise.resolve(
+            "I can only help with your calendar and scheduling - ask me about your schedule, or tell me what to book, move, or cancel.",
+          ),
+      userTimezone(userId),
+    ]);
+    return { draft: noneDraft(answer), timezone: tz, target: null, matchedEventType: null, answer };
+  }
+
   // RAG-lite: retrieve only the bookings relevant to this request. This
   // retrieved list is the source of truth for the model's booking refs. In
   // parallel, recall (and self-refresh) Otter's memory of this user.
@@ -82,5 +129,5 @@ export async function interpretOtterCommand(
     if (b) target = { uid: b.uid, title: b.title, startISO: b.startsAt.toISOString() };
   }
 
-  return { draft, timezone: tz, target, matchedEventType };
+  return { draft, timezone: tz, target, matchedEventType, answer: null };
 }

--- a/apps/web/lib/messaging/otter-sms.ts
+++ b/apps/web/lib/messaging/otter-sms.ts
@@ -42,7 +42,10 @@ function whenLabel(iso: string, tz: string): string {
  * "reply YES to confirm" prompt - confirm-first, over text.
  */
 export async function interpretForSms(userId: string, text: string): Promise<InterpretResult> {
-  const { draft, timezone: tz, target } = await interpretOtterCommand(userId, text);
+  const { draft, timezone: tz, target, answer } = await interpretOtterCommand(userId, text);
+
+  // A question / out-of-scope ask → text the answer straight back, nothing to confirm.
+  if (answer) return { reply: answer };
 
   if (!draft.understood || draft.intent === "none") {
     return {

--- a/docs/AI.md
+++ b/docs/AI.md
@@ -62,9 +62,14 @@ its own client**, which is what makes the model layer swappable.
 
 ### The interpret core - `lib/ai/interpret.ts`
 `interpretOtterCommand(userId, text)` is the shared brain for every non-chat
-surface. It recalls memory + retrieves relevant bookings in parallel, then routes:
-availability-dependent requests go through the agentic loop; everything else
-through the fast single-shot parser. Returns a confirm-first draft. Never writes.
+surface (command bar, mobile Ask bar, inbound SMS/WhatsApp). It first classifies
+the request (`lib/ai/answer.ts` `classifyRequest`): an **action** goes to the
+drafter (availability-dependent requests through the agentic loop, everything
+else through the fast single-shot parser) and returns a confirm-first draft; a
+**question** goes to `answerCalendarQuestion` - a read-only agentic loop over the
+same read tools the chat assistant uses - and comes back as a plain-text `answer`
+(so these surfaces can finally reply to "how busy am I?" / "when's my next
+meeting?" instead of only "I help with scheduling"). Never writes.
 
 ### The tool registry - `lib/ai/tools/`
 A declarative catalog where each tool is tagged `read` / `write` / `destructive`


### PR DESCRIPTION
Implements [#186](https://github.com/Dayotter/dayotter/issues/186) — the highest-impact remaining gap from the coverage audit. Branches off `main` (clean, not stacked).

## The gap

The interpret path (web command bar, mobile Ask bar, inbound SMS/WhatsApp) could only ever produce a create/reschedule/cancel **draft**. Any *question* — "how busy am I?", "when's my next meeting?", "am I free Friday?" — got **"I only help with scheduling."** An entire surface family couldn't answer a single question. (The chat panel already could; this brings the lighter surfaces up to it.)

## The fix — a text-answer path, isolated from the action flow

`lib/ai/answer.ts` (new):
- **`classifyRequest(text)`** — one cheap `fast`-tier call → `action | question | other`. Keeps the answer path **off the shared command-draft schema**, so the chat/action path is untouched.
- **`answerCalendarQuestion(userId, text)`** — a **read-only** agentic loop over the same read tools the chat assistant uses (`get_agenda`, `analyze_schedule`, `search_bookings`, `check_availability`, `list_*`, `get_analytics`, `search_knowledge`, `find_free_slots`), grounded in a per-request context block, returning plain text. **Read-only by construction** — only read tools are offered, so a one-shot ask on a surface with no confirm step can never mutate anything.

Wiring:
- `interpret.ts` classifies first — questions → `answerCalendarQuestion`, out-of-scope → a short decline, actions → the existing drafting path unchanged. `OtterInterpretation` gains `answer: string | null`.
- `/api/ai/command` returns `{ answer }` when present; **mobile** speaks + shows it via `finish()`; **SMS** texts it straight back.

## Use cases → ✅ (were ❌ on these surfaces)

"How busy am I this week?" · "When's my next meeting?" · "Am I free Friday at 2pm?" · "How many meetings did I have last week?" · "How do I reduce no-shows?" — now answered from the command bar, mobile Ask bar, and over text. Requests to *change* something are steered back to action phrasing.

## Testing
- web typecheck ✅ · **mobile typecheck ✅** · web tests ✅ (165) · biome ✅. `interpret.ts`/`answer.ts` confirmed server-only (no client bundle pulls in the DB import).
