### PR TITLE
feat(deploy): first-class DigitalOcean, Fly.io, Heroku + Railway deploy configs

### DIFF
--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -1,0 +1,93 @@
+# DigitalOcean App Platform - one-click DayOtter (web + worker + Postgres + Redis).
+#
+# Deploy: https://cloud.digitalocean.com/apps/new?repo=https://github.com/Dayotter/dayotter/tree/main
+# (the "Deploy to DO" button in the README points here). App Platform reads this
+# file, provisions the components below, and prompts for the SECRET envs.
+#
+# ⚠️ Values you must set during the create flow (App Platform can't generate them):
+#   ENCRYPTION_KEY  - 64 hex chars:  openssl rand -hex 32   (identical on all 3 components)
+#   AUTH_SECRET     - 32+ random chars:  openssl rand -hex 32
+#   APP_URL / NEXT_PUBLIC_APP_URL / BETTER_AUTH_URL - your assigned
+#                     https://<app-name>.ondigitalocean.app  (set after first deploy, then redeploy;
+#                     NEXT_PUBLIC_APP_URL is baked into the web build, so it needs a rebuild).
+#
+# 💸 Cost note: the Postgres below is a free *dev database*. DigitalOcean has no free
+# Redis - `engine: REDIS` provisions a paid managed Valkey cluster. If your account
+# rejects `REDIS`, rename it to `VALKEY` (DO's newer name for the same engine).
+spec:
+  name: dayotter
+  region: nyc
+
+  services:
+    - name: web
+      dockerfile_path: apps/web/Dockerfile
+      source_dir: /
+      http_port: 3000
+      instance_size_slug: apps-s-1vcpu-1gb
+      instance_count: 1
+      health_check:
+        http_path: /api/me # fast 401 when unauthenticated = alive
+      envs:
+        - key: NODE_ENV
+          value: production
+        - key: DATABASE_URL
+          scope: RUN_AND_BUILD_TIME
+          value: ${db.DATABASE_URL}
+        - key: REDIS_URL
+          value: ${redis.DATABASE_URL}
+        - key: AUTH_SECRET
+          scope: RUN_TIME
+          type: SECRET
+        - key: ENCRYPTION_KEY
+          scope: RUN_TIME
+          type: SECRET
+        - key: APP_URL
+          scope: RUN_TIME
+        - key: BETTER_AUTH_URL
+          scope: RUN_TIME
+        # Baked into the client bundle at build time -> BUILD_TIME scope + rebuild on change.
+        - key: NEXT_PUBLIC_APP_URL
+          scope: BUILD_TIME
+        - key: AI_PROVIDER # optional: "anthropic" or "openai" (unset = no AI)
+          scope: RUN_TIME
+
+    - name: worker
+      dockerfile_path: apps/worker/Dockerfile
+      source_dir: /
+      instance_size_slug: apps-s-1vcpu-1gb
+      instance_count: 1
+      envs:
+        - key: NODE_ENV
+          value: production
+        - key: DATABASE_URL
+          value: ${db.DATABASE_URL}
+        - key: REDIS_URL
+          value: ${redis.DATABASE_URL}
+        - key: ENCRYPTION_KEY
+          scope: RUN_TIME
+          type: SECRET
+        - key: APP_URL
+          scope: RUN_TIME
+
+  # Runs once before each deploy goes live. Uses the worker image (has pnpm +
+  # drizzle-kit + the committed migrations) - the web image is a slim standalone
+  # bundle and cannot run migrations.
+  jobs:
+    - name: migrate
+      kind: PRE_DEPLOY
+      dockerfile_path: apps/worker/Dockerfile
+      source_dir: /
+      instance_size_slug: apps-s-1vcpu-0.5gb
+      run_command: pnpm --filter @dayotter/db migrate
+      envs:
+        - key: DATABASE_URL
+          value: ${db.DATABASE_URL}
+
+  databases:
+    - name: db
+      engine: PG
+      version: "16"
+      production: false # free dev database; set true for a managed cluster
+    - name: redis
+      engine: REDIS # paid managed Valkey; rename to VALKEY if your account requires it
+      production: true

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Make all your calendars work as one.**
 The open-source calendar & scheduling app for people juggling **multiple calendars** - connect every calendar (personal + work + clients), never get double-booked, protect your focus, and share **one booking link that respects them all**. With an AI assistant, Otter, built into the core.
 
-**[▶ Try the hosted version](https://dayotter.com)** &nbsp;·&nbsp; [🚀 One-click deploy to Render](https://render.com/deploy?repo=https://github.com/Dayotter/dayotter) &nbsp;·&nbsp; [🐳 Self-host with Docker](#self-hosting-production) &nbsp;·&nbsp; [How we compare](./docs/COMPARISON.md)
+**[▶ Try the hosted version](https://dayotter.com)** &nbsp;·&nbsp; [🚀 Self-host it](#self-hosting-production) &nbsp;·&nbsp; [How we compare](./docs/COMPARISON.md)
 
 <br>
 
@@ -13,7 +13,7 @@ The open-source calendar & scheduling app for people juggling **multiple calenda
 
 <br>
 
-[Website](https://dayotter.com) · [Docs](./docs) · [Discord](https://discord.gg/cxwETDsY85) · [Roadmap](./docs/ROADMAP.md) · [Discussions](https://github.com/Dayotter/dayotter/discussions) · [Good first tasks](./docs/TASKS.md) · [Contributing](./CONTRIBUTING.md)
+[Docs](./docs) · [Discord](https://discord.gg/cxwETDsY85) · [Roadmap](./docs/ROADMAP.md) · [Discussions](https://github.com/Dayotter/dayotter/discussions) · [Good first tasks](./docs/TASKS.md) · [Contributing](./CONTRIBUTING.md)
 
 ![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)
 ![Self-hostable](https://img.shields.io/badge/self--hostable-yes-brightgreen)
@@ -147,15 +147,24 @@ Run the mobile app against your local server with `pnpm --filter @dayotter/mobil
 
 ## Self-hosting (production)
 
-**Requirements:** Docker + Docker Compose, a Postgres database, and a Redis instance (both come up in the compose stack). AI is **optional** - DayOtter is a full scheduler with no model configured; add a key or a local model to turn Otter on. **Typical first-boot: ~10 minutes** to `docker compose up` and connect a calendar; OAuth for Google/Microsoft needs client IDs (see the integrations guide).
+Run the whole product - **web, worker, Postgres, Redis** - on your own infrastructure under AGPLv3. AI is **optional**: DayOtter is a full scheduler with no model configured; add a key or a local model to turn Otter on. Every path below runs database migrations for you.
 
-**One-click:** [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/Dayotter/dayotter) &nbsp; [![Deploy to DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/Dayotter/dayotter/tree/main) &nbsp; [![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/Dayotter/dayotter)
+**1. One-click** - the host provisions everything:
 
-Fly.io, Railway, Coolify / CapRover, or any Docker host: **[docs/DEPLOY.md](./docs/DEPLOY.md)**.
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/Dayotter/dayotter) &nbsp; [![Deploy to DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/Dayotter/dayotter/tree/main) &nbsp; [![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/Dayotter/dayotter)
 
-Or **Docker Compose** brings up Postgres, Redis, migrations, web, worker, and a reverse proxy. See [`deploy/README.md`](./deploy/README.md) and [`docs/SELF_HOSTING.md`](./docs/SELF_HOSTING.md). Redeploys always run migrations via [`deploy/deploy.sh`](./deploy/deploy.sh).
+Fly.io, Railway, AWS, and per-platform notes are in the **[deploy guide →](./docs/DEPLOY.md)**.
 
-**Connecting integrations** (Google, Microsoft, Apple, Salesforce, HubSpot, Zoom, Stripe, Twilio, Resend) - where to get each client ID / API key and which redirect URI & webhook to register: [`docs/INTEGRATIONS.md`](./docs/INTEGRATIONS.md), mirrored on the site at `/docs/integration-setup`.
+**2. Your own server, one command** - installs Docker, generates secrets, starts everything (Postgres, Redis, web, worker, and a Caddy reverse proxy with automatic HTTPS):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Dayotter/dayotter/main/deploy/install.sh \
+  | sudo DAYOTTER_DOMAIN=cal.example.com bash
+```
+
+Prefer to drive Docker Compose yourself? See [`deploy/README.md`](./deploy/README.md). Upgrade a running instance safely (back up → migrate → health-check → roll back on failure) with [`deploy/upgrade.sh`](./deploy/upgrade.sh).
+
+**Then: connect integrations** (Google, Microsoft, Apple, Stripe, Twilio, …) - where to get each client ID / key and which redirect URI & webhook to register: [`docs/INTEGRATIONS.md`](./docs/INTEGRATIONS.md).
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,9 @@ Run the mobile app against your local server with `pnpm --filter @dayotter/mobil
 
 **Requirements:** Docker + Docker Compose, a Postgres database, and a Redis instance (both come up in the compose stack). AI is **optional** - DayOtter is a full scheduler with no model configured; add a key or a local model to turn Otter on. **Typical first-boot: ~10 minutes** to `docker compose up` and connect a calendar; OAuth for Google/Microsoft needs client IDs (see the integrations guide).
 
-**One-click:** [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/Dayotter/dayotter) &nbsp; (Railway / DigitalOcean / Coolify / CapRover / any Docker host: **[docs/DEPLOY.md](./docs/DEPLOY.md)**).
+**One-click:** [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/Dayotter/dayotter) &nbsp; [![Deploy to DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/Dayotter/dayotter/tree/main) &nbsp; [![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/Dayotter/dayotter)
+
+Fly.io, Railway, Coolify / CapRover, or any Docker host: **[docs/DEPLOY.md](./docs/DEPLOY.md)**.
 
 Or **Docker Compose** brings up Postgres, Redis, migrations, web, worker, and a reverse proxy. See [`deploy/README.md`](./deploy/README.md) and [`docs/SELF_HOSTING.md`](./docs/SELF_HOSTING.md). Redeploys always run migrations via [`deploy/deploy.sh`](./deploy/deploy.sh).
 

--- a/app.json
+++ b/app.json
@@ -1,0 +1,45 @@
+{
+  "name": "DayOtter",
+  "description": "Open-source, AI-native scheduling. Connect every calendar, never get double-booked, share one booking link that respects them all.",
+  "repository": "https://github.com/Dayotter/dayotter",
+  "logo": "https://raw.githubusercontent.com/Dayotter/dayotter/main/.github/assets/logo.png",
+  "keywords": ["calendar", "scheduling", "booking", "nextjs", "self-hosted", "ai"],
+  "stack": "container",
+  "addons": [
+    { "plan": "heroku-postgresql" },
+    { "plan": "heroku-redis" }
+  ],
+  "formation": {
+    "web": { "quantity": 1, "size": "basic" },
+    "worker": { "quantity": 1, "size": "basic" }
+  },
+  "env": {
+    "NODE_ENV": {
+      "value": "production"
+    },
+    "AUTH_SECRET": {
+      "description": "Session signing secret (32+ random chars). Auto-generated.",
+      "generator": "secret"
+    },
+    "ENCRYPTION_KEY": {
+      "description": "MUST be 64 hex chars for encrypting calendar tokens at rest. Generate with: openssl rand -hex 32",
+      "required": true
+    },
+    "APP_URL": {
+      "description": "Your app's public URL, e.g. https://your-app.herokuapp.com",
+      "required": true
+    },
+    "BETTER_AUTH_URL": {
+      "description": "Same as APP_URL.",
+      "required": true
+    },
+    "NEXT_PUBLIC_APP_URL": {
+      "description": "Same as APP_URL. NOTE: baked into the web bundle at build time - set it, then trigger a rebuild (git push / redeploy) for client-side links to pick it up.",
+      "required": false
+    },
+    "AI_PROVIDER": {
+      "description": "Optional: \"anthropic\" or \"openai\". Leave blank to run with no AI (DayOtter is a full scheduler without it).",
+      "required": false
+    }
+  }
+}

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -38,26 +38,75 @@ run migrations before each deploy. After the first deploy:
 > Render renamed "Redis" to "Key Value". If your account only offers `type: keyvalue`,
 > change that one line in `render.yaml`.
 
+## One-click: DigitalOcean App Platform
+
+[![Deploy to DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/Dayotter/dayotter/tree/main)
+
+Uses [`.do/deploy.template.yaml`](../.do/deploy.template.yaml) to provision web +
+worker + Postgres + a **PRE_DEPLOY** migration job. During the create flow, set
+`ENCRYPTION_KEY` and `AUTH_SECRET` (`openssl rand -hex 32` each) and, after the first
+deploy, `APP_URL` / `NEXT_PUBLIC_APP_URL` / `BETTER_AUTH_URL` to your assigned
+`https://<name>.ondigitalocean.app` (then redeploy so `NEXT_PUBLIC_APP_URL` bakes in).
+
+> 💸 DigitalOcean has **no free Redis** - the template's `engine: REDIS` line
+> provisions a paid managed **Valkey** cluster. If your account rejects `REDIS`, rename
+> it to `VALKEY`. Postgres uses the free dev database (`production: false`).
+
+## Fly.io
+
+DayOtter runs as **two Fly apps** (web + worker ship different images). Configs live in
+[`fly/`](../fly/); deploy from the repo root so the Docker build context is the whole
+monorepo. Migrations run from the worker app's `release_command`, so **deploy the
+worker first**:
+
+```bash
+fly postgres create --name dayotter-db          # managed Postgres
+fly redis create                                # Upstash Redis - copy the redis:// URL
+
+# worker (also runs migrations via release_command)
+fly apps create dayotter-worker
+fly postgres attach dayotter-db --app dayotter-worker
+fly secrets set --app dayotter-worker REDIS_URL=redis://... \
+  ENCRYPTION_KEY=$(openssl rand -hex 32) APP_URL=https://dayotter-web.fly.dev
+fly deploy --config fly/fly.worker.toml
+
+# web
+fly apps create dayotter-web
+fly postgres attach dayotter-db --app dayotter-web
+fly secrets set --app dayotter-web REDIS_URL=redis://... \
+  AUTH_SECRET=$(openssl rand -hex 32) ENCRYPTION_KEY=<same key as worker> \
+  APP_URL=https://dayotter-web.fly.dev BETTER_AUTH_URL=https://dayotter-web.fly.dev
+fly deploy --config fly/fly.web.toml
+```
+
+Use the **same** `ENCRYPTION_KEY` on both apps.
+
+## One-click: Heroku
+
+[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/Dayotter/dayotter)
+
+Uses [`app.json`](../app.json) + [`heroku.yml`](../heroku.yml) (container stack) to add
+Postgres + Redis, run migrations in the **release phase** (worker image), and start the
+web + worker dynos. `AUTH_SECRET` is auto-generated; set `ENCRYPTION_KEY` and the URL
+vars when prompted.
+
+> If the button errors on the container stack, deploy from the CLI instead:
+> `heroku create → heroku stack:set container → git push heroku main`, then
+> `heroku addons:create heroku-postgresql` and `heroku-redis`. `NEXT_PUBLIC_APP_URL`
+> is baked at build time - set it and push again for client-side links to use it.
+
 ## Railway
 
-Railway builds each service straight from its Dockerfile. There's no committed template
-(a Railway template is published from the Railway dashboard, not the repo), so:
+Config-as-code lives in [`railway.web.json`](../railway.web.json) and
+[`railway.worker.json`](../railway.worker.json) (a one-click Railway *button* must be
+published from your own dashboard, so it can't ship in the repo):
 
-1. New Project → Deploy from repo → add **two services** pointing at
-   `apps/web/Dockerfile` and `apps/worker/Dockerfile`.
+1. New Project → Deploy from repo → add **two services**. In each service's settings set
+   **Config-as-code Path** to `railway.web.json` (web) and `railway.worker.json`
+   (worker). The worker config already runs migrations as its pre-deploy command.
 2. Add the **Postgres** and **Redis** plugins; Railway injects `DATABASE_URL` /
-   `REDIS_URL` - reference them on both services.
+   `REDIS_URL` - reference both on each service.
 3. Set the three values above; expose the web service and use its domain as `APP_URL`.
-
-*(Want a one-click Railway button? Publish a template from your deployed project and
-drop the `https://railway.com/new/template?...` URL into this file.)*
-
-## DigitalOcean App Platform
-
-Create an App from this repo with two **Dockerfile** components (web + worker), a
-**Dev/Managed Postgres** and a **Managed Redis (Valkey)**; bind `DATABASE_URL` /
-`REDIS_URL` and set the three values above. Run `pnpm --filter @dayotter/db migrate`
-as a pre-deploy job.
 
 ## Coolify / CapRover / any Docker host
 

--- a/fly/fly.web.toml
+++ b/fly/fly.web.toml
@@ -1,0 +1,48 @@
+# Fly.io - DayOtter web (Next.js). Deploy from the repo root so the Docker build
+# context is the whole monorepo:
+#
+#   fly deploy --config fly/fly.web.toml
+#
+# DayOtter is two Fly apps because it ships two images (this slim web bundle has no
+# pnpm; the worker image does). Create Postgres + Redis once and attach to BOTH apps:
+#
+#   fly postgres create --name dayotter-db
+#   fly postgres attach dayotter-db --app dayotter-web      # sets DATABASE_URL
+#   fly redis create                                        # Upstash; copy the redis:// URL
+#   fly secrets set --app dayotter-web \
+#     REDIS_URL=redis://... \
+#     AUTH_SECRET=$(openssl rand -hex 32) \
+#     ENCRYPTION_KEY=$(openssl rand -hex 32) \
+#     APP_URL=https://dayotter-web.fly.dev \
+#     BETTER_AUTH_URL=https://dayotter-web.fly.dev
+#
+# Migrations run from the WORKER app's release_command (see fly.worker.toml) - deploy
+# it first so the schema is current before web goes live.
+
+app = "dayotter-web"
+primary_region = "iad"
+
+[build]
+  dockerfile = "apps/web/Dockerfile"
+
+[env]
+  NODE_ENV = "production"
+  PORT = "3000"
+
+[http_service]
+  internal_port = 3000
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 1
+
+  [[http_service.checks]]
+    interval = "15s"
+    timeout = "3s"
+    grace_period = "20s"
+    method = "GET"
+    path = "/api/me" # fast 401 = alive
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "1gb"

--- a/fly/fly.worker.toml
+++ b/fly/fly.worker.toml
@@ -1,0 +1,37 @@
+# Fly.io - DayOtter worker (BullMQ: reminders, calendar sync, webhooks) + migrations.
+# Deploy from the repo root so the Docker build context is the whole monorepo:
+#
+#   fly deploy --config fly/fly.worker.toml
+#
+# This app owns the migration step: `release_command` runs in the worker image
+# (which has pnpm + drizzle-kit + the committed migrations) before the release goes
+# live. Deploy the worker BEFORE the web app so the schema is current.
+#
+# Attach the same Postgres + Redis you created for the web app, and mirror the secrets:
+#
+#   fly postgres attach dayotter-db --app dayotter-worker    # sets DATABASE_URL
+#   fly secrets set --app dayotter-worker \
+#     REDIS_URL=redis://... \
+#     ENCRYPTION_KEY=<same 64-hex key as the web app> \
+#     APP_URL=https://dayotter-web.fly.dev
+
+app = "dayotter-worker"
+primary_region = "iad"
+
+[build]
+  dockerfile = "apps/worker/Dockerfile"
+
+[deploy]
+  release_command = "pnpm --filter @dayotter/db migrate"
+
+[env]
+  NODE_ENV = "production"
+
+# Background worker - no public HTTP service/ports. One always-on machine.
+[processes]
+  worker = "pnpm --filter @dayotter/worker start"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "1gb"
+  processes = ["worker"]

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,26 @@
+# Heroku container deploy for DayOtter (web + worker).
+#
+# Heroku builds each Dockerfile with the repo root as context, runs migrations in the
+# release phase (using the worker image, which has pnpm + drizzle-kit), then starts
+# the web and worker dynos. Provision Postgres + Redis with:
+#
+#   heroku addons:create heroku-postgresql        # sets DATABASE_URL
+#   heroku addons:create heroku-redis             # sets REDIS_URL
+#
+# See app.json for the one-click "Deploy to Heroku" button and required config vars.
+build:
+  docker:
+    web: apps/web/Dockerfile
+    worker: apps/worker/Dockerfile
+
+# Runs once per release, before the new dynos receive traffic. The web image can't
+# run migrations (slim standalone, no pnpm), so run them in the worker image.
+release:
+  image: worker
+  command:
+    - pnpm --filter @dayotter/db migrate
+
+run:
+  # Heroku injects $PORT at runtime; the Next.js standalone server binds to it.
+  web: node apps/web/server.js
+  worker: pnpm --filter @dayotter/worker start

--- a/railway.web.json
+++ b/railway.web.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "apps/web/Dockerfile"
+  },
+  "deploy": {
+    "healthcheckPath": "/api/me",
+    "healthcheckTimeout": 120,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}

--- a/railway.worker.json
+++ b/railway.worker.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "apps/worker/Dockerfile"
+  },
+  "deploy": {
+    "preDeployCommand": "pnpm --filter @dayotter/db migrate",
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}


### PR DESCRIPTION
Adds first-class deploy configs for the major managed platforms, so DayOtter has a real committed spec (not just prose) for each. Before this, only **Render** and **AWS** had committed one-click configs; Railway and DigitalOcean were manual walkthroughs.

Every platform needs the same five pieces — **web, worker, Postgres, Redis, and a migration step that runs before boot** — and the only real per-platform difference is the migration hook. In all of them migrations run from the **worker image** (which has pnpm + drizzle-kit); the slim web standalone image can't run them.

| Platform | Files | Migration hook | One-click |
|---|---|---|---|
| **DigitalOcean App Platform** | `.do/deploy.template.yaml` | `PRE_DEPLOY` job | ✅ Deploy-to-DO button |
| **Fly.io** | `fly/fly.web.toml`, `fly/fly.worker.toml` | worker `[deploy] release_command` | CLI (`fly deploy -c …`) |
| **Heroku** | `app.json`, `heroku.yml` | `release` phase (worker image) | ✅ Deploy-to-Heroku button |
| **Railway** | `railway.web.json`, `railway.worker.json` | worker `preDeployCommand` | config-as-code (button must be published from a Railway account) |

**Notes / caveats (documented in each file + docs/DEPLOY.md):**
- **Fly = two apps** because web and worker ship different images; deploy the worker first (it migrates), then web. Uses the same `ENCRYPTION_KEY` on both.
- **Redis isn't free on DO or Heroku** (paid managed Valkey / `heroku-redis` add-on); Fly uses Upstash. Render remains the only bundled-Redis free-ish path. Called out inline.
- **`NEXT_PUBLIC_APP_URL` is baked at build time** on every platform — set it and redeploy, same as Render.
- **Railway can't ship a true one-click button** from the repo (templates are published from the dashboard), so it gets config-as-code + documented steps.

**Validation:** all seven files parse (JSON/YAML/TOML) and cross-check — service/db refs resolve, both Dockerfile paths exist, health-check target `/api/me` exists, migrate command matches `packages/db` (`drizzle-kit migrate`). Not yet deployed live on each platform (each needs its own account + billing) — the specs mirror the already-working Render blueprint and Docker Compose migrate path.

README self-hosting section now shows **Render + DO + Heroku** buttons; `docs/DEPLOY.md` has per-platform steps.
