### PR TITLE
fix(calendar): show real account email for Microsoft connections (not a Graph id)

### DIFF
--- a/apps/web/lib/calendar/calendar-connect.ts
+++ b/apps/web/lib/calendar/calendar-connect.ts
@@ -92,10 +92,20 @@ export async function connectCalendarAccount(params: {
   const externalCalendars = await adapter.listCalendars();
   const primary = externalCalendars.find((c) => c.primary) ?? externalCalendars[0];
 
+  // Prefer the account's real email as the connection label + stable id. The
+  // primary calendar's id is the email for Google but an opaque id for Microsoft,
+  // so ask the provider directly; fall back to the primary id if the lookup fails.
+  let accountEmail: string | undefined;
+  try {
+    accountEmail = await adapter.getAccountEmail?.();
+  } catch {
+    accountEmail = undefined;
+  }
+
   return persistConnection({
     userId: params.userId,
     provider: params.provider,
-    externalAccountId: primary?.externalId ?? `${params.provider}:${params.userId}`,
+    externalAccountId: accountEmail ?? primary?.externalId ?? `${params.provider}:${params.userId}`,
     encryptedCredentials: encryptJson(params.credentials),
     externalCalendars,
   });

--- a/packages/calendar/src/providers/microsoft.ts
+++ b/packages/calendar/src/providers/microsoft.ts
@@ -90,6 +90,15 @@ export class MicrosoftCalendarAdapter implements CalendarAdapter {
     };
   }
 
+  async getAccountEmail(): Promise<string | undefined> {
+    const me = (await this.client.api("/me").select("mail,userPrincipalName").get()) as {
+      mail?: string | null;
+      userPrincipalName?: string | null;
+    };
+    // Personal/consumer accounts often have a null `mail`; fall back to the UPN.
+    return me.mail ?? me.userPrincipalName ?? undefined;
+  }
+
   async listCalendars(): Promise<ExternalCalendar[]> {
     const res = (await this.client.api("/me/calendars").get()) as {
       value: Array<{ id: string; name: string; isDefaultCalendar?: boolean; hexColor?: string }>;

--- a/packages/calendar/src/types.ts
+++ b/packages/calendar/src/types.ts
@@ -130,6 +130,13 @@ export interface WatchResult {
 export interface CalendarAdapter {
   readonly provider: Provider;
   listCalendars(): Promise<ExternalCalendar[]>;
+  /**
+   * The email/login this account authenticated as - used as the connection's
+   * display label and stable account id. Optional: when absent the caller falls
+   * back to the primary calendar's id, which is the email for Google but an
+   * opaque calendar id for Microsoft (hence this override for Graph).
+   */
+  getAccountEmail?(): Promise<string | undefined>;
   /** Busy intervals across the given calendars within [timeMin, timeMax]. */
   getBusy(calendarExternalIds: string[], timeMin: Date, timeMax: Date): Promise<BusyInterval[]>;
   createEvent(calendarExternalId: string, event: NewCalendarEvent): Promise<CreatedEvent>;


### PR DESCRIPTION
**Bug:** a connected **Microsoft 365 / Outlook** account showed a garbled string like `AQMkADAw…` where the email should be (Google shows `you@gmail.com` fine).

**Cause:** `connectCalendarAccount` set the connection's `externalAccountId` (the label the UI renders, `settings/calendars/page.tsx:76`) to the **primary calendar's `externalId`**. For Google that id *is* the email; for Microsoft it's an opaque Graph calendar id.

**Fix:** add optional `CalendarAdapter.getAccountEmail()`. Microsoft implements it via Graph `/me` (`mail`, falling back to `userPrincipalName` for consumer accounts). The connect flow prefers it and falls back to the primary calendar id (Google unchanged) if unavailable/failed — wrapped in try/catch so a `/me` hiccup can't break connecting.

Typecheck ✅ (calendar + web) · biome ✅.

⚠️ **Existing** Microsoft connections keep the old garbled label until disconnected + reconnected (only the stored value is stale; new connects are correct).