### PR TITLE
fix(mobile): use EAS-managed Play service account (drop local key path)

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -23,7 +23,6 @@
   "submit": {
     "production": {
       "android": {
-        "serviceAccountKeyPath": "./play-service-account.json",
         "track": "internal",
         "releaseStatus": "draft"
       }


### PR DESCRIPTION
`eas submit -p android --profile production` started prompting for `./play-service-account.json` because #196 pinned `serviceAccountKeyPath` to a local file. This app's Play service account is **managed by EAS** server-side, so the pin just overrode the working managed credential.

Remove the `serviceAccountKeyPath` line — EAS falls back to its managed key (pre-#196 behavior). `track: internal` / `releaseStatus: draft` unchanged. No local key file needed.

Verified: `eas.json` is valid JSON.