### PR TITLE
feat(ai): edit an existing booking — title / location / attendees (#187)

### DIFF
--- a/apps/web/lib/ai/chat.ts
+++ b/apps/web/lib/ai/chat.ts
@@ -65,6 +65,7 @@ HOW YOU WORK:
 - Resolve every time to an absolute ISO-8601 instant in the host's timezone. Never pick a past time. Interpret vague times locally (morning=09:00, afternoon=14:00, evening=18:00).
 - For reschedule/cancel, set bookingRef to the exact ref of the intended booking. If several could match and you can't tell, DON'T propose - just ask which one in your reply.
 - propose_action works on the bookings listed in context (each has a ref). To act on a booking that ISN'T listed - one from search_bookings, a past or far-future meeting, or when you need its uid - use reschedule_booking (one booking, by uid) or cancel_bookings (one or more uids). For BULK requests ("cancel all my meetings tomorrow", "push everything Friday back an hour") call search_bookings for the window FIRST to get the uids, then cancel_bookings(uids) or shift_bookings(uids, deltaMinutes). To cancel a whole recurring series, use cancel_bookings with scope "series". These are one confirm card for the whole batch.
+- To change a booking's DETAILS rather than its time (rename it, change its location, add or remove a guest by email) use update_booking with its uid - "rename my 3pm to Budget review", "move the review to Zoom", "add priya@acme.com to my standup". (Reschedule is still for changing the time.)
 - If you're only answering a question (not proposing a change), reply in plain text and do not call propose_action.
 
 BEYOND BOOKINGS - you can also read and control the rest of the host's setup with these tools:

--- a/apps/web/lib/ai/tools/exec.ts
+++ b/apps/web/lib/ai/tools/exec.ts
@@ -10,6 +10,7 @@ import { resolveScheduleId } from "@/lib/booking/schedule";
 import { ensureUserWorkspace } from "@/lib/bootstrap";
 import { getAgenda } from "@/lib/calendar/agenda";
 import { type BusyItem, analyzeSchedule } from "@/lib/calendar/analyze";
+import { updateBookingCalendarEvent } from "@/lib/calendar/host-calendar";
 import { recurringBlockOccurrences } from "@/lib/calendar/recurrence";
 import {
   channelInputSchema,
@@ -777,6 +778,106 @@ export async function executeActionTool(
           const msg = err instanceof Error ? err.message : "that time wasn't available";
           return { ok: false, message: `Couldn't move “${owned.title}” - ${msg}.` };
         }
+      }
+
+      case "update_booking": {
+        const uid = input.uid as string;
+        const booking = await db.query.bookings.findFirst({
+          where: and(eq(schema.bookings.uid, uid), eq(schema.bookings.hostId, userId)),
+          columns: {
+            id: true,
+            status: true,
+            title: true,
+            description: true,
+            startsAt: true,
+            endsAt: true,
+            timezone: true,
+            location: true,
+          },
+          with: { attendees: { columns: { email: true, name: true } } },
+        });
+        if (!booking || booking.status === "cancelled") {
+          return { ok: false, message: "I couldn't find that booking." };
+        }
+
+        // Field changes on the booking row.
+        const set: Record<string, unknown> = {};
+        if (input.title !== undefined) set.title = input.title;
+        if (input.notes !== undefined) set.description = input.notes;
+        if (input.location !== undefined) {
+          set.locationType = input.location;
+          if (input.locationDetail !== undefined) set.location = input.locationDetail;
+        } else if (input.locationDetail !== undefined) {
+          set.location = input.locationDetail;
+        }
+
+        // Attendee add/remove, de-duplicated against the current list.
+        const removeEmails = new Set(
+          ((input.removeGuests as string[] | undefined) ?? []).map((e) => e.toLowerCase()),
+        );
+        const currentEmails = new Set(booking.attendees.map((a) => a.email.toLowerCase()));
+        const toAdd = ((input.addGuests as { email: string; name?: string }[] | undefined) ?? [])
+          .filter((g) => g.email.includes("@"))
+          .filter((g) => !currentEmails.has(g.email.toLowerCase()));
+
+        if (Object.keys(set).length === 0 && toAdd.length === 0 && removeEmails.size === 0) {
+          return { ok: false, message: "Tell me what to change on that booking." };
+        }
+
+        if (Object.keys(set).length > 0) {
+          await db.update(schema.bookings).set(set).where(eq(schema.bookings.id, booking.id));
+        }
+        if (removeEmails.size > 0) {
+          await db
+            .delete(schema.bookingAttendees)
+            .where(eq(schema.bookingAttendees.bookingId, booking.id));
+          // Re-insert the survivors + additions below in one pass.
+        }
+        const survivors = booking.attendees.filter((a) => !removeEmails.has(a.email.toLowerCase()));
+        const finalAttendees = [
+          ...survivors.map((a) => ({ email: a.email, name: a.name ?? undefined })),
+          ...toAdd.map((g) => ({ email: g.email, name: g.name })),
+        ];
+        if (removeEmails.size > 0 || toAdd.length > 0) {
+          if (removeEmails.size === 0) {
+            // Only additions - insert just the new ones.
+            if (toAdd.length > 0) {
+              await db.insert(schema.bookingAttendees).values(
+                toAdd.map((g) => ({
+                  bookingId: booking.id,
+                  email: g.email,
+                  name: g.name ?? null,
+                  timezone: booking.timezone,
+                })),
+              );
+            }
+          } else if (finalAttendees.length > 0) {
+            // We cleared the table above; rewrite the full surviving + added set.
+            await db.insert(schema.bookingAttendees).values(
+              finalAttendees.map((a) => ({
+                bookingId: booking.id,
+                email: a.email,
+                name: a.name ?? null,
+                timezone: booking.timezone,
+              })),
+            );
+          }
+        }
+
+        // Push the change to the connected calendar (best-effort). The provider
+        // sends updated invites to attendees, so no separate email is needed.
+        await updateBookingCalendarEvent(booking.id, {
+          title: (set.title as string) ?? booking.title,
+          description: (set.description as string) ?? booking.description ?? undefined,
+          start: booking.startsAt,
+          end: booking.endsAt,
+          timezone: booking.timezone,
+          attendees: finalAttendees,
+          location: (set.location as string) ?? booking.location ?? undefined,
+          createConference: false,
+        }).catch(() => undefined);
+
+        return { ok: true, message: `Updated “${(set.title as string) ?? booking.title}”.` };
       }
 
       case "shift_bookings": {

--- a/apps/web/lib/ai/tools/registry.ts
+++ b/apps/web/lib/ai/tools/registry.ts
@@ -985,6 +985,67 @@ export const TOOLS: AiToolDef[] = [
         : `Set ${i.date} hours to ${i.start}–${i.end}`,
   },
   {
+    name: "update_booking",
+    description:
+      "Edit an existing booking's details (NOT its time - use reschedule for that) by its public id (uid, from search_bookings or context). Change the title, the notes/description, the location, and/or add or remove guests by email. Only the fields you pass change; attendees are notified via the updated calendar invite. Confirm-first.",
+    kind: "write",
+    confirmLevel: "confirm",
+    schema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        uid: { type: "string", description: "The booking's public id." },
+        title: { type: "string", description: "New title." },
+        notes: { type: "string", description: "New description / notes." },
+        location: { type: "string", enum: LOCATIONS as unknown as string[] },
+        locationDetail: {
+          type: "string",
+          description: "Address, phone number, or meeting link for the location.",
+        },
+        addGuests: {
+          type: "array",
+          description: "Guests to invite (need an email).",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            properties: { email: { type: "string" }, name: { type: "string" } },
+            required: ["email"],
+          },
+        },
+        removeGuests: {
+          type: "array",
+          items: { type: "string" },
+          description: "Emails of guests to remove.",
+        },
+      },
+      required: ["uid"],
+    },
+    zod: z.object({
+      uid: z.string().min(1).max(120),
+      title: z.string().min(1).max(200).optional(),
+      notes: z.string().max(2000).optional(),
+      location: z.enum(LOCATIONS).optional(),
+      locationDetail: z.string().max(500).optional(),
+      addGuests: z
+        .array(z.object({ email: z.string().email(), name: z.string().max(120).optional() }))
+        .max(20)
+        .optional(),
+      removeGuests: z.array(z.string().email()).max(20).optional(),
+    }),
+    title: "Edit booking",
+    summarize: (i) => {
+      const parts: string[] = [];
+      if (i.title !== undefined) parts.push("title");
+      if (i.notes !== undefined) parts.push("notes");
+      if (i.location !== undefined) parts.push("location");
+      const add = (i.addGuests as unknown[] | undefined)?.length ?? 0;
+      const rem = (i.removeGuests as unknown[] | undefined)?.length ?? 0;
+      if (add) parts.push(`add ${add} guest${add === 1 ? "" : "s"}`);
+      if (rem) parts.push(`remove ${rem} guest${rem === 1 ? "" : "s"}`);
+      return `Edit this booking: ${parts.length ? parts.join(", ") : "no changes"}`;
+    },
+  },
+  {
     name: "reschedule_booking",
     description:
       "Move ONE booking to a new time by its public id (uid). Use this to act on a specific booking you found with search_bookings - a past, far-future, or otherwise not-in-context meeting, or to resolve which of several you mean. For the common case of moving a booking that's already listed in the context, use propose_action instead. Confirm-first.",


### PR DESCRIPTION
Implements [#187](https://github.com/Dayotter/dayotter/issues/187). Branches off `main`.

## The gap

Bookings could only be **created, time-moved (reschedule), or cancelled** — no way to change a booking's **title, location, or attendees**. "Rename my 3pm", "move it to Zoom", "add Priya" all failed.

## The fix — `update_booking`

`update_booking { uid, title?, notes?, location?, locationDetail?, addGuests?, removeGuests? }` — write, confirm-first, **host-ownership guarded**:
- updates the booking row (title / description / locationType + location),
- **adds/removes attendees by email**, de-duplicated against the current list,
- **re-syncs the connected calendar** via `updateBookingCalendarEvent`, so the provider pushes updated invites to attendees — no separate email path needed.

The system prompt steers the model to `update_booking` for *detail* changes; reschedule stays for *time* changes.

## Use cases → ✅ (were ❌ MISSING)

"Rename my 3pm to Budget review" · "Move the review to Zoom" · "Add priya@acme.com to my standup" · "Take Bob off the sync".

## Scope note

Changing to a conferencing location doesn't auto-generate a fresh Meet/Zoom link here (`createConference:false`) — it records the location and updates the calendar event; link regeneration stays with the event-type/conferencing path.

## Testing
- web typecheck ✅ · web tests ✅ (165) · biome ✅. Routes through the existing confirm-card `/api/ai/act` pathway; execution only after the user confirms.
