### PR TITLE
docs: audit + de-stale all markdown after recent shipping

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -12,7 +12,7 @@ skill under [`.claude/skills/`](../.claude/skills/) for the area you're touching
   A small `apps/web/lib/ee/` layer holds cloud-only infrastructure, inert unless
   `DAYOTTER_CLOUD=1`. Never move a core feature behind that flag.
 - **API-first** - all domain logic lives in `packages/*`, never only in `apps/web`.
-  Web and (upcoming) mobile are peer clients of a stable REST/OpenAPI surface.
+  Web and mobile are peer clients of a stable REST/OpenAPI surface.
 
 ## Layout
 
@@ -32,8 +32,8 @@ packages/notifications | emails | auth | plugin-host | plugin-sdk | plugins
 
 ```bash
 pnpm turbo typecheck                 # all packages (15 projects)
-pnpm --filter @dayotter/core test    # 30 tests incl. DST correctness
-pnpm --filter @dayotter/web test     # ~85 tests (vitest)
+pnpm --filter @dayotter/core test    # 39 tests incl. DST correctness
+pnpm --filter @dayotter/web test     # ~165 tests (vitest)
 npx biome check --write <files>      # format + lint (biome, not prettier/eslint)
 ```
 

--- a/.claude/skills/dayotter-overview/SKILL.md
+++ b/.claude/skills/dayotter-overview/SKILL.md
@@ -44,8 +44,8 @@ Two **single sources of truth** everything else reads from:
 
 ```bash
 pnpm turbo typecheck
-pnpm --filter @dayotter/core test   # 30, incl. DST
-pnpm --filter @dayotter/web test    # ~85
+pnpm --filter @dayotter/core test   # 39, incl. DST
+pnpm --filter @dayotter/web test    # ~165
 npx biome check --write <files>     # biome - NOT prettier/eslint
 ```
 

--- a/.claude/skills/editions-and-billing/SKILL.md
+++ b/.claude/skills/editions-and-billing/SKILL.md
@@ -10,7 +10,6 @@ DayOtter ships in two editions chosen **at deploy time** by one env var.
 ```ts
 // apps/web/lib/billing/edition.ts
 export const isCloud = process.env.DAYOTTER_CLOUD === "1";
-export const isSelfHosted = !isCloud;
 ```
 
 - **Self-hosted (flag unset - the default):** every Pro feature is unlocked, no

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ alternative). Turborepo + pnpm monorepo. TypeScript everywhere, strict mode.
 - `packages/core` - pure logic: the availability engine, round-robin, crypto, SSRF guards. No I/O.
 - `packages/db` - Drizzle schema + migrations (`drizzle/`).
 - `packages/calendar` - provider adapters (Google, Microsoft, Apple/CalDAV, ICS).
-- `packages/integrations` - CRM (Salesforce, HubSpot), Zoom.
+- `packages/integrations` - CRM (Salesforce, HubSpot).
 - `packages/{jobs,notifications,emails,auth,plugin-host,plugin-sdk,plugins}` - supporting libs.
 
 ## Commands (run from the repo root)
@@ -28,7 +28,7 @@ pnpm build          # turbo run build
 pnpm typecheck      # tsc --noEmit across all packages
 pnpm test           # vitest across packages
 pnpm check          # biome check --write (format + lint + import order)
-pnpm --filter web typecheck   # scope to one package
+pnpm --filter @dayotter/web typecheck   # scope to one package
 pnpm db:generate    # drizzle-kit generate after a schema change
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Think Calendly + Motion + a real assistant - except **open-source and self-hosta
 
 - **Individuals** - a booking page and an assistant that clears the scheduling back-and-forth for you.
 - **Teams** - weighted round-robin, collective availability, routing forms, and shared analytics.
-- **Organisations & self-hosters** - run the entire product on your own infrastructure under AGPLv3, keep your calendar data on your servers, and roll the mobile app out to your whole team pointed at your own instance (see [Mobile app](#mobile-app-in-progress)).
+- **Organisations & self-hosters** - run the entire product on your own infrastructure under AGPLv3, keep your calendar data on your servers, and roll the mobile app out to your whole team pointed at your own instance (see [Mobile app](#mobile-app)).
 
 ## Why we're building it
 
@@ -80,7 +80,7 @@ It covers the day-to-day host workflow - dashboard, bookings, availability, even
 
 No forking, no per-org app build required. One app, any DayOtter server.
 
-> Note: the app is pre-1.0 and evolving quickly. Android push needs a Firebase `google-services.json` to deliver remote reminders - see [`docs/TASKS.md`](./docs/TASKS.md).
+> Note: the app is pre-1.0 and evolving quickly. Android push works out of the box for the Play Store build. Self-hosters point it at their own Firebase project by dropping `apps/mobile/google-services.json` (or setting `GOOGLE_SERVICES_JSON`); `app.config.js` wires it up automatically.
 
 ## Open-core
 
@@ -117,7 +117,7 @@ Full breakdown: [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md).
 
 ## Quick start (development)
 
-**Prerequisites:** Node 20+, [pnpm](https://pnpm.io) 9+, and Docker (for Postgres + Redis). Everything else installs with `pnpm install`.
+**Prerequisites:** Node 20+, [pnpm](https://pnpm.io) 10+, and Docker (for Postgres + Redis). Everything else installs with `pnpm install`.
 
 ```bash
 git clone https://github.com/Dayotter/dayotter && cd dayotter

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -6,10 +6,14 @@ this monorepo, shares code with the web via `@dayotter/core`, and talks to the
 
 ## Status
 
-Foundation + core screens: **auth (sign in / sign up), dashboard, event types,
-teams, bookings**, all wired to the live REST API and typechecked. Next parity
-milestones (added alongside their web counterparts): availability editor,
-event-type create/edit, team management, calendar connect, booking manage, settings.
+Shipping: **live on Google Play** (`com.dayotter.app`, 0.3.0 / versionCode 12);
+iOS shares the same codebase and is in progress (not yet submitted). Screens now
+track their web counterparts - auth (sign in / sign up), dashboard, event types,
+availability editor, teams and team detail, calendars, bookings with
+cancel/reschedule reason capture, plus payouts, packages/credits, group polls,
+routing forms, CRM connections, billing/edition, out-of-office, automations,
+workflows, insights, analytics, and inbox - all wired to the live REST API and
+typechecked.
 
 Type-checks in the monorepo (`pnpm --filter @dayotter/mobile typecheck`). Running
 on a simulator additionally requires the Expo/RN native toolchain (below).

--- a/apps/mobile/store/README.md
+++ b/apps/mobile/store/README.md
@@ -111,8 +111,9 @@ to download the signed **.aab** - upload that in Play Console → Production →
 Create release. Bump `versionCode` (or rely on `autoIncrement`) for each
 subsequent upload.
 
-To push straight to Play from CI later: `eas submit -p android` (needs a Play
-service-account JSON configured under `submit.production`).
+To push straight to Play from CI later: `eas submit -p android` - `submit.production`
+in [`../eas.json`](../eas.json) targets the internal track as a draft and authorizes
+via the Play service account linked to the EAS project (no local key path).
 
 ## EAS build (Expo cloud) - iOS (.ipa)
 

--- a/apps/mobile/store/SUBMIT.md
+++ b/apps/mobile/store/SUBMIT.md
@@ -5,7 +5,7 @@ A tight, per-release checklist. General build docs + listing copy live in
 from `apps/mobile/`.
 
 > **Version source of truth:** [`../app.json`](../app.json) (`eas.json` uses
-> `appVersionSource: local`). Current: **0.3.0 / versionCode 11**. The
+> `appVersionSource: local`). Current: **0.3.0 / versionCode 12**. The
 > `production` profile has `autoIncrement`, so the next build bumps versionCode
 > automatically — you don't edit it by hand.
 
@@ -17,11 +17,11 @@ from `apps/mobile/`.
    `play-feature-graphic-1024x500.png`, ≥2 phone screenshots), **Data safety**
    form, **content rating**, target audience, and a **privacy policy URL**
    (`https://dayotter.com/privacy`). Play won't let you roll out until these are green.
-2. **Play service-account key** — Play Console → *Setup → API access* → create/
-   link a Google Cloud service account with the **Release Manager** role, download
-   its JSON, and save it at **`apps/mobile/play-service-account.json`**. It's
-   **gitignored** (`*service-account*.json`) — never commit it. `eas.json` →
-   `submit.production.android.serviceAccountKeyPath` points at it.
+2. **Play submissions use the EAS-managed Play service account** — the Google
+   Play account linked to this EAS project (set up once via `eas credentials` /
+   the Expo dashboard, using a Release Manager service account). `eas.json` →
+   `submit.production.android` no longer pins a local `serviceAccountKeyPath`, so
+   there's no JSON key to download or keep out of git — EAS holds it.
 3. `npm i -g eas-cli` (or `npx eas-cli@latest`) and `eas login`.
 
 ## 1. Build the AAB (from `main`)
@@ -38,7 +38,7 @@ eas build -p android --profile production
 
 EAS builds a **signed .aab** in the cloud with its managed **upload key** (not the
 local debug keystore — that one is only for sideloaded test APKs and Play rejects
-it). `autoIncrement` bumps versionCode (11 → 12) and writes it back to `app.json`
+it). `autoIncrement` bumps versionCode (12 → 13) and writes it back to `app.json`
 — **commit that bump** so the next build continues cleanly.
 
 ## 2. Submit to the internal track (draft)
@@ -58,8 +58,9 @@ prompted (or add `--latest`).
 2. Install from the internal-test link on a device and smoke-test (sign in, open
    Otter, ask "how busy am I this week?", create a booking).
 3. When happy, **promote** the release: Internal → (Closed/Open testing →)
-   **Production**, set the rollout %, and submit for review. First-time apps take
-   a few days for Google review.
+   **Production**, set the rollout %, and submit for review. The app is already
+   live on Play, so updates usually clear Google review faster than the first
+   submission did.
 
 ## 4. Next release
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,7 +1,7 @@
 # Deploying dayotter
 
 Self-host the whole platform - web app, background worker, Postgres, Redis, and
-automatic HTTPS - on one server. Three ways in, easiest first.
+automatic HTTPS - on one server. Four ways in, easiest first.
 
 > These links point at `Dayotter/dayotter`. If you're deploying from a fork,
 > swap in your own `OWNER/REPO` first.
@@ -175,7 +175,7 @@ Compose network.
 cd deploy
 docker compose -f docker-compose.prod.yml logs -f            # tail logs
 docker compose -f docker-compose.prod.yml ps                 # status
-git -C .. pull && bash install.sh                            # update to latest
+./upgrade.sh                                                 # safe upgrade (backup → migrate → health-check)
 docker compose -f docker-compose.prod.yml exec postgres \
   pg_dump -U dayotter dayotter > backup-$(date +%F).sql        # back up the DB
 ```
@@ -183,7 +183,9 @@ docker compose -f docker-compose.prod.yml exec postgres \
 ## Turning on integrations
 
 Everything except the calendar core is optional and off until you add its keys
-to `deploy/.env`, then `docker compose -f docker-compose.prod.yml up -d`:
+to `deploy/.env`, then `docker compose -f docker-compose.prod.yml up -d`.
+Step-by-step setup for each provider (redirect URIs, webhooks, which keys need a
+rebuild) is in [`INTEGRATIONS.md`](./INTEGRATIONS.md):
 
 - **Google / Microsoft calendar + Google sign-in** - OAuth client id/secret
   (register `${APP_URL}/api/auth/callback/google` as a redirect URI).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,7 +17,8 @@ Every feature builds on these; nothing duplicates their logic.
    busy blocks + constraints → bookable slots. DST-correct, unit-tested.
 4. **Notification** (`packages/jobs` + `apps/worker/reminders` + `packages/notifications`) -
    durable BullMQ delayed jobs; multi-channel delivery.
-5. **LLM** (`apps/web/lib/ai/llm.ts`) - the single Anthropic choke point; model
+5. **LLM** (`apps/web/lib/ai/llm.ts`) - the single vendor-agnostic choke point
+   (Anthropic / OpenAI / OpenAI-compatible, selected by `AI_PROVIDER`); model
    tiering, prompt caching, structured output. Every AI feature goes through it.
 
 ## Monorepo layout
@@ -36,6 +37,10 @@ packages/
   notifications Slack / Twilio (SMS·WhatsApp) / Expo push / web push
   emails        Nodemailer + transactional templates
   auth          Better Auth server instance (identity + organizations)
+  embed-react   White-label React components for embedding the booking flow
+  plugin-sdk    Public contract for building in-process DayOtter extensions
+  plugin-host   Loads config-listed plugins and runs their hooks in-process
+  plugins       First-party bundled plugins (notes, webhook-relay)
 ```
 
 ## `apps/web/lib` - by domain

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -24,6 +24,10 @@ Rules:
 
 ## 2. API-first - web and mobile are peer clients
 
+> **Status (2026-07):** shipped - the Android app is live on Google Play and
+> `apps/mobile` (Expo / React Native) exists; iOS ships from the same codebase and
+> is in progress. The original decision below stands and guided the build.
+
 Android and iOS apps are coming. So:
 - **All domain logic lives in `packages/*`, never in `apps/web`.** The Next.js app
   is one client; it must not be the only place a rule exists.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -108,6 +108,17 @@ published from your own dashboard, so it can't ship in the repo):
    `REDIS_URL` - reference both on each service.
 3. Set the three values above; expose the web service and use its domain as `APP_URL`.
 
+## One-click: AWS
+
+[![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://raw.githubusercontent.com/Dayotter/dayotter/main/deploy/aws/cloudformation.yaml&stackName=dayotter)
+
+Launches a single EC2 instance that boots the full compose stack - web + worker +
+Postgres + Redis + a Caddy reverse proxy with automatic HTTPS - from
+[`deploy/aws/cloudformation.yaml`](../deploy/aws/cloudformation.yaml). Set the optional
+**Domain** parameter for automatic HTTPS, or start on plain HTTP at the instance's public
+IP. Full walkthrough - adding a domain later, cost, upgrades - is in
+[`deploy/README.md`](../deploy/README.md#option-a---one-click-on-aws-recommended).
+
 ## Coolify / CapRover / any Docker host
 
 Use the production compose in [`deploy/`](../deploy/README.md) - it brings up Postgres,
@@ -115,7 +126,7 @@ Redis, migrations, web, worker, and a Caddy reverse proxy with automatic HTTPS:
 
 ```bash
 git clone https://github.com/Dayotter/dayotter && cd dayotter/deploy
-cp .env.example .env        # fill ENCRYPTION_KEY, AUTH_SECRET, DAYOTTER_DOMAIN, ...
+cp .env.prod.example .env   # fill ENCRYPTION_KEY, AUTH_SECRET, DAYOTTER_SITE_ADDRESS, ...
 ./deploy.sh                 # builds, migrates, and starts everything
 ```
 

--- a/docs/EDITIONS.md
+++ b/docs/EDITIONS.md
@@ -19,11 +19,11 @@ The hosted product at dayotter.com has:
 
 - **Free tier** - all core scheduling: unlimited event types, availability,
   Google/Microsoft/Apple calendar sync, booking management, email reminders,
-  teams.
+  teams - plus Otter AI, deep-work defense, the developer platform (API /
+  webhooks / embed), and Slack/WhatsApp reminders, which are free on cloud too.
 - **Pro - $9/seat/month** - unlocks the differentiator bundle (the same features
-  self-hosters get for free): AI + Intelligence, automations, analytics,
-  Slack/WhatsApp/SMS reminders, adaptive availability, travel-aware, deep-work
-  defense, accept-payments, and the developer platform.
+  self-hosters get for free): automations, workflows, analytics, SMS reminders,
+  adaptive availability, travel-aware, and accept-payments.
 - **Cloud-only** (commercial `ee/`, Pro): **Managed AI** (no API key to
   configure), **SSO** (SAML / Google Workspace), **White-label** (remove branding
   + custom booking domain), and **Hosted messaging** (SMS/WhatsApp on dayotter's

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,6 +1,6 @@
 # dayotter - Feature Plan
 
-> Open-source (permissive, Apache-2.0) team scheduling & calendar platform.
+> Open-source (copyleft, AGPLv3) team scheduling & calendar platform.
 > Superset of Calendly / Cal.com / SavvyCal / Reclaim / Motion / Clockwise, with
 > **shared team availability as a first-class primitive** as the core wedge.
 
@@ -229,10 +229,11 @@ References: **Planif.ai** (minimal, color-coded, confirm-first AI) and **Todofi*
 - Mobile-first interactions (gestures, drag-drop) - see mobile note below.
 - Meaningful analytics (where your time actually went), **no vanity metrics**.
 
-## Mobile (Android + iOS) - structural readiness now
-Native apps are planned. The codebase is kept **API-first**: all domain logic in
-`packages/*`, a versioned REST/OpenAPI contract, token-based auth, shared Zod
-DTOs, and push as a notification channel. See
+## Mobile (Android + iOS)
+The Android app is **live on Google Play**; iOS is in progress. The codebase is
+kept **API-first**: all domain logic in `packages/*`, a versioned REST/OpenAPI
+contract, token-based auth, shared Zod DTOs, and push as a notification channel.
+The native client lives in `apps/mobile` (Expo / React Native). See
 [DECISIONS.md](DECISIONS.md#2-api-first--web-and-mobile-are-peer-clients).
 
 ## What P0 (MVP) explicitly includes

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -6,8 +6,8 @@ Living map of the **original brief requirements → status**. Legend: ✅ done �
 > This page tracks the *original* asks. For where the product is heading next, see
 > the [Roadmap](ROADMAP.md) (the maintained forward-looking list) and the full
 > [Feature catalog](FEATURES.md). The original brief is now essentially complete;
-> the one requirement not fully shipped is native mobile (built, pending a device
-> test + store submission).
+> the one requirement not fully shipped is native iOS - the Android app is live on
+> Google Play (v0.3.0), and iOS ships from the same Expo codebase (in progress).
 
 ## Original must-haves (first brief)
 
@@ -25,7 +25,7 @@ Living map of the **original brief requirements → status**. Legend: ✅ done �
 |---|---|---|---|
 | 1 | Timezone correctness (no wrong-hour bookings) | ✅ | UTC-everywhere; DST unit-tested. |
 | 2 | Remember user preferences (encrypted at rest) | ✅ | `user_preferences` (AES-GCM blob for sensitive data) + full Settings UI (profile, preferences, notifications, automations, calendars, CRM, billing, developer). |
-| 3 | iOS + Android apps | 🟡 | Expo / React Native app (`apps/mobile`, SDK 53, shares `@dayotter/core`): auth, dashboard, event types (CRUD), teams, bookings (+ detail & cancel), availability editor, voice capture. Typechecks + Metro-bundles clean. **Remaining: run on a device, then build the AAB and submit to the stores** (also clears the Google Play 16 KB page-size gate). |
+| 3 | iOS + Android apps | 🟡 | Expo / React Native app (`apps/mobile`, SDK 53, shares `@dayotter/core`) with near-full web parity: auth, dashboard, event types (CRUD), teams (+ detail), bookings (detail, cancel/reschedule with reason), availability editor, voice capture, plus payouts, packages, polls, routing, CRM, billing, insights/analytics, automations/workflows, out-of-office, and inbox screens. **Android is live on Google Play** (v0.3.0, versionCode 12); iOS ships from the same codebase and is in progress. |
 | 4 | AI: calendar blocking, deep work, invite replies | ✅ | Otter does confirm-first focus/deep-work blocking; calendar invites surface in the Inbox with accept/decline; running-late overflow nudges ship. |
 | 5 | Stay in calendar/scheduling scope | ✅ | Guardrail documented + enforced in Otter's system prompt. |
 | 6 | Meeting-overflow "running late" nudge | ✅ | Worker detects overrun and notifies the next meeting's attendees (opt-in per user). |
@@ -49,10 +49,10 @@ Living map of the **original brief requirements → status**. Legend: ✅ done �
 | Native CRM sync (Salesforce / HubSpot) | 🟡 beta (built; needs a live test with provider credentials) |
 | Webhooks + API keys, automations/workflows, group polls, routing forms | ✅ |
 | Self-host: Docker/compose, one-command + AWS one-click installers | ✅ |
-| Mobile app (Expo, iOS + Android) | 🟡 built; pending device test + store submission |
+| Mobile app (Expo, iOS + Android) | 🟡 Android live on Google Play (v0.3.0); iOS in progress |
 
 ## Remaining gaps (priority order)
 
-1. **Mobile: device test → build AAB → submit to stores** (clears the Google Play 16 KB gate). The only original requirement not fully shipped.
+1. **Mobile: ship iOS** - the Android app is live on Google Play (v0.3.0); iOS ships from the same Expo codebase and is the remaining store submission. The only original requirement not fully shipped.
 2. **CRM sync: beta → GA** - live-test the Salesforce/HubSpot OAuth + push, then add field mapping and CRM-side routing.
 3. Everything else is forward-looking - see the [Roadmap](ROADMAP.md): Real Scribe (transcription), team briefings, deeper analytics, Zapier app, self-host SSO, proactive weekly planning.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -31,15 +31,14 @@ longest focus streak, external-vs-internal)
 per booking, kept in sync on reschedule/cancel
 
 **Platform** - ✅ multi-channel reminders (email/Slack/WhatsApp/SMS/push) ·
-✅ automations & workflows (unified) · ✅ daily morning briefing · ✅ API keys &
-webhooks · ✅ mobile app (Expo, iOS + Android)
+✅ automations & workflows (unified) · ✅ daily morning briefing · ✅ shared team
+briefings · ✅ API keys & webhooks · ✅ mobile app (Expo - Android live on Google Play, iOS in progress)
 
 ## Now (in progress / next up)
 
 - 🟡 **Native CRM (beta → GA)** - harden Salesforce / HubSpot sync, add field
   mapping and CRM-side routing
 - 🟡 **Real Scribe** - Zoom/Meet transcription → summary + action items
-- ⬜ **Team briefings** - a shared daily digest, not just personal
 - 🟡 **Deeper time analytics** - shipped back-to-back share, focus streaks,
   external-vs-internal; next: reclaimed time, recurring load
 

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -28,15 +28,17 @@ a one-shot migration, web, worker, and a reverse proxy.
 
 ```bash
 cd deploy
-cp .env.example .env            # fill in production values
+cp .env.prod.example .env       # fill in production values
 ./deploy.sh                     # build → run migrations → start
 ```
 
 `deploy.sh` **always runs migrations before starting the app** - a plain
 `docker compose up -d` reuses the completed migrate container and can boot new
 code against an un-migrated DB. Full walkthrough (nginx + TLS options) in
-[`deploy/README.md`](../deploy/README.md). To update: `git pull` then re-run
-`./deploy.sh`.
+[`deploy/README.md`](../deploy/README.md). To move to a newer version, use the
+safe upgrade script `./deploy/upgrade.sh` - it backs up Postgres, pulls, migrates,
+restarts, and waits for `/api/health` to go green, with rollback guidance if a step
+fails.
 
 ## Configuration
 
@@ -121,6 +123,8 @@ schema directly.
 - Rotate `BETTER_AUTH_SECRET` / `ENCRYPTION_KEY` carefully - changing
   `ENCRYPTION_KEY` invalidates stored OAuth tokens (users reconnect calendars).
 - The worker writes a Redis heartbeat; monitor it for liveness.
+- `GET /api/health` reports overall status plus a `version` field (the running git
+  build id) - useful for uptime checks and confirming an upgrade landed.
 
 ## Troubleshooting
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -24,12 +24,6 @@ build` (which imports server modules) tries to connect to Redis and logs
 - **Done when:** a clean `pnpm --filter @dayotter/web build` shows no Redis errors,
   and queues/heartbeat still work at runtime (worker enqueues/consumes).
 
-### 🟢 Add `CONTACT_EMAIL` to the deploy env example
-The contact form (`apps/web/app/api/contact/route.ts`) sends to `CONTACT_EMAIL`
-(default `hello@dayotter.com`), but that var isn't documented in
-`deploy/.env.prod.example` or `.env.example`.
-- **Done when:** both example files list `CONTACT_EMAIL` with a comment.
-
 ---
 
 ## Reliability / correctness
@@ -101,55 +95,6 @@ No tests currently exercise: `lib/payments/stripe.ts`, the withdraw route, check
 including the `/api/book` double-book guard.
 - **Do:** add focused unit/integration tests for any one of these (each is its own
   good PR). Follow the existing Vitest setup under `apps/web/lib/**/*.test.ts`.
-
----
-
-## Mobile (Expo) - parity with the web app
-
-The mobile app (`apps/mobile`) covers most host-facing features, but several web
-surfaces have **no mobile screen yet**. Each is a self-contained new screen; the
-web version is the reference. Add a route under `apps/mobile/app/` and follow the
-patterns in the existing screens (e.g. `settings.tsx`, `developer.tsx`).
-
-### 🟡 Android push notifications (Firebase/FCM)
-`expo-notifications` needs FCM on Android, but there's no `google-services.json`,
-so `FirebaseInitProvider` fails and remote reminders don't deliver (push is
-guarded, so it doesn't crash - it just no-ops). Create a Firebase project, add
-`google-services.json`, and wire it via `android.googleServicesFile` in
-`app.json`. Needs a Google/Firebase account (maintainer task).
-
-### 🟡 Stripe Connect payouts screen
-No mobile equivalent of `apps/web/app/(app)/settings/payouts/page.tsx` +
-`apps/web/components/payouts-panel.tsx`. Show per-currency available/pending
-balances and a withdraw action (`/api/payments/withdraw`, connect status).
-
-### 🟡 Session packages / credits
-No mobile equivalent of `apps/web/app/(app)/settings/packages/page.tsx` +
-`apps/web/components/packages-manager.tsx`. Create/manage prepaid session bundles
-per event type.
-
-### 🟡 Group polls (find-a-time)
-No mobile screen for `apps/web/app/(app)/polls/*`. List/create polls and finalize a time.
-
-### 🟡 Routing forms
-No mobile screen for `apps/web/app/(app)/routing/*`. Build/list qualify-and-route forms.
-
-### 🟢 CRM connections
-No mobile screen for `apps/web/app/(app)/settings/crm/page.tsx`. Connect/disconnect
-Salesforce/HubSpot (OAuth start + status).
-
-### 🟢 Billing / edition
-No mobile screen for `apps/web/app/(app)/settings/billing/page.tsx`. Show plan/edition
-and a link to manage the subscription.
-
-### 🟢 Team detail / edit
-Mobile `teams.tsx` is a read-only list; the web has `teams/[id]` for members and
-settings. Add a mobile team detail screen.
-
-### 🟢 Cancel/reschedule reason on mobile
-Whole-series cancel now works on mobile, but the optional **reason** isn't captured
-(Android has no `Alert.prompt`). Add a small text-input modal and pass `reason`
-through to `/api/bookings/[uid]/{cancel,reschedule}`.
 
 ---
 


### PR DESCRIPTION
After the recent shipping (mobile on Play, the 6-platform deploy set, upgrade.sh, 2FA/CalDAV/plugins/embed/etc.), a lot of docs still described the old state. This is a full markdown audit — every tracked `.md` file was checked against the actual code, and only stale / done / contradicted / redundant content was changed (no restyling). 18 files updated.

### Highlights (verified against source)
- **`docs/TASKS.md`** — removed the entire "Mobile parity" backlog section; every screen it called "not built yet" now exists (payouts, packages, polls, routing, CRM, billing, team detail, cancel/reschedule reason) and Android push is done (`google-services.json` committed + auto-wired by `app.config.js`). Removed the already-done `CONTACT_EMAIL` item. Genuinely-open items were re-verified in code and **kept** (Redis `lazyConnect`, contact-form persistence, recurring per-occurrence caps, whole-series *reschedule*, `rememberUserFact` wiring, booking-assistant cost ceiling, per-currency withdraw min, testing gaps).
- **`docs/FEATURES.md`** — license said **Apache-2.0**; corrected to **AGPLv3** (it contradicted every other doc).
- **`docs/EDITIONS.md`** — Free/Pro tier split corrected to match `lib/billing/features.ts` (AI, deep-work, developer platform, Slack/WhatsApp are free-tier, not Pro).
- **`docs/ARCHITECTURE.md`** — LLM choke point is now vendor-agnostic (Anthropic/OpenAI via `AI_PROVIDER`); added the four shipped packages (embed-react, plugin-sdk, plugin-host, plugins).
- **`README.md`** — reframed the Android-push note (works out of the box; self-hosters supply their own Firebase file), fixed a broken `#mobile-app` anchor, pnpm 9→10.
- **Deploy docs** — "three→four ways"; replaced a contradictory `install.sh` update command with `upgrade.sh`; added the missing AWS one-click to the deploy hub; fixed `.env.example`→`.env.prod.example` and `DAYOTTER_DOMAIN`→`DAYOTTER_SITE_ADDRESS`; surfaced `deploy/upgrade.sh` and the `/api/health` `version` field.
- **Mobile docs** — reflect the published Android app (0.3.0 / vc12), committed `google-services.json`, and EAS-managed submit (no local key path).
- **Skill/README docs** — verified against source; fixed real test counts (core 30→39, web ~85→~165) and removed a fabricated `isSelfHosted` export.
- **Cross-file consistency**: mobile status now reads the same everywhere (Android live / iOS in progress); repo-wide sweep confirms no lingering Apache claim, "no mobile screen", stale google-services todo, pnpm 9, or dangling anchors.

### Method
Six parallel auditors, each owning a disjoint cluster, verifying every claim against the code (Glob/Grep/Read, and two ran the test suites) before editing. Docs-only; no code touched.
