### PR TITLE
feat(ai): mobile/SMS Q&A + edit-booking + focus-as-block (#186/#187/#188)

### DIFF
--- a/apps/mobile/src/components/otter-launcher.tsx
+++ b/apps/mobile/src/components/otter-launcher.tsx
@@ -248,6 +248,8 @@ function OtterSheet({ onClose }: { onClose: () => void }) {
           // Map to the real event type when one was matched, so its location,
           // workflows and reminders apply (not the hidden Personal type).
           eventTypeSlug: draft.eventTypeSlug || undefined,
+          // "focus" is held as a personal focus block, not a meeting.
+          kind: draft.kind,
         });
         finish("Added to your calendar.");
       } else if (draft.intent === "reschedule" && target) {

--- a/apps/mobile/src/components/otter-launcher.tsx
+++ b/apps/mobile/src/components/otter-launcher.tsx
@@ -207,9 +207,15 @@ function OtterSheet({ onClose }: { onClose: () => void }) {
     setDone(null);
     resetDraft();
     try {
-      const data = await api.post<{ draft: Draft; target: Target | null }>("/api/ai/command", {
-        text: input,
-      });
+      const data = await api.post<{ answer?: string; draft: Draft; target: Target | null }>(
+        "/api/ai/command",
+        { text: input },
+      );
+      // A question / out-of-scope ask → a spoken text answer, nothing to confirm.
+      if (data.answer) {
+        finish(data.answer);
+        return;
+      }
       const d = data.draft;
       if (!d.understood || d.intent === "none") {
         setError(d.message || "I can only help with scheduling.");

--- a/apps/web/app/api/ai/command/route.ts
+++ b/apps/web/app/api/ai/command/route.ts
@@ -34,7 +34,13 @@ export const POST = withUser(async (u, request) => {
   if (!parsed.success) return jsonError("Enter a request", 400);
 
   try {
-    const { draft, target, matchedEventType } = await interpretOtterCommand(u.id, parsed.data.text);
+    const { draft, target, matchedEventType, answer } = await interpretOtterCommand(
+      u.id,
+      parsed.data.text,
+    );
+
+    // A question / out-of-scope ask → a plain-text reply, nothing to confirm.
+    if (answer) return NextResponse.json({ answer, draft, target: null });
 
     // Manage intent that couldn't be resolved to a real booking → tell the user.
     if ((draft.intent === "reschedule" || draft.intent === "cancel") && !target) {

--- a/apps/web/app/api/ai/schedule/create/route.ts
+++ b/apps/web/app/api/ai/schedule/create/route.ts
@@ -1,5 +1,6 @@
 import { aiEnabled } from "@/lib/ai/schedule-parse";
 import { createHostBooking } from "@/lib/booking/host-booking";
+import { writeBookingToCalendar } from "@/lib/calendar/host-calendar";
 import { jsonError, withUser } from "@/lib/server/http";
 import { enforceRateLimit } from "@/lib/server/rate-limit";
 import { logger } from "@dayotter/core";
@@ -20,6 +21,8 @@ const body = z.object({
     .default([]),
   /** Optional: a real event type the create maps to (so its workflows apply). */
   eventTypeSlug: z.string().max(200).optional(),
+  /** "focus" is held as a personal focus block (not a meeting/booking). */
+  kind: z.enum(["meeting", "focus", "reminder"]).optional(),
 });
 
 /**
@@ -56,13 +59,47 @@ export const POST = withUser(async (u, request) => {
     .filter((a) => a.email.includes("@"))
     .map((a) => ({ email: a.email, name: a.name || undefined }));
 
+  const timezone = user?.timezone ?? "UTC";
+
+  // A "focus" draft is a personal hold, not a meeting: write it as a focus
+  // time_block (blocks bookable availability, no attendees/reminders/invite) and
+  // best-effort mirror it to the calendar - the same shape as protect_focus_time.
+  if (d.kind === "focus") {
+    try {
+      await getDb().insert(schema.timeBlocks).values({
+        userId: u.id,
+        title: d.title,
+        kind: "focus",
+        startsAt: start,
+        endsAt: end,
+        seriesId: null,
+      });
+      await writeBookingToCalendar(u.id, {
+        title: d.title,
+        start,
+        end,
+        timezone,
+        attendees: [],
+      }).catch(() => null);
+      logger.info("ai focus block created", { event: "ai_focus_block_created", userId: u.id });
+      return NextResponse.json({ ok: true });
+    } catch (err) {
+      logger.error("ai focus block create failed", {
+        event: "ai_focus_block_failed",
+        userId: u.id,
+        err,
+      });
+      return jsonError("Couldn't hold that focus time. Please try again.", 502);
+    }
+  }
+
   try {
     const result = await createHostBooking({
       userId: u.id,
       title: d.title,
       start,
       end,
-      timezone: user?.timezone ?? "UTC",
+      timezone,
       notes: d.notes,
       attendees,
       eventTypeSlug: d.eventTypeSlug,

--- a/apps/web/components/ai-assistant.tsx
+++ b/apps/web/components/ai-assistant.tsx
@@ -233,6 +233,8 @@ export function AiAssistant({
         // Carry the matched event type so the booking maps to the real type (its
         // location, workflows and reminders apply) instead of the Personal type.
         eventTypeSlug: action.matchedEventType?.slug,
+        // "focus" is held as a personal focus block, not a meeting.
+        kind: action.draft.kind,
       }),
     });
     setBusy(false);

--- a/apps/web/lib/ai/answer.ts
+++ b/apps/web/lib/ai/answer.ts
@@ -1,0 +1,171 @@
+import { DateTime } from "luxon";
+import { z } from "zod";
+import { FREE_SLOTS_TOOL, findFreeSlots } from "./agent";
+import { capabilitySummary } from "./catalogue";
+import { GUARDRAIL_PREAMBLE } from "./guardrails";
+import {
+  type AgentToolResult,
+  type AgentToolSpec,
+  type AgentTurn,
+  type SystemBlock,
+  agentStep,
+  extract,
+} from "./llm";
+import { retrieveCalendarContext } from "./retrieval";
+import { executeReadTool } from "./tools/exec";
+import { TOOLS, getTool } from "./tools/registry";
+
+/**
+ * Read-only Q&A for the non-chat surfaces (command bar, mobile Ask bar, inbound
+ * SMS/WhatsApp). Those go through `interpret.ts`, which only ever produced a
+ * create/reschedule/cancel DRAFT - so any question ("how busy am I?", "when's my
+ * next meeting?") was answered with "I only help with scheduling". This adds a
+ * text answer path: a compact, read-only agentic loop that grounds its reply in
+ * the same tools the chat assistant uses, then returns plain text.
+ *
+ * Read-only by construction: only read tools + find_free_slots are offered, so a
+ * one-shot ask can never mutate anything (no confirm step exists on these
+ * surfaces).
+ */
+
+/** How the interpret layer should handle a request. */
+export type RequestClass = "action" | "question" | "other";
+
+const classifySchema = z.object({ label: z.enum(["action", "question", "other"]) });
+
+const CLASSIFY_SYSTEM = `${GUARDRAIL_PREAMBLE}
+
+Classify the user's message into exactly one label:
+- "action": they want to CREATE, MOVE / RESCHEDULE, or CANCEL something on their calendar (book a meeting, hold focus time, move their 3pm, cancel a booking, set out of office, change a setting).
+- "question": they are ASKING about their schedule, availability, bookings, analytics, or how DayOtter works, with NO change requested (e.g. "how busy am I this week?", "when's my next meeting?", "am I free Friday at 2pm?", "how do I reduce no-shows?").
+- "other": not about the user's calendar or scheduling at all.
+Return only the label.`;
+
+/**
+ * Decide whether a request is an action to draft, a question to answer, or out
+ * of scope. One cheap classification call; keeps the answer path off the shared
+ * command-draft schema (so the chat/action path is untouched).
+ */
+export async function classifyRequest(text: string): Promise<RequestClass> {
+  try {
+    const { label } = await extract({
+      feature: "otter-classify",
+      system: CLASSIFY_SYSTEM,
+      user: text,
+      tier: "fast",
+      maxTokens: 8,
+      inputSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: { label: { type: "string", enum: ["action", "question", "other"] } },
+        required: ["label"],
+      },
+      parse: (i) => classifySchema.parse(i),
+    });
+    return label;
+  } catch {
+    // If the classifier fails, fall back to treating it as an action (the
+    // existing, safe, confirm-first path) rather than guessing an answer.
+    return "action";
+  }
+}
+
+const ANSWER_SYSTEM = `You are Otter, DayOtter's friendly scheduling assistant, answering the host's question about their own calendar. Reply in a warm, natural voice - usually one or two sentences, no markdown.
+
+You are READ-ONLY here: look things up with the tools, but you never change anything (this surface has no confirm step). NEVER guess times, counts, or availability - call a tool to get real data:
+- get_agenda / search_bookings for what's on the calendar; analyze_schedule for counts, hours, "when do I finish", conflicts, longest gap.
+- check_availability for "am I free at X"; find_free_slots for bookable openings.
+- list_booking_types, get_availability, get_preferences, list_out_of_office, get_analytics for setup/analytics questions; search_knowledge for how-to questions.
+If the request isn't about the host's calendar or scheduling, briefly say you only help with their schedule. If they want to CHANGE something, tell them to ask directly (e.g. "book…", "move…", "cancel…") - you can't make changes from here.`;
+
+/** Read tools only (never write/destructive), so this loop can't mutate anything. */
+function readToolSpecs(): AgentToolSpec[] {
+  return TOOLS.filter((t) => t.kind === "read").map((t) => ({
+    name: t.name,
+    description: t.description,
+    schema: t.schema,
+  }));
+}
+
+const MAX_STEPS = 4;
+
+/**
+ * Answer a calendar question as plain text, grounded in real reads. Returns a
+ * short natural-language reply (never mutates). Used by the non-chat surfaces.
+ */
+export async function answerCalendarQuestion(userId: string, text: string): Promise<string> {
+  const ctx = await retrieveCalendarContext(userId, text);
+  const tz = ctx.timezone;
+  const bookingList = ctx.bookings.length
+    ? ctx.bookings
+        .map((b) => {
+          const when = DateTime.fromJSDate(b.startsAt)
+            .setZone(tz)
+            .toFormat("ccc, LLL d 'at' h:mm a");
+          return `- "${b.title}" - ${when}${b.attendees.length ? ` (with ${b.attendees.join(", ")})` : ""}`;
+        })
+        .join("\n")
+    : "(none)";
+  const externalList = ctx.externalEvents.length
+    ? ctx.externalEvents
+        .map((e) => {
+          const s = DateTime.fromJSDate(e.startsAt).setZone(tz);
+          const en = DateTime.fromJSDate(e.endsAt).setZone(tz);
+          return `- "${e.title}" - ${s.toFormat("ccc, LLL d 'at' h:mm a")}–${en.toFormat("h:mm a")}`;
+        })
+        .join("\n")
+    : "(none)";
+  const block = `Current time: ${new Date().toISOString()} (timezone: ${tz})
+
+The host's upcoming DayOtter bookings:
+${bookingList}
+
+The host's synced calendar events (busy time from connected calendars, read-only):
+${externalList}`;
+
+  const system: SystemBlock[] = [
+    { text: GUARDRAIL_PREAMBLE, cache: true },
+    { text: ANSWER_SYSTEM, cache: true },
+    { text: capabilitySummary(), cache: true },
+    { text: block },
+  ];
+  const tools: AgentToolSpec[] = [FREE_SLOTS_TOOL, ...readToolSpecs()];
+  const history: AgentTurn[] = [{ role: "user", text }];
+
+  let fullText = "";
+  for (let step = 0; step < MAX_STEPS; step++) {
+    const res = await agentStep({
+      system,
+      history,
+      tools,
+      tier: "deep",
+      effort: "low",
+      maxTokens: 800,
+      onToken: (t) => {
+        fullText += t;
+      },
+    });
+    const reads = res.toolCalls.filter(
+      (c) => c.name === "find_free_slots" || getTool(c.name)?.kind === "read",
+    );
+    if (reads.length === 0) break;
+    history.push({ role: "assistant_raw", raw: res.assistant });
+    const results: AgentToolResult[] = [];
+    for (const call of reads) {
+      const content =
+        call.name === "find_free_slots"
+          ? await findFreeSlots(
+              userId,
+              call.input as { durationMinutes: number; fromISO: string; toISO: string },
+              tz,
+            ).catch(() => "Could not look up availability.")
+          : await executeReadTool(userId, call.name, call.input).catch(
+              () => "Could not read that.",
+            );
+      results.push({ id: call.id, content });
+    }
+    history.push({ role: "tool_results", results });
+  }
+
+  return fullText.trim() || "I couldn't work that out - try asking a bit differently.";
+}

--- a/apps/web/lib/ai/chat.ts
+++ b/apps/web/lib/ai/chat.ts
@@ -65,6 +65,7 @@ HOW YOU WORK:
 - Resolve every time to an absolute ISO-8601 instant in the host's timezone. Never pick a past time. Interpret vague times locally (morning=09:00, afternoon=14:00, evening=18:00).
 - For reschedule/cancel, set bookingRef to the exact ref of the intended booking. If several could match and you can't tell, DON'T propose - just ask which one in your reply.
 - propose_action works on the bookings listed in context (each has a ref). To act on a booking that ISN'T listed - one from search_bookings, a past or far-future meeting, or when you need its uid - use reschedule_booking (one booking, by uid) or cancel_bookings (one or more uids). For BULK requests ("cancel all my meetings tomorrow", "push everything Friday back an hour") call search_bookings for the window FIRST to get the uids, then cancel_bookings(uids) or shift_bookings(uids, deltaMinutes). To cancel a whole recurring series, use cancel_bookings with scope "series". These are one confirm card for the whole batch.
+- To change a booking's DETAILS rather than its time (rename it, change its location, add or remove a guest by email) use update_booking with its uid - "rename my 3pm to Budget review", "move the review to Zoom", "add priya@acme.com to my standup". (Reschedule is still for changing the time.)
 - If you're only answering a question (not proposing a change), reply in plain text and do not call propose_action.
 
 BEYOND BOOKINGS - you can also read and control the rest of the host's setup with these tools:

--- a/apps/web/lib/ai/interpret.ts
+++ b/apps/web/lib/ai/interpret.ts
@@ -1,5 +1,7 @@
+import { eq, getDb, schema } from "@dayotter/db";
 import { DateTime } from "luxon";
 import { runSchedulingAgent } from "./agent";
+import { answerCalendarQuestion, classifyRequest } from "./answer";
 import { type BookingContext, type CommandDraft, parseCommand } from "./command-parse";
 import { recallFreshMemory, summarizeMemory } from "./memory";
 import { retrieveCalendarContext } from "./retrieval";
@@ -25,6 +27,35 @@ export interface OtterInterpretation {
   target: OtterTarget | null;
   /** For create: the matched event type, when the request named one. */
   matchedEventType: { title: string; slug: string; durationMinutes: number } | null;
+  /** A plain-text reply for a question / out-of-scope request (no draft to confirm). */
+  answer: string | null;
+}
+
+/** A benign "nothing to confirm" draft, returned alongside a text `answer`. */
+function noneDraft(message: string): CommandDraft {
+  return {
+    reasoning: "",
+    understood: false,
+    intent: "none",
+    kind: "meeting",
+    title: "",
+    startISO: "",
+    durationMinutes: 30,
+    attendees: [],
+    notes: "",
+    eventTypeSlug: "",
+    bookingRef: 0,
+    newStartISO: "",
+    message,
+  };
+}
+
+async function userTimezone(userId: string): Promise<string> {
+  const u = await getDb().query.users.findFirst({
+    where: eq(schema.users.id, userId),
+    columns: { timezone: true },
+  });
+  return u?.timezone ?? "UTC";
 }
 
 /**
@@ -42,6 +73,22 @@ export async function interpretOtterCommand(
   userId: string,
   text: string,
 ): Promise<OtterInterpretation> {
+  // First decide what kind of request this is. Questions and out-of-scope asks
+  // get a text answer (these surfaces have no chat, so historically they could
+  // only ever return "I help with scheduling"); only actions go on to drafting.
+  const cls = await classifyRequest(text);
+  if (cls !== "action") {
+    const [answer, tz] = await Promise.all([
+      cls === "question"
+        ? answerCalendarQuestion(userId, text)
+        : Promise.resolve(
+            "I can only help with your calendar and scheduling - ask me about your schedule, or tell me what to book, move, or cancel.",
+          ),
+      userTimezone(userId),
+    ]);
+    return { draft: noneDraft(answer), timezone: tz, target: null, matchedEventType: null, answer };
+  }
+
   // RAG-lite: retrieve only the bookings relevant to this request. This
   // retrieved list is the source of truth for the model's booking refs. In
   // parallel, recall (and self-refresh) Otter's memory of this user.
@@ -82,5 +129,5 @@ export async function interpretOtterCommand(
     if (b) target = { uid: b.uid, title: b.title, startISO: b.startsAt.toISOString() };
   }
 
-  return { draft, timezone: tz, target, matchedEventType };
+  return { draft, timezone: tz, target, matchedEventType, answer: null };
 }

--- a/apps/web/lib/ai/tools/exec.ts
+++ b/apps/web/lib/ai/tools/exec.ts
@@ -10,6 +10,7 @@ import { resolveScheduleId } from "@/lib/booking/schedule";
 import { ensureUserWorkspace } from "@/lib/bootstrap";
 import { getAgenda } from "@/lib/calendar/agenda";
 import { type BusyItem, analyzeSchedule } from "@/lib/calendar/analyze";
+import { updateBookingCalendarEvent } from "@/lib/calendar/host-calendar";
 import { recurringBlockOccurrences } from "@/lib/calendar/recurrence";
 import {
   channelInputSchema,
@@ -777,6 +778,106 @@ export async function executeActionTool(
           const msg = err instanceof Error ? err.message : "that time wasn't available";
           return { ok: false, message: `Couldn't move “${owned.title}” - ${msg}.` };
         }
+      }
+
+      case "update_booking": {
+        const uid = input.uid as string;
+        const booking = await db.query.bookings.findFirst({
+          where: and(eq(schema.bookings.uid, uid), eq(schema.bookings.hostId, userId)),
+          columns: {
+            id: true,
+            status: true,
+            title: true,
+            description: true,
+            startsAt: true,
+            endsAt: true,
+            timezone: true,
+            location: true,
+          },
+          with: { attendees: { columns: { email: true, name: true } } },
+        });
+        if (!booking || booking.status === "cancelled") {
+          return { ok: false, message: "I couldn't find that booking." };
+        }
+
+        // Field changes on the booking row.
+        const set: Record<string, unknown> = {};
+        if (input.title !== undefined) set.title = input.title;
+        if (input.notes !== undefined) set.description = input.notes;
+        if (input.location !== undefined) {
+          set.locationType = input.location;
+          if (input.locationDetail !== undefined) set.location = input.locationDetail;
+        } else if (input.locationDetail !== undefined) {
+          set.location = input.locationDetail;
+        }
+
+        // Attendee add/remove, de-duplicated against the current list.
+        const removeEmails = new Set(
+          ((input.removeGuests as string[] | undefined) ?? []).map((e) => e.toLowerCase()),
+        );
+        const currentEmails = new Set(booking.attendees.map((a) => a.email.toLowerCase()));
+        const toAdd = ((input.addGuests as { email: string; name?: string }[] | undefined) ?? [])
+          .filter((g) => g.email.includes("@"))
+          .filter((g) => !currentEmails.has(g.email.toLowerCase()));
+
+        if (Object.keys(set).length === 0 && toAdd.length === 0 && removeEmails.size === 0) {
+          return { ok: false, message: "Tell me what to change on that booking." };
+        }
+
+        if (Object.keys(set).length > 0) {
+          await db.update(schema.bookings).set(set).where(eq(schema.bookings.id, booking.id));
+        }
+        if (removeEmails.size > 0) {
+          await db
+            .delete(schema.bookingAttendees)
+            .where(eq(schema.bookingAttendees.bookingId, booking.id));
+          // Re-insert the survivors + additions below in one pass.
+        }
+        const survivors = booking.attendees.filter((a) => !removeEmails.has(a.email.toLowerCase()));
+        const finalAttendees = [
+          ...survivors.map((a) => ({ email: a.email, name: a.name ?? undefined })),
+          ...toAdd.map((g) => ({ email: g.email, name: g.name })),
+        ];
+        if (removeEmails.size > 0 || toAdd.length > 0) {
+          if (removeEmails.size === 0) {
+            // Only additions - insert just the new ones.
+            if (toAdd.length > 0) {
+              await db.insert(schema.bookingAttendees).values(
+                toAdd.map((g) => ({
+                  bookingId: booking.id,
+                  email: g.email,
+                  name: g.name ?? null,
+                  timezone: booking.timezone,
+                })),
+              );
+            }
+          } else if (finalAttendees.length > 0) {
+            // We cleared the table above; rewrite the full surviving + added set.
+            await db.insert(schema.bookingAttendees).values(
+              finalAttendees.map((a) => ({
+                bookingId: booking.id,
+                email: a.email,
+                name: a.name ?? null,
+                timezone: booking.timezone,
+              })),
+            );
+          }
+        }
+
+        // Push the change to the connected calendar (best-effort). The provider
+        // sends updated invites to attendees, so no separate email is needed.
+        await updateBookingCalendarEvent(booking.id, {
+          title: (set.title as string) ?? booking.title,
+          description: (set.description as string) ?? booking.description ?? undefined,
+          start: booking.startsAt,
+          end: booking.endsAt,
+          timezone: booking.timezone,
+          attendees: finalAttendees,
+          location: (set.location as string) ?? booking.location ?? undefined,
+          createConference: false,
+        }).catch(() => undefined);
+
+        return { ok: true, message: `Updated “${(set.title as string) ?? booking.title}”.` };
       }
 
       case "shift_bookings": {

--- a/apps/web/lib/ai/tools/registry.ts
+++ b/apps/web/lib/ai/tools/registry.ts
@@ -985,6 +985,67 @@ export const TOOLS: AiToolDef[] = [
         : `Set ${i.date} hours to ${i.start}–${i.end}`,
   },
   {
+    name: "update_booking",
+    description:
+      "Edit an existing booking's details (NOT its time - use reschedule for that) by its public id (uid, from search_bookings or context). Change the title, the notes/description, the location, and/or add or remove guests by email. Only the fields you pass change; attendees are notified via the updated calendar invite. Confirm-first.",
+    kind: "write",
+    confirmLevel: "confirm",
+    schema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        uid: { type: "string", description: "The booking's public id." },
+        title: { type: "string", description: "New title." },
+        notes: { type: "string", description: "New description / notes." },
+        location: { type: "string", enum: LOCATIONS as unknown as string[] },
+        locationDetail: {
+          type: "string",
+          description: "Address, phone number, or meeting link for the location.",
+        },
+        addGuests: {
+          type: "array",
+          description: "Guests to invite (need an email).",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            properties: { email: { type: "string" }, name: { type: "string" } },
+            required: ["email"],
+          },
+        },
+        removeGuests: {
+          type: "array",
+          items: { type: "string" },
+          description: "Emails of guests to remove.",
+        },
+      },
+      required: ["uid"],
+    },
+    zod: z.object({
+      uid: z.string().min(1).max(120),
+      title: z.string().min(1).max(200).optional(),
+      notes: z.string().max(2000).optional(),
+      location: z.enum(LOCATIONS).optional(),
+      locationDetail: z.string().max(500).optional(),
+      addGuests: z
+        .array(z.object({ email: z.string().email(), name: z.string().max(120).optional() }))
+        .max(20)
+        .optional(),
+      removeGuests: z.array(z.string().email()).max(20).optional(),
+    }),
+    title: "Edit booking",
+    summarize: (i) => {
+      const parts: string[] = [];
+      if (i.title !== undefined) parts.push("title");
+      if (i.notes !== undefined) parts.push("notes");
+      if (i.location !== undefined) parts.push("location");
+      const add = (i.addGuests as unknown[] | undefined)?.length ?? 0;
+      const rem = (i.removeGuests as unknown[] | undefined)?.length ?? 0;
+      if (add) parts.push(`add ${add} guest${add === 1 ? "" : "s"}`);
+      if (rem) parts.push(`remove ${rem} guest${rem === 1 ? "" : "s"}`);
+      return `Edit this booking: ${parts.length ? parts.join(", ") : "no changes"}`;
+    },
+  },
+  {
     name: "reschedule_booking",
     description:
       "Move ONE booking to a new time by its public id (uid). Use this to act on a specific booking you found with search_bookings - a past, far-future, or otherwise not-in-context meeting, or to resolve which of several you mean. For the common case of moving a booking that's already listed in the context, use propose_action instead. Confirm-first.",

--- a/apps/web/lib/messaging/otter-sms.ts
+++ b/apps/web/lib/messaging/otter-sms.ts
@@ -42,7 +42,10 @@ function whenLabel(iso: string, tz: string): string {
  * "reply YES to confirm" prompt - confirm-first, over text.
  */
 export async function interpretForSms(userId: string, text: string): Promise<InterpretResult> {
-  const { draft, timezone: tz, target } = await interpretOtterCommand(userId, text);
+  const { draft, timezone: tz, target, answer } = await interpretOtterCommand(userId, text);
+
+  // A question / out-of-scope ask → text the answer straight back, nothing to confirm.
+  if (answer) return { reply: answer };
 
   if (!draft.understood || draft.intent === "none") {
     return {

--- a/apps/web/lib/messaging/otter-sms.ts
+++ b/apps/web/lib/messaging/otter-sms.ts
@@ -2,7 +2,9 @@ import { interpretOtterCommand } from "@/lib/ai/interpret";
 import { cancelBooking } from "@/lib/booking/cancel-booking";
 import { createHostBooking } from "@/lib/booking/host-booking";
 import { rescheduleBooking } from "@/lib/booking/reschedule-booking";
+import { writeBookingToCalendar } from "@/lib/calendar/host-calendar";
 import { logger } from "@dayotter/core";
+import { getDb, schema } from "@dayotter/db";
 import { DateTime } from "luxon";
 
 /**
@@ -20,6 +22,8 @@ export type PendingAction =
       attendees: { name: string; email: string }[];
       timezone: string;
       eventTypeSlug?: string;
+      /** "focus" is held as a personal focus block, not a meeting. */
+      kind?: "meeting" | "focus" | "reminder";
     }
   | { intent: "reschedule"; uid: string; newStartISO: string; title: string; timezone: string }
   | { intent: "cancel"; uid: string; title: string };
@@ -65,6 +69,7 @@ export async function interpretForSms(userId: string, text: string): Promise<Int
         attendees: draft.attendees,
         timezone: tz,
         eventTypeSlug: draft.eventTypeSlug || undefined,
+        kind: draft.kind,
       },
     };
   }
@@ -100,6 +105,27 @@ export async function executePending(userId: string, pending: PendingAction): Pr
     if (pending.intent === "create") {
       const start = new Date(pending.startISO);
       const end = new Date(start.getTime() + pending.durationMinutes * 60_000);
+
+      // A "focus" hold is a personal focus block, not a meeting/booking.
+      if (pending.kind === "focus") {
+        await getDb().insert(schema.timeBlocks).values({
+          userId,
+          title: pending.title,
+          kind: "focus",
+          startsAt: start,
+          endsAt: end,
+          seriesId: null,
+        });
+        await writeBookingToCalendar(userId, {
+          title: pending.title,
+          start,
+          end,
+          timezone: pending.timezone,
+          attendees: [],
+        }).catch(() => null);
+        return `Done ✓ Focus time "${pending.title}" is held for ${whenLabel(pending.startISO, pending.timezone)}.`;
+      }
+
       const attendees = pending.attendees
         .filter((a) => a.email.includes("@"))
         .map((a) => ({ email: a.email, name: a.name || undefined }));

--- a/docs/AI.md
+++ b/docs/AI.md
@@ -62,9 +62,14 @@ its own client**, which is what makes the model layer swappable.
 
 ### The interpret core - `lib/ai/interpret.ts`
 `interpretOtterCommand(userId, text)` is the shared brain for every non-chat
-surface. It recalls memory + retrieves relevant bookings in parallel, then routes:
-availability-dependent requests go through the agentic loop; everything else
-through the fast single-shot parser. Returns a confirm-first draft. Never writes.
+surface (command bar, mobile Ask bar, inbound SMS/WhatsApp). It first classifies
+the request (`lib/ai/answer.ts` `classifyRequest`): an **action** goes to the
+drafter (availability-dependent requests through the agentic loop, everything
+else through the fast single-shot parser) and returns a confirm-first draft; a
+**question** goes to `answerCalendarQuestion` - a read-only agentic loop over the
+same read tools the chat assistant uses - and comes back as a plain-text `answer`
+(so these surfaces can finally reply to "how busy am I?" / "when's my next
+meeting?" instead of only "I help with scheduling"). Never writes.
 
 ### The tool registry - `lib/ai/tools/`
 A declarative catalog where each tool is tagged `read` / `write` / `destructive`


### PR DESCRIPTION
Lands the three remaining Otter AI feature PRs together, so the mobile client + server changes ship in one deploy (they're coupled). Combines and supersedes:

- **#191** (#186) — command bar / mobile / SMS can now **answer questions** (read-only answer loop, isolated from the draft schema).
- **#192** (#187) — **edit an existing booking** (title / location / add-remove guests, calendar re-synced; host-guarded).
- **#193** (#188 part) — **`kind: focus` drafts become real focus blocks**, not meetings (mobile/SMS/draft path).

Verified on the combined branch: web typecheck ✅ · mobile typecheck ✅ · web tests ✅ (165) · biome ✅. Also **built a release APK from this branch and installed/launched it on a physical device** (0.3.0 / versionCode 10) — no crash, sign-in flow works.

After merge: deploy the web app (server half of #191/#193 must be live for the mobile behaviors to activate), then the already-built mobile client shows them.
