### PR TITLE
feat(deploy): one-command self-host upgrade (backup + migrate + healthcheck + rollback)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ SECURITY-AUDIT.md
 
 # Internal launch strategy (not for publication)
 LAUNCH-POSITIONING.md
+
+# self-host DB backups from deploy/upgrade.sh
+deploy/backups/

--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -31,6 +31,9 @@ export async function GET() {
     {
       status: ready ? "ok" : "degraded",
       service: "dayotter-web",
+      // Running build id (git short SHA), stamped by deploy.sh / upgrade.sh so
+      // self-hosters can see which version they're on. "dev" when unset.
+      version: process.env.APP_VERSION ?? "dev",
       db,
       redis,
       worker,

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -109,18 +109,34 @@ sudo certbot renew --dry-run
 
 Open **https://dayotter.com**.
 
-### Redeploying / updating
+### Upgrading to a new DayOtter version
+
+Run the upgrade script - it does the safe thing in order: **backs up the
+database**, pulls the new code, rebuilds, runs pending **migrations**, restarts,
+waits for `/api/health` to go green, and prints how to roll back if anything
+fails:
+
+```bash
+./deploy/upgrade.sh            # upgrade to the latest on your branch
+./deploy/upgrade.sh --check    # just tell me if there's an update (no changes)
+./deploy/upgrade.sh --ref v0.3.0   # pin to a specific release tag
+```
+
+Backups land in `deploy/backups/` (gitignored). Check what you're running at any
+time with `curl -s https://<your-domain>/api/health` - the `version` field is the
+git build id.
+
+### Redeploying (same version, e.g. after an `.env` change)
 
 Do **not** just re-run `up -d --build`: `docker compose up -d` reuses the already
 completed one-shot `migrate` container instead of re-running it, so new app code
 can boot against an un-migrated database (missing columns → 500s everywhere).
 
-Use the script, which always builds, then runs a **fresh** migration one-shot,
-then (re)starts the stack - in that order:
+Use the deploy script, which always builds, then runs a **fresh** migration
+one-shot, then (re)starts the stack - in that order:
 
 ```bash
-git -C .. pull
-./deploy.sh          # build → run --rm migrate → up -d
+./deploy/deploy.sh          # build → run --rm migrate → up -d
 ```
 
 Or run the equivalent by hand from `deploy/` (add `-f docker-compose.nginx.yml`

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -15,6 +15,10 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
+# Stamp the running build id (git short SHA) so /api/health reports the version.
+# Harmless if this isn't a git checkout (falls back to "unknown").
+export APP_VERSION="${APP_VERSION:-$(git rev-parse --short HEAD 2>/dev/null || echo unknown)}"
+
 if [ ! -f .env ]; then
   echo "error: deploy/.env not found. Copy .env.example and fill it in." >&2
   exit 1

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -13,6 +13,9 @@ x-app-env: &app-env
   # set DATABASE_URL and/or REDIS_URL in deploy/.env and they take precedence.
   DATABASE_URL: ${DATABASE_URL:-postgresql://dayotter:${POSTGRES_PASSWORD}@postgres:5432/dayotter}
   REDIS_URL: ${REDIS_URL:-redis://redis:6379}
+  # Running build id, surfaced at /api/health. deploy.sh / upgrade.sh export the
+  # git short SHA before `up`; defaults to "dev" when run by hand.
+  APP_VERSION: ${APP_VERSION:-dev}
 
 services:
   postgres:

--- a/deploy/upgrade.sh
+++ b/deploy/upgrade.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+#
+# Upgrade a self-hosted DayOtter to the latest (or a specific) version - safely.
+#
+# The pattern most self-hostable projects use (Ghost, Gitea, Plausible): one
+# command that backs up, pulls, migrates, restarts, and health-checks - and tells
+# you how to roll back if anything goes wrong. This does exactly that, in order:
+#
+#   1. Fetch upstream and show what's changed (link to the diff).
+#   2. Back up the Postgres database (gzipped, under deploy/backups/).
+#   3. Fast-forward the code (or check out --ref <tag>).
+#   4. Rebuild images, run pending migrations, restart the stack
+#      (delegates to deploy.sh so migration ordering lives in one place).
+#   5. Wait for /api/health to report "ok".
+# If a step fails it stops and prints how to roll back.
+#
+# Usage (from anywhere in the repo):
+#   ./deploy/upgrade.sh                # upgrade to the latest on the current branch
+#   ./deploy/upgrade.sh --check        # only report whether an update is available
+#   ./deploy/upgrade.sh --ref v0.3.0   # upgrade to a specific tag / branch / commit
+#   ./deploy/upgrade.sh --no-backup    # skip the DB backup (not recommended)
+#
+set -euo pipefail
+cd "$(dirname "$0")" # deploy/ - git still resolves the repo from here
+
+REF="" CHECK=0 BACKUP=1
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --check) CHECK=1 ;;
+    --ref) REF="${2:-}"; shift ;;
+    --no-backup) BACKUP=0 ;;
+    -h|--help) sed -n '2,26p' "$0"; exit 0 ;;
+    *) echo "unknown option: $1 (see --help)" >&2; exit 1 ;;
+  esac
+  shift
+done
+
+command -v git >/dev/null || { echo "error: git is required." >&2; exit 1; }
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 ||
+  { echo "error: not a git checkout - upgrade only works for source installs." >&2; exit 1; }
+[ -f .env ] || { echo "error: deploy/.env not found - is this a self-host install?" >&2; exit 1; }
+
+REPO_URL="https://github.com/Dayotter/dayotter"
+CURRENT=$(git rev-parse --short HEAD)
+
+echo "==> Fetching updates"
+git fetch --tags --quiet origin
+
+TARGET_REF="${REF:-@{u}}" # default: the upstream of the current branch
+if ! TARGET=$(git rev-parse --short "$TARGET_REF" 2>/dev/null); then
+  echo "error: can't resolve '$TARGET_REF'. Pass a valid --ref, or set an upstream." >&2
+  exit 1
+fi
+
+if [ "$CURRENT" = "$TARGET" ]; then
+  echo "==> Already up to date ($CURRENT)."
+  exit 0
+fi
+
+COUNT=$(git rev-list --count "$CURRENT..$TARGET" 2>/dev/null || echo "?")
+echo "==> Update available: $CURRENT -> $TARGET  ($COUNT new commit(s))"
+echo "    What changed: $REPO_URL/compare/$CURRENT...$TARGET"
+[ "$CHECK" = 1 ] && exit 0
+
+# Refuse to clobber local edits - self-host installs should track upstream cleanly.
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "error: you have uncommitted local changes. Commit or 'git stash' them first." >&2
+  exit 1
+fi
+
+FILES=(-f docker-compose.prod.yml)
+[ -f docker-compose.nginx.yml ] && FILES+=(-f docker-compose.nginx.yml)
+DC=(docker compose "${FILES[@]}" --env-file .env)
+
+# --- 1. Back up the database BEFORE migrating ---
+if [ "$BACKUP" = 1 ]; then
+  if "${DC[@]}" ps --status running postgres 2>/dev/null | grep -q postgres; then
+    mkdir -p backups
+    BACKUP_FILE="backups/dayotter-db-${CURRENT}-$(date +%Y%m%d-%H%M%S).sql.gz"
+    echo "==> Backing up database -> $BACKUP_FILE"
+    "${DC[@]}" exec -T postgres pg_dump -U dayotter dayotter | gzip > "$BACKUP_FILE"
+  else
+    echo "==> Postgres isn't running yet - skipping backup."
+    BACKUP_FILE=""
+  fi
+else
+  echo "==> Skipping database backup (--no-backup)."
+  BACKUP_FILE=""
+fi
+
+# --- 2. Update the code ---
+echo "==> Updating code to $TARGET"
+if [ -n "$REF" ]; then
+  git checkout --quiet "$REF"
+else
+  git merge --ff-only --quiet "$TARGET_REF"
+fi
+
+# --- 3. Rebuild + migrate + restart (deploy.sh runs migrations first) ---
+echo "==> Rebuilding and restarting the stack"
+if ! ./deploy.sh; then
+  echo "" >&2
+  echo "!! Deploy failed. Roll back with:" >&2
+  echo "     git checkout $CURRENT && ./deploy/deploy.sh" >&2
+  [ -n "$BACKUP_FILE" ] &&
+    echo "     gunzip -c deploy/$BACKUP_FILE | docker compose -f deploy/docker-compose.prod.yml --env-file deploy/.env exec -T postgres psql -U dayotter dayotter" >&2
+  exit 1
+fi
+
+# --- 4. Wait for the app to report healthy ---
+echo "==> Waiting for the app to become healthy"
+healthy=0
+for _ in $(seq 1 24); do
+  if "${DC[@]}" exec -T web node -e "fetch('http://localhost:3000/api/health').then(r=>r.json()).then(j=>process.exit(j.status==='ok'?0:1)).catch(()=>process.exit(1))" 2>/dev/null; then
+    healthy=1; break
+  fi
+  sleep 5
+done
+
+if [ "$healthy" != 1 ]; then
+  echo "" >&2
+  echo "!! The app didn't report healthy at /api/health within ~2 minutes." >&2
+  echo "   Check logs:  docker compose -f deploy/docker-compose.prod.yml logs web worker" >&2
+  echo "   Roll back:   git checkout $CURRENT && ./deploy/deploy.sh" >&2
+  [ -n "$BACKUP_FILE" ] &&
+    echo "   Restore DB:  gunzip -c deploy/$BACKUP_FILE | docker compose -f deploy/docker-compose.prod.yml --env-file deploy/.env exec -T postgres psql -U dayotter dayotter" >&2
+  exit 1
+fi
+
+echo ""
+echo "==> Upgraded: $CURRENT -> $(git rev-parse --short HEAD)  ✓  (healthy)"
+[ -n "$BACKUP_FILE" ] && echo "    Pre-upgrade DB backup: deploy/$BACKUP_FILE"


### PR DESCRIPTION
Gives self-hosters a **safe, one-command upgrade** — the thing every self-hostable OSS project ships (Ghost `ghost update`, Gitea/Plausible `docker compose pull && migrate`, Discourse `launcher rebuild`). Today they only had `deploy.sh` (build → migrate → restart) with no backup, no version check, and no rollback guidance.

## `deploy/upgrade.sh`

Runs the safe sequence, stopping on any failure:
1. **Fetch** upstream, show what changed (a `github.com/.../compare/OLD...NEW` link).
2. **Back up** Postgres — gzipped dump to `deploy/backups/` (gitignored) *before* any migration.
3. **Update** code — fast-forward the branch, or `--ref v0.3.0` to pin a release tag.
4. **Rebuild + migrate + restart** — delegates to `deploy.sh` so the "fresh migrate one-shot before app start" ordering stays in one place.
5. **Health-check** `/api/health` until it's `ok`; on failure, prints exact **roll-back** + **DB-restore** commands.

```bash
./deploy/upgrade.sh            # latest on your branch
./deploy/upgrade.sh --check    # is there an update? (no changes made)
./deploy/upgrade.sh --ref v0.3.0
```

## Version visibility

`/api/health` now returns a **`version`** field (git short SHA), stamped via `APP_VERSION` through the compose env by `deploy.sh`/`upgrade.sh`. So `curl -s https://you/api/health` shows what's running, and `--check` can compare local vs upstream.

## Testing
- `bash -n` syntax-clean on both scripts; web typecheck ✅ · biome ✅.
- Docs: `deploy/README.md` now leads with the upgrade flow.
- Full end-to-end (backup/migrate/restart) runs against a live Docker stack — best validated on a real self-host box; the logic mirrors the existing, working `deploy.sh`.

Follow-up idea (not in this PR): an in-dashboard "update available" banner for admins that hits the GitHub releases API — the CLI + `version` field here are the foundation for it.
