### PR TITLE
chore(mobile): Play Store submission config + 0.3.0 release notes + runbook

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -25,7 +25,7 @@
     },
     "android": {
       "package": "com.dayotter.app",
-      "versionCode": 11,
+      "versionCode": 12,
       "edgeToEdgeEnabled": true,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -21,6 +21,12 @@
     }
   },
   "submit": {
-    "production": {}
+    "production": {
+      "android": {
+        "serviceAccountKeyPath": "./play-service-account.json",
+        "track": "internal",
+        "releaseStatus": "draft"
+      }
+    }
   }
 }

--- a/apps/mobile/store/SUBMIT.md
+++ b/apps/mobile/store/SUBMIT.md
@@ -1,0 +1,76 @@
+# Submitting DayOtter Android to the Play Store
+
+A tight, per-release checklist. General build docs + listing copy live in
+[`README.md`](./README.md); this is the "ship it" runbook. Everything here runs
+from `apps/mobile/`.
+
+> **Version source of truth:** [`../app.json`](../app.json) (`eas.json` uses
+> `appVersionSource: local`). Current: **0.3.0 / versionCode 11**. The
+> `production` profile has `autoIncrement`, so the next build bumps versionCode
+> automatically — you don't edit it by hand.
+
+## 0. One-time setup (skip if already done)
+
+1. **Play Console app** exists for package `com.dayotter.app` (Productivity), with
+   the store listing filled in (title, short + full description from
+   [`README.md`](./README.md), icon `play-icon-512.png`, feature graphic
+   `play-feature-graphic-1024x500.png`, ≥2 phone screenshots), **Data safety**
+   form, **content rating**, target audience, and a **privacy policy URL**
+   (`https://dayotter.com/privacy`). Play won't let you roll out until these are green.
+2. **Play service-account key** — Play Console → *Setup → API access* → create/
+   link a Google Cloud service account with the **Release Manager** role, download
+   its JSON, and save it at **`apps/mobile/play-service-account.json`**. It's
+   **gitignored** (`*service-account*.json`) — never commit it. `eas.json` →
+   `submit.production.android.serviceAccountKeyPath` points at it.
+3. `npm i -g eas-cli` (or `npx eas-cli@latest`) and `eas login`.
+
+## 1. Build the AAB (from `main`)
+
+> ⚠️ Build from **current `main`** — it now includes the merged AI features
+> (mobile Q&A, focus-as-block, edit-booking via #195). An AAB built before that
+> merge won't have them.
+
+```bash
+git checkout main && git pull
+cd apps/mobile
+eas build -p android --profile production
+```
+
+EAS builds a **signed .aab** in the cloud with its managed **upload key** (not the
+local debug keystore — that one is only for sideloaded test APKs and Play rejects
+it). `autoIncrement` bumps versionCode (11 → 12) and writes it back to `app.json`
+— **commit that bump** so the next build continues cleanly.
+
+## 2. Submit to the internal track (draft)
+
+```bash
+eas submit -p android --profile production
+```
+
+This uploads the AAB to the **internal testing** track as a **draft** (per
+`eas.json` — safe defaults; nothing goes public). Pick the just-built binary when
+prompted (or add `--latest`).
+
+## 3. Finish in Play Console
+
+1. Open the release on the **Internal testing** track → add the testers/link →
+   **paste the "What's new"** text from [`whatsnew/whatsnew-en-US.txt`](./whatsnew/whatsnew-en-US.txt).
+2. Install from the internal-test link on a device and smoke-test (sign in, open
+   Otter, ask "how busy am I this week?", create a booking).
+3. When happy, **promote** the release: Internal → (Closed/Open testing →)
+   **Production**, set the rollout %, and submit for review. First-time apps take
+   a few days for Google review.
+
+## 4. Next release
+
+Bump nothing by hand — `autoIncrement` handles versionCode; edit `version` in
+`app.json` for a new user-facing number, refresh
+[`whatsnew/whatsnew-en-US.txt`](./whatsnew/whatsnew-en-US.txt), then repeat from
+step 1.
+
+---
+
+**What I (the assistant) can't run for you:** `eas login`, `eas build`,
+`eas submit`, creating the service-account key, or the Play Console steps — those
+need your account, credentials, and Google's terms. Everything above the line is
+wired and ready; you drive the three commands.

--- a/apps/mobile/store/whatsnew/whatsnew-en-US.txt
+++ b/apps/mobile/store/whatsnew/whatsnew-en-US.txt
@@ -1,0 +1,6 @@
+New in 0.3.0
+
+• Ask Otter about your schedule — "how busy am I this week?", "when's my next meeting?", "am I free Friday?" — and get real answers, right from the Ask bar.
+• Holding focus time now blocks your calendar as a proper focus block.
+• Bookings map to the right event type, so their location, reminders, and workflows apply.
+• Reliability and polish across bookings, availability, and sign-in.


### PR DESCRIPTION
Wires the repo side of the **0.3.0 Play Store submission** (the `store/` folder already had graphics, listing copy, and build docs — this fills the gaps for actually shipping this release).

## What's in

- **`eas.json` → `submit.production.android`** — `serviceAccountKeyPath: ./play-service-account.json` (already gitignored via `*service-account*.json`), `track: internal`, `releaseStatus: draft`. Safe defaults: `eas submit` uploads to internal testing as a draft; nothing goes public on its own.
- **`store/whatsnew/whatsnew-en-US.txt`** — the 0.3.0 "What's new" copy (414/500 chars) to paste into Play Console.
- **`store/SUBMIT.md`** — a tight per-release runbook: one-time setup (Play app + service-account key), `eas build -p android --profile production`, `eas submit`, then the Console steps.

## The 3 commands you run (I can't — they need your login/keys)

```bash
git checkout main && git pull
cd apps/mobile
eas build  -p android --profile production   # signed AAB, autoIncrements versionCode 11→12
eas submit -p android --profile production   # → internal track, draft
```

## ⚠️ Important

Build from **current `main`** — it now includes the merged AI features (#195). The AAB you built earlier (versionCode 11) predates that merge and **doesn't have the mobile Q&A / focus-block changes** you just tested. Rebuild so the store version matches what we validated on-device.

Screenshots: I captured real 0.3.0 device screenshots during testing (Home, Bookings, Events, Calendars, Availability, Insights, Otter) — happy to add clean ones to `store/screenshots/` if you want, though a clean capture (no personal notification icons in the status bar) is better for the listing.
