### PR TITLE
Security hardening: email header/link boundary + rate-limit write-heavy booking routes

### DIFF
--- a/apps/web/app/api/bookings/[uid]/confirm/route.ts
+++ b/apps/web/app/api/bookings/[uid]/confirm/route.ts
@@ -1,11 +1,22 @@
 import { approveBooking } from "@/lib/booking/confirm-booking";
 import { jsonError, withUser } from "@/lib/server/http";
+import { enforceRateLimit } from "@/lib/server/rate-limit";
 import { NextResponse } from "next/server";
 
 export const dynamic = "force-dynamic";
 
 /** Host approves a pending (opt-in) booking, confirming it. Host-only. */
-export const POST = withUser(async (u, _request, ctx: { params: Promise<{ uid: string }> }) => {
+export const POST = withUser(async (u, request, ctx: { params: Promise<{ uid: string }> }) => {
+  // Approval runs finalizeConfirmedBooking (calendar writes, emails, recurring inserts);
+  // cap per-host so a runaway client can't hammer it.
+  const limited = await enforceRateLimit(request, {
+    name: "booking-confirm",
+    limit: 20,
+    windowSec: 60,
+    key: u.id,
+  });
+  if (limited) return limited;
+
   const { uid } = await ctx.params;
   const result = await approveBooking(uid, u.id);
   switch (result) {

--- a/apps/web/app/api/bookings/[uid]/decline/route.ts
+++ b/apps/web/app/api/bookings/[uid]/decline/route.ts
@@ -1,5 +1,6 @@
 import { declineBooking } from "@/lib/booking/confirm-booking";
 import { jsonError, withUser } from "@/lib/server/http";
+import { enforceRateLimit } from "@/lib/server/rate-limit";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
@@ -9,6 +10,14 @@ const body = z.object({ reason: z.string().max(500).optional() });
 
 /** Host declines a pending (opt-in) booking, rejecting the request. Host-only. */
 export const POST = withUser(async (u, request, ctx: { params: Promise<{ uid: string }> }) => {
+  const limited = await enforceRateLimit(request, {
+    name: "booking-decline",
+    limit: 20,
+    windowSec: 60,
+    key: u.id,
+  });
+  if (limited) return limited;
+
   const { uid } = await ctx.params;
   const parsed = body.safeParse(await request.json().catch(() => ({})));
   const reason = parsed.success ? parsed.data.reason?.trim() || undefined : undefined;

--- a/apps/web/app/api/otter/suggestions/route.ts
+++ b/apps/web/app/api/otter/suggestions/route.ts
@@ -1,6 +1,7 @@
 import { getProactiveSuggestions } from "@/lib/ai/proactive";
 import { writeBookingToCalendar } from "@/lib/calendar/host-calendar";
 import { jsonError, withUser } from "@/lib/server/http";
+import { enforceRateLimit } from "@/lib/server/rate-limit";
 import { logger } from "@dayotter/core";
 import { eq, getDb, schema } from "@dayotter/db";
 import { NextResponse } from "next/server";
@@ -27,6 +28,15 @@ const actSchema = z.discriminatedUnion("type", [
 
 /** Act on a suggestion (confirm-first - always from an explicit user tap). */
 export const POST = withUser(async (u, request) => {
+  // Writes a time-block + mirrors to the calendar; cap per-user.
+  const limited = await enforceRateLimit(request, {
+    name: "otter-suggestions",
+    limit: 20,
+    windowSec: 60,
+    key: u.id,
+  });
+  if (limited) return limited;
+
   const parsed = actSchema.safeParse(await request.json().catch(() => null));
   if (!parsed.success) return jsonError("Unknown suggestion", 400);
   const d = parsed.data;

--- a/packages/emails/src/mailer.ts
+++ b/packages/emails/src/mailer.ts
@@ -54,7 +54,19 @@ async function sendViaResend(email: OutboundEmail, from: string, apiKey: string)
  */
 let warnedExampleFrom = false;
 
-export async function sendEmail(email: OutboundEmail): Promise<void> {
+/** Strip CR/LF from a single-line header value so an interpolated name/address can't
+ *  inject extra headers (defense in depth: Resend sends JSON and nodemailer rejects
+ *  newlines, but sanitize at the boundary regardless). */
+function oneLine(v: string): string {
+  return v.replace(/[\r\n]+/g, " ").trim();
+}
+
+export async function sendEmail(input: OutboundEmail): Promise<void> {
+  const email: OutboundEmail = {
+    ...input,
+    subject: oneLine(input.subject),
+    replyTo: input.replyTo ? oneLine(input.replyTo) : undefined,
+  };
   const from = process.env.EMAIL_FROM ?? "DayOtter <no-reply@example.com>";
 
   // The placeholder example.com sender is unverified everywhere, so EVERY email

--- a/packages/emails/src/templates.ts
+++ b/packages/emails/src/templates.ts
@@ -40,12 +40,19 @@ function esc(value: string): string {
   return value.replace(/[&<>"']/g, (c) => ESC[c] ?? c);
 }
 
+/** Only ever render http(s) URLs in an href. A `javascript:`/`data:` URL (even though
+ *  these are host-generated) would otherwise reach the anchor; mirror the client-side
+ *  `^https?://` guard in slot-picker.tsx. Falls back to a harmless "#". */
+function safeUrl(url: string): string {
+  return /^https?:\/\//i.test(url) ? url : "#";
+}
+
 function shell(heading: string, lines: string[], cta?: { label: string; url: string }): string {
   const body = lines
     .map((l) => `<p style="margin:0 0 10px;color:#3a3f4b;font-size:14px;line-height:1.6">${l}</p>`)
     .join("");
   const button = cta
-    ? `<a href="${esc(cta.url)}" style="display:inline-block;margin-top:12px;background:#4f46e5;color:#fff;text-decoration:none;padding:10px 18px;border-radius:10px;font-size:14px;font-weight:500">${esc(cta.label)}</a>`
+    ? `<a href="${esc(safeUrl(cta.url))}" style="display:inline-block;margin-top:12px;background:#4f46e5;color:#fff;text-decoration:none;padding:10px 18px;border-radius:10px;font-size:14px;font-weight:500">${esc(cta.label)}</a>`
     : "";
   return `<div style="max-width:520px;margin:0 auto;font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif">
     <h2 style="font-size:18px;color:#0c0e14;margin:0 0 14px">${heading}</h2>


### PR DESCRIPTION
Two small, self-contained hardening items from the last-20-PR security audit.

### #142 — Email boundary hardening
- `sendEmail()` now CRLF-strips the **subject** and **reply-to** header values (header-injection defense in depth; the Resend HTTP + nodemailer transports already reject newlines, but sanitize at the boundary regardless).
- Email templates render **only `http(s)` URLs** in an `href`, via a `safeUrl()` guard that mirrors the existing client-side `^https?://` check in `slot-picker.tsx`. A `javascript:`/`data:` `meetingUrl`/`manageUrl` now falls back to `#`.

### #141 — Rate-limit write-heavy authenticated booking routes
Added `enforceRateLimit` (per-user key, 20/min) to:
- `POST /api/bookings/[uid]/confirm` (runs `finalizeConfirmedBooking` — calendar writes, emails, recurring inserts)
- `POST /api/bookings/[uid]/decline`
- `POST /api/otter/suggestions` (writes a time-block + mirrors to calendar)

All are ownership-checked, so this is self-inflicted-runaway insurance rather than cross-user abuse.

### Verification
- `pnpm typecheck` clean (web + emails).
- 172/172 web tests pass.
- Guard behavior sanity-checked: `safeUrl("javascript:…") → "#"`, `oneLine("Ann\r\nBcc: …") → "Ann Bcc: …"`.

Closes #142
Closes #141