### PR TITLE
feat(ai): hold "focus" drafts as real focus blocks (#188, part)

### DIFF
--- a/apps/mobile/src/components/otter-launcher.tsx
+++ b/apps/mobile/src/components/otter-launcher.tsx
@@ -248,6 +248,8 @@ function OtterSheet({ onClose }: { onClose: () => void }) {
           // Map to the real event type when one was matched, so its location,
           // workflows and reminders apply (not the hidden Personal type).
           eventTypeSlug: draft.eventTypeSlug || undefined,
+          // "focus" is held as a personal focus block, not a meeting.
+          kind: draft.kind,
         });
         finish("Added to your calendar.");
       } else if (draft.intent === "reschedule" && target) {

--- a/apps/web/app/api/ai/schedule/create/route.ts
+++ b/apps/web/app/api/ai/schedule/create/route.ts
@@ -1,5 +1,6 @@
 import { aiEnabled } from "@/lib/ai/schedule-parse";
 import { createHostBooking } from "@/lib/booking/host-booking";
+import { writeBookingToCalendar } from "@/lib/calendar/host-calendar";
 import { jsonError, withUser } from "@/lib/server/http";
 import { enforceRateLimit } from "@/lib/server/rate-limit";
 import { logger } from "@dayotter/core";
@@ -20,6 +21,8 @@ const body = z.object({
     .default([]),
   /** Optional: a real event type the create maps to (so its workflows apply). */
   eventTypeSlug: z.string().max(200).optional(),
+  /** "focus" is held as a personal focus block (not a meeting/booking). */
+  kind: z.enum(["meeting", "focus", "reminder"]).optional(),
 });
 
 /**
@@ -56,13 +59,47 @@ export const POST = withUser(async (u, request) => {
     .filter((a) => a.email.includes("@"))
     .map((a) => ({ email: a.email, name: a.name || undefined }));
 
+  const timezone = user?.timezone ?? "UTC";
+
+  // A "focus" draft is a personal hold, not a meeting: write it as a focus
+  // time_block (blocks bookable availability, no attendees/reminders/invite) and
+  // best-effort mirror it to the calendar - the same shape as protect_focus_time.
+  if (d.kind === "focus") {
+    try {
+      await getDb().insert(schema.timeBlocks).values({
+        userId: u.id,
+        title: d.title,
+        kind: "focus",
+        startsAt: start,
+        endsAt: end,
+        seriesId: null,
+      });
+      await writeBookingToCalendar(u.id, {
+        title: d.title,
+        start,
+        end,
+        timezone,
+        attendees: [],
+      }).catch(() => null);
+      logger.info("ai focus block created", { event: "ai_focus_block_created", userId: u.id });
+      return NextResponse.json({ ok: true });
+    } catch (err) {
+      logger.error("ai focus block create failed", {
+        event: "ai_focus_block_failed",
+        userId: u.id,
+        err,
+      });
+      return jsonError("Couldn't hold that focus time. Please try again.", 502);
+    }
+  }
+
   try {
     const result = await createHostBooking({
       userId: u.id,
       title: d.title,
       start,
       end,
-      timezone: user?.timezone ?? "UTC",
+      timezone,
       notes: d.notes,
       attendees,
       eventTypeSlug: d.eventTypeSlug,

--- a/apps/web/components/ai-assistant.tsx
+++ b/apps/web/components/ai-assistant.tsx
@@ -233,6 +233,8 @@ export function AiAssistant({
         // Carry the matched event type so the booking maps to the real type (its
         // location, workflows and reminders apply) instead of the Personal type.
         eventTypeSlug: action.matchedEventType?.slug,
+        // "focus" is held as a personal focus block, not a meeting.
+        kind: action.draft.kind,
       }),
     });
     setBusy(false);

--- a/apps/web/lib/messaging/otter-sms.ts
+++ b/apps/web/lib/messaging/otter-sms.ts
@@ -2,7 +2,9 @@ import { interpretOtterCommand } from "@/lib/ai/interpret";
 import { cancelBooking } from "@/lib/booking/cancel-booking";
 import { createHostBooking } from "@/lib/booking/host-booking";
 import { rescheduleBooking } from "@/lib/booking/reschedule-booking";
+import { writeBookingToCalendar } from "@/lib/calendar/host-calendar";
 import { logger } from "@dayotter/core";
+import { getDb, schema } from "@dayotter/db";
 import { DateTime } from "luxon";
 
 /**
@@ -20,6 +22,8 @@ export type PendingAction =
       attendees: { name: string; email: string }[];
       timezone: string;
       eventTypeSlug?: string;
+      /** "focus" is held as a personal focus block, not a meeting. */
+      kind?: "meeting" | "focus" | "reminder";
     }
   | { intent: "reschedule"; uid: string; newStartISO: string; title: string; timezone: string }
   | { intent: "cancel"; uid: string; title: string };
@@ -65,6 +69,7 @@ export async function interpretForSms(userId: string, text: string): Promise<Int
         attendees: draft.attendees,
         timezone: tz,
         eventTypeSlug: draft.eventTypeSlug || undefined,
+        kind: draft.kind,
       },
     };
   }
@@ -100,6 +105,27 @@ export async function executePending(userId: string, pending: PendingAction): Pr
     if (pending.intent === "create") {
       const start = new Date(pending.startISO);
       const end = new Date(start.getTime() + pending.durationMinutes * 60_000);
+
+      // A "focus" hold is a personal focus block, not a meeting/booking.
+      if (pending.kind === "focus") {
+        await getDb().insert(schema.timeBlocks).values({
+          userId,
+          title: pending.title,
+          kind: "focus",
+          startsAt: start,
+          endsAt: end,
+          seriesId: null,
+        });
+        await writeBookingToCalendar(userId, {
+          title: pending.title,
+          start,
+          end,
+          timezone: pending.timezone,
+          attendees: [],
+        }).catch(() => null);
+        return `Done ✓ Focus time "${pending.title}" is held for ${whenLabel(pending.startISO, pending.timezone)}.`;
+      }
+
       const attendees = pending.attendees
         .filter((a) => a.email.includes("@"))
         .map((a) => ({ email: a.email, name: a.name || undefined }));


### PR DESCRIPTION
Implements the clean, self-contained half of [#188](https://github.com/Dayotter/dayotter/issues/188). Branches off `main`.

## The gap

A create draft with `kind: "focus"` ("hold 2 hours of deep work tomorrow") was executed by `createHostBooking` as a **regular booking** — a confirmed *meeting* on the calendar, not a personal focus hold. The chat assistant already does this right via its dedicated focus tools; this fixes the **draft path** (mobile Ask bar, SMS/WhatsApp, and web `propose_action` create).

## The fix

- `/api/ai/schedule/create` accepts `kind`; a `"focus"` create is written as a **`timeBlocks` focus hold** (blocks bookable availability, no attendees/invite) and best-effort mirrored to the calendar — the same shape as `protect_focus_time`.
- web, mobile, and SMS confirm paths now send the draft's `kind`. SMS `executePending` holds a focus block for `kind: "focus"` instead of booking a meeting.

→ "Hold 2 hours of focus tomorrow" from the mobile Ask bar or over text now creates a real **focus block**, not a meeting.

## Kept open in #188

- **Ad-hoc conferencing location** on the create path ("45-min review on Zoom" with no matching event type) — needs the shared draft schema + conferencing plumbing; #184 already carries a *matched event type's* location through.
- **Reminders as true notifications** rather than calendar holds — needs a notifications primitive.

## Testing
- web typecheck ✅ · mobile typecheck ✅ · web tests ✅ (165) · biome ✅.
