### PR TITLE
fix(billing): self-heal Pro checkout when the stored Stripe customer is missing

### DIFF
--- a/apps/web/app/api/billing/checkout/route.ts
+++ b/apps/web/app/api/billing/checkout/route.ts
@@ -29,7 +29,7 @@ export const POST = withUser(async (u) => {
 
   const appUrl = process.env.APP_URL ?? "http://localhost:3000";
   try {
-    const { url } = await createSubscriptionCheckout({
+    const { url, customerReset } = await createSubscriptionCheckout({
       organizationId: org.id,
       quantity: await seatCount(org.id),
       customerId: org.stripeCustomerId,
@@ -37,6 +37,15 @@ export const POST = withUser(async (u) => {
       successUrl: `${appUrl}/settings/billing?upgraded=1&session_id={CHECKOUT_SESSION_ID}`,
       cancelUrl: `${appUrl}/settings/billing`,
     });
+    // The stored customer was stale (Stripe key/account changed). Drop it so the
+    // portal and future checkouts don't reuse the dead id; the completion webhook
+    // writes the fresh customer id back.
+    if (customerReset) {
+      await getDb()
+        .update(schema.organizations)
+        .set({ stripeCustomerId: null })
+        .where(eq(schema.organizations.id, org.id));
+    }
     return NextResponse.json({ url });
   } catch (err) {
     // Almost always a Stripe config issue (invalid STRIPE_PRICE_PRO, a non-recurring

--- a/apps/web/lib/payments/stripe.ts
+++ b/apps/web/lib/payments/stripe.ts
@@ -115,21 +115,54 @@ export async function createSubscriptionCheckout(params: {
   customerEmail?: string;
   successUrl: string;
   cancelUrl: string;
-}): Promise<{ url: string }> {
-  const session = await stripe().checkout.sessions.create({
+}): Promise<{ url: string; customerReset?: boolean }> {
+  const base = {
     mode: "subscription",
     line_items: [{ price: proPriceId, quantity: Math.max(1, params.quantity) }],
     success_url: params.successUrl,
     cancel_url: params.cancelUrl,
-    ...(params.customerId
-      ? { customer: params.customerId }
-      : { customer_email: params.customerEmail }),
     client_reference_id: params.organizationId,
     subscription_data: { metadata: { organizationId: params.organizationId } },
     metadata: { organizationId: params.organizationId },
     allow_promotion_codes: true,
-  });
-  return { url: session.url ?? "" };
+  } satisfies Stripe.Checkout.SessionCreateParams;
+
+  try {
+    const session = await stripe().checkout.sessions.create({
+      ...base,
+      ...(params.customerId
+        ? { customer: params.customerId }
+        : { customer_email: params.customerEmail }),
+    });
+    return { url: session.url ?? "" };
+  } catch (err) {
+    // The stored customer belongs to a different Stripe account/mode (e.g. the
+    // STRIPE_SECRET_KEY changed between deploys, or the customer was deleted).
+    // Don't wedge checkout on a stale id - mint a fresh customer and signal the
+    // caller to clear the bad id. The completion webhook restores the new id.
+    if (params.customerId && isMissingCustomer(err, params.customerId)) {
+      logger.warn("stripe: stored customer missing, retrying with a fresh one", {
+        event: "billing_customer_reset",
+        organizationId: params.organizationId,
+        customerId: params.customerId,
+      });
+      const session = await stripe().checkout.sessions.create({
+        ...base,
+        ...(params.customerEmail ? { customer_email: params.customerEmail } : {}),
+      });
+      return { url: session.url ?? "", customerReset: true };
+    }
+    throw err;
+  }
+}
+
+/** True when a Stripe error is "No such customer" for the id we passed. */
+function isMissingCustomer(err: unknown, customerId: string): boolean {
+  return (
+    err instanceof Stripe.errors.StripeInvalidRequestError &&
+    err.code === "resource_missing" &&
+    (err.param === "customer" || (err.message ?? "").includes(customerId))
+  );
 }
 
 /** Billing-portal session so a customer can update seats, card, or cancel. */


### PR DESCRIPTION
## What
When `STRIPE_SECRET_KEY` changes between deploys (a different Stripe account, or test↔live flipped), an org's stored `stripe_customer_id` no longer resolves under the new key. Stripe returns `No such customer`, which the old code surfaced as a hard 500 — permanently wedging **Upgrade to Pro** for that org (observed as `{"error":"Couldn't start checkout...","detail":"No such customer: 'cus_...'"}`).

## Fix
- `lib/payments/stripe.ts` — `createSubscriptionCheckout` now catches the `resource_missing` customer error, retries the Checkout Session with a **fresh customer** (via `customer_email`), and returns `customerReset: true`. A new `isMissingCustomer()` helper scopes the catch to genuine "No such customer" cases so unrelated Stripe errors still propagate.
- `api/billing/checkout/route.ts` — on `customerReset`, clears the dead `stripeCustomerId` on the org row so the portal and future checkouts don't reuse it. The completion webhook (`syncOrgSubscription`) writes the new customer id back on success.

## Why it's safe
- Only self-heals on a genuine missing-customer error; any other failure still bubbles up to the existing owner/admin-only error surface.
- The subscription is still linked to the org via `subscription_data.metadata.organizationId` + `client_reference_id`, so the webhook sync is unchanged.

## Reviewer notes
- This does **not** fix a mismatched `STRIPE_PRICE_PRO` or `STRIPE_WEBHOOK_SECRET` — if the key was switched to a different account/mode, those env vars must be from the same account/mode too.
- Existing wedged orgs self-heal on their next checkout attempt (or by manually nulling `stripe_customer_id`).

Typecheck: `pnpm --filter @dayotter/web typecheck` passes.