### PR TITLE
docs(readme): surface one-click Render deploy at the top

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Make all your calendars work as one.**
 The open-source calendar & scheduling app for people juggling **multiple calendars** - connect every calendar (personal + work + clients), never get double-booked, protect your focus, and share **one booking link that respects them all**. With an AI assistant, Otter, built into the core.
 
-**[▶ Try the hosted version](https://dayotter.com)** &nbsp;·&nbsp; [🐳 Self-host with Docker](#self-hosting-production) &nbsp;·&nbsp; [How we compare](./docs/COMPARISON.md)
+**[▶ Try the hosted version](https://dayotter.com)** &nbsp;·&nbsp; [🚀 One-click deploy to Render](https://render.com/deploy?repo=https://github.com/Dayotter/dayotter) &nbsp;·&nbsp; [🐳 Self-host with Docker](#self-hosting-production) &nbsp;·&nbsp; [How we compare](./docs/COMPARISON.md)
 
 <br>
 


### PR DESCRIPTION
The Deploy-to-Render button was buried at line ~152 under *Self-hosting (production)*, so it was easy to miss (exactly what was reported — 'I don't see any option to deploy on Render'). Add a **🚀 One-click deploy to Render** link to the hero callout row, pointing at `https://render.com/deploy?repo=https://github.com/Dayotter/dayotter`. The full button + Docker/Railway/etc. options remain in the Self-hosting section.