### PR TITLE
chore(mobile): bump to 0.3.0 (versionCode 10) for Play Store

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -25,7 +25,7 @@
     },
     "android": {
       "package": "com.dayotter.app",
-      "versionCode": 10,
+      "versionCode": 11,
       "edgeToEdgeEnabled": true,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -4,7 +4,7 @@
     "slug": "dayotter",
     "owner": "dayotter",
     "scheme": "dayotter",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "orientation": "default",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": false,
@@ -17,7 +17,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.dayotter.app",
-      "buildNumber": "2",
+      "buildNumber": "3",
       "infoPlist": {
         "NSSpeechRecognitionUsageDescription": "DayOtter turns your spoken commands into scheduling actions.",
         "NSMicrophoneUsageDescription": "DayOtter uses the microphone so you can speak scheduling commands."
@@ -25,7 +25,7 @@
     },
     "android": {
       "package": "com.dayotter.app",
-      "versionCode": 9,
+      "versionCode": 10,
       "edgeToEdgeEnabled": true,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",


### PR DESCRIPTION
Release prep for the next Android (Play Store) submission.

`app.json` is the version source of truth (`eas.json` → `appVersionSource: local`):
- **version** `0.2.0` → **`0.3.0`**
- **android.versionCode** `9` → **`10`** — must exceed the `9` already sideloaded to the test device; the `production` profile also `autoIncrement`s from here.
- **ios.buildNumber** `2` → **`3`** (kept in step).

(`apps/mobile/android/` is gitignored — it's regenerated from `app.json` by `expo prebuild` / EAS at build time — so only `app.json` changes here.)

## ⚠️ Blocker to resolve before submitting (not a code change — flagging)

The Android **release** build type is currently signed with the **debug keystore** (`signingConfigs.debug`). That's fine for sideloading to a test device, but **Play Store rejects debug-signed bundles**. The real submission must use **EAS-managed signing**:

```bash
cd apps/mobile
eas login
eas build -p android --profile production   # builds a proper, upload-key-signed AAB
eas submit -p android --profile production   # needs a Play service-account key (yours to provide)
```

EAS provisions/stores the upload key in the cloud — I can't create or handle that key, so those two commands are yours to run under your account.

## Build verification

Ran a local `./gradlew :app:bundleRelease` against this branch to confirm the app compiles into an AAB (result in the PR thread / my message). The local artifact is debug-signed (not submittable) — it only proves the build is green; the submittable AAB comes from `eas build` above.
