### PR TITLE
Clear Biome lint debt + make CI lint a hard gate (#166, #165)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,9 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
-      # Non-blocking until the pre-existing Biome debt is cleared (issue #166);
-      # drop continue-on-error to make it a hard gate once the tree is clean.
+      # Hard gate: the tree is clean (issue #166 cleared). Fails the build on any
+      # Biome error; the few "warn"-level rules stay non-blocking.
       - name: Lint + format (Biome, read-only)
-        continue-on-error: true
         run: pnpm exec biome ci .
 
       - name: Type-check

--- a/app.json
+++ b/app.json
@@ -5,10 +5,7 @@
   "logo": "https://raw.githubusercontent.com/Dayotter/dayotter/main/.github/assets/logo.png",
   "keywords": ["calendar", "scheduling", "booking", "nextjs", "self-hosted", "ai"],
   "stack": "container",
-  "addons": [
-    { "plan": "heroku-postgresql" },
-    { "plan": "heroku-redis" }
-  ],
+  "addons": [{ "plan": "heroku-postgresql" }, { "plan": "heroku-redis" }],
   "formation": {
     "web": { "quantity": 1, "size": "basic" },
     "worker": { "quantity": 1, "size": "basic" }

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -31,9 +31,7 @@
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#12305F"
       },
-      "permissions": [
-        "android.permission.RECORD_AUDIO"
-      ]
+      "permissions": ["android.permission.RECORD_AUDIO"]
     },
     "web": {
       "favicon": "./assets/favicon.png"
@@ -47,9 +45,7 @@
         {
           "microphonePermission": "DayOtter uses the microphone so you can speak scheduling commands.",
           "speechRecognitionPermission": "DayOtter turns your spoken commands into scheduling actions.",
-          "androidSpeechServicePackages": [
-            "com.google.android.googlequicksearchbox"
-          ]
+          "androidSpeechServicePackages": ["com.google.android.googlequicksearchbox"]
         }
       ],
       [

--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -1,7 +1,7 @@
 // Metro config for a pnpm monorepo so the app can import workspace packages
 // (e.g. @dayotter/core). See https://docs.expo.dev/guides/monorepos/
 const { getDefaultConfig } = require("expo/metro-config");
-const path = require("path");
+const path = require("node:path");
 
 const projectRoot = __dirname;
 const workspaceRoot = path.resolve(projectRoot, "../..");

--- a/apps/mobile/src/components/ui.tsx
+++ b/apps/mobile/src/components/ui.tsx
@@ -7,7 +7,7 @@ export function Card({ children, style }: { children: React.ReactNode; style?: V
 
 export function Badge({ label, color }: { label: string; color: string }) {
   return (
-    <View style={[styles.badge, { backgroundColor: color + "22" }]}>
+    <View style={[styles.badge, { backgroundColor: `${color}22` }]}>
       <Text style={[styles.badgeText, { color }]}>{label}</Text>
     </View>
   );

--- a/apps/mobile/src/hooks.ts
+++ b/apps/mobile/src/hooks.ts
@@ -13,6 +13,7 @@ export function useAsync<T>(loader: () => Promise<T>, deps: unknown[] = []): Asy
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: loader is stable for the hook's lifetime
   const run = useCallback(() => {
     let active = true;
     setLoading(true);

--- a/apps/web/app/(app)/settings/security/page.tsx
+++ b/apps/web/app/(app)/settings/security/page.tsx
@@ -102,7 +102,9 @@ export default async function SecuritySettingsPage() {
                       </span>
                     </div>
                     {e.sample ? (
-                      <p className="mt-1 truncate text-xs text-[var(--color-faint)]">"{e.sample}"</p>
+                      <p className="mt-1 truncate text-xs text-[var(--color-faint)]">
+                        "{e.sample}"
+                      </p>
                     ) : null}
                   </li>
                 ))}

--- a/apps/web/app/api/ai/chat/route.ts
+++ b/apps/web/app/api/ai/chat/route.ts
@@ -81,11 +81,11 @@ export const POST = withUser(async (u, request) => {
           await streamAssistant({ userId: u.id, turns, emit: send });
         }
       } catch (err) {
-        logger.error("ai chat stream failed", 
-          { event: "ai_chat_failed", 
-            userId: u.id, 
-            error: err instanceof Error ? err.message : String(err)
-          });
+        logger.error("ai chat stream failed", {
+          event: "ai_chat_failed",
+          userId: u.id,
+          error: err instanceof Error ? err.message : String(err),
+        });
         send({ type: "error", message: "The assistant hit a snag. Please try again." });
       } finally {
         controller.close();

--- a/apps/web/app/api/calendars/apple/route.ts
+++ b/apps/web/app/api/calendars/apple/route.ts
@@ -1,7 +1,7 @@
 import { AppleConnectError, connectAppleAccount } from "@/lib/calendar/calendar-connect";
 import { jsonError, withUser } from "@/lib/server/http";
-import { NextResponse } from "next/server";
 import { logger } from "@dayotter/core";
+import { NextResponse } from "next/server";
 import { z } from "zod";
 
 export const dynamic = "force-dynamic";
@@ -38,12 +38,11 @@ export const POST = withUser(async (u, request) => {
     return NextResponse.json({ ok: true, calendarCount: result.calendarCount });
   } catch (err) {
     if (err instanceof AppleConnectError) return jsonError(err.message, 400);
-    logger.error("[calendars/apple] connect failed:",
-      {
-        event:"[calendars/apple] connect failed",
-        userId :u.id,
-        error: err instanceof Error ? err.message :String(err)
-      });
+    logger.error("[calendars/apple] connect failed:", {
+      event: "[calendars/apple] connect failed",
+      userId: u.id,
+      error: err instanceof Error ? err.message : String(err),
+    });
     return jsonError("Could not connect. Please try again.", 500);
   }
 });

--- a/apps/web/app/api/import/calendly/route.ts
+++ b/apps/web/app/api/import/calendly/route.ts
@@ -38,11 +38,11 @@ export const POST = withUser(async (u, request) => {
         400,
       );
     }
-    logger.error("calendly import failed",
-       { event: "calendly_import_failed", 
-        userId: u.id, 
-        error: err instanceof Error ? err.message : String(err)
-      });
+    logger.error("calendly import failed", {
+      event: "calendly_import_failed",
+      userId: u.id,
+      error: err instanceof Error ? err.message : String(err),
+    });
     return jsonError("Couldn't import from Calendly right now. Please try again.", 502);
   }
 });

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -4,7 +4,7 @@ import { buttonVariants } from "@/components/ui/button";
 import Link from "next/link";
 import { useEffect } from "react";
 
-export default function Error({
+export default function ErrorBoundary({
   error,
   reset,
 }: {
@@ -17,7 +17,6 @@ export default function Error({
 
   return (
     <main className="flex min-h-screen flex-col items-center justify-center bg-[var(--color-bg)] px-6 text-center">
-      {/* biome-ignore lint/a11y/useAltText: decorative illustration */}
       <img
         src="/brand/illustrations/otter-focus.png"
         alt=""

--- a/apps/web/app/global-error.tsx
+++ b/apps/web/app/global-error.tsx
@@ -20,7 +20,6 @@ export default function GlobalError({ reset }: { error: Error; reset: () => void
           padding: 24,
         }}
       >
-        {/* biome-ignore lint/a11y/useAltText: decorative illustration */}
         <img
           src="/brand/illustrations/otter-focus.png"
           alt=""

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -72,6 +72,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       suppressHydrationWarning
     >
       <head>
+        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: inline theme script (static string, no user input) to prevent FOUC */}
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
       </head>
       <body>

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 export default function NotFound() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center bg-[var(--color-bg)] px-6 text-center">
-      {/* biome-ignore lint/a11y/useAltText: decorative illustration */}
       <img
         src="/brand/illustrations/otter-relax.png"
         alt=""

--- a/apps/web/app/welcome/page.tsx
+++ b/apps/web/app/welcome/page.tsx
@@ -37,7 +37,6 @@ export default function WelcomePage() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center bg-[var(--color-bg)] px-6 py-10">
       <div className="flex w-full max-w-md flex-1 flex-col items-center justify-center text-center">
-        {/* biome-ignore lint/a11y/useAltText: decorative illustration */}
         <img src={slide.img} alt="" className="mb-9 h-60 w-60 object-contain sm:h-64 sm:w-64" />
         <h1 className="font-display text-3xl tracking-tight sm:text-4xl">{slide.title}</h1>
         <p className="mt-3 max-w-sm leading-relaxed text-[var(--color-muted)]">{slide.body}</p>

--- a/apps/web/components/ai-assistant.tsx
+++ b/apps/web/components/ai-assistant.tsx
@@ -107,7 +107,6 @@ export function AiAssistant({
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
   }, [messages, action]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: speak is stable enough; re-creating send per voice change is unnecessary
   const send = useCallback(
     async (raw: string) => {
       const content = raw.trim();

--- a/apps/web/components/marketing/why.tsx
+++ b/apps/web/components/marketing/why.tsx
@@ -20,7 +20,6 @@ export function WhyOtter() {
       <div className="mt-14 grid grid-cols-2 gap-x-4 gap-y-10 sm:grid-cols-3 lg:grid-cols-6">
         {BADGES.map((b) => (
           <div key={b.label} className="flex flex-col items-center text-center">
-            {/* biome-ignore lint/a11y/useAltText: decorative badge */}
             <img src={b.img} alt="" className="h-24 w-24 sm:h-28 sm:w-28" />
             <span className="mt-3 text-sm font-medium">{b.label}</span>
           </div>

--- a/apps/web/components/otter-launcher.tsx
+++ b/apps/web/components/otter-launcher.tsx
@@ -45,7 +45,6 @@ export function OtterLauncher() {
           className="group fixed bottom-24 right-4 z-40 flex items-center gap-2.5 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] py-1.5 pl-1.5 pr-2.5 shadow-[var(--shadow-raise)] transition-transform hover:-translate-y-0.5 lg:bottom-6 lg:right-6"
         >
           <span className="relative flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden rounded-full ring-2 ring-[var(--color-accent)]">
-            {/* biome-ignore lint/a11y/useAltText: decorative otter avatar */}
             <img
               src="/brand/illustrations/otter-focus.png"
               alt=""

--- a/apps/web/components/page-header.tsx
+++ b/apps/web/components/page-header.tsx
@@ -47,7 +47,6 @@ export function EmptyState({
 }) {
   return (
     <div className="flex flex-col items-center justify-center rounded-[var(--radius-lg)] border border-dashed border-[var(--color-border-strong)] px-6 py-14 text-center">
-      {/* biome-ignore lint/a11y/useAltText: decorative illustration */}
       <img src={illustration} alt="" className="mb-5 h-28 w-28 object-contain" />
       <p className="font-display text-xl tracking-tight">{title}</p>
       {description ? (

--- a/apps/web/components/pending-invites.tsx
+++ b/apps/web/components/pending-invites.tsx
@@ -2,8 +2,8 @@
 
 import { Button } from "@/components/ui/button";
 import { Card, CardBody, CardHeader } from "@/components/ui/card";
-import { FormError } from "@/components/ui/form";
 import { DateTimeField } from "@/components/ui/datetime-field";
+import { FormError } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { track } from "@/lib/analytics";
 import { AlertTriangle, Sparkles } from "lucide-react";

--- a/apps/web/components/poll-create-form.tsx
+++ b/apps/web/components/poll-create-form.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { FormError } from "@/components/ui/form";
 import { DateTimeField } from "@/components/ui/datetime-field";
+import { FormError } from "@/components/ui/form";
 import { Input, Label } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
 import { useToast } from "@/components/ui/toast";
@@ -122,7 +122,6 @@ export function PollCreateForm() {
         </p>
         <div className="space-y-2">
           {times.map((t, i) => (
-            // biome-ignore lint/suspicious/noArrayIndexKey: rows are positional and reorder-free
             <div key={i} className="flex items-center gap-2">
               <DateTimeField
                 value={t}

--- a/apps/web/components/ui/datetime-field.tsx
+++ b/apps/web/components/ui/datetime-field.tsx
@@ -77,15 +77,15 @@ export function DateTimeField({
   const minDt = parse(min);
 
   // The day the calendar is focused on; a tapped time attaches to it.
-  const [draftDay, setDraftDay] = useState<Date>(
-    () => (selected ?? minDt ?? DateTime.now()).startOf("day").toJSDate(),
+  const [draftDay, setDraftDay] = useState<Date>(() =>
+    (selected ?? minDt ?? DateTime.now()).startOf("day").toJSDate(),
   );
 
   // Re-sync from an external value change while closed.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional; re-sync keyed on value/open only
   useEffect(() => {
     if (open) return;
     setDraftDay((selected ?? minDt ?? DateTime.now()).startOf("day").toJSDate());
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value, open]);
 
   // Close on outside click / Escape.
@@ -113,6 +113,7 @@ export function DateTimeField({
   }, [open]);
 
   const draft = DateTime.fromJSDate(draftDay);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on draftDay, not the derived `draft`
   const times = useMemo(() => {
     const out: DateTime[] = [];
     let t = draft.startOf("day");
@@ -122,7 +123,6 @@ export function DateTimeField({
       t = t.plus({ minutes: stepMinutes });
     }
     return out;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [draftDay, stepMinutes]);
 
   function commitTime(time: DateTime) {
@@ -216,7 +216,8 @@ export function DateTimeField({
                       isSel
                         ? "bg-[var(--color-accent)] font-medium text-[var(--color-accent-fg)]"
                         : "text-[var(--color-text)] hover:bg-[var(--color-accent-soft)] hover:text-[var(--color-accent)]",
-                      disabled && "cursor-not-allowed opacity-30 hover:bg-transparent hover:text-[var(--color-text)]",
+                      disabled &&
+                        "cursor-not-allowed opacity-30 hover:bg-transparent hover:text-[var(--color-text)]",
                     )}
                   >
                     {t.toFormat("h:mm a")}

--- a/apps/web/components/ui/datetime-range-field.tsx
+++ b/apps/web/components/ui/datetime-range-field.tsx
@@ -173,11 +173,11 @@ export function DateTimeRangeField({
   const endDt = parse(endValue);
   const minDt = parse(min);
 
-  const [startDate, setStartDate] = useState<Date>(
-    () => (startDt ?? minDt ?? DateTime.now()).startOf("day").toJSDate(),
+  const [startDate, setStartDate] = useState<Date>(() =>
+    (startDt ?? minDt ?? DateTime.now()).startOf("day").toJSDate(),
   );
-  const [endDate, setEndDate] = useState<Date>(
-    () => (endDt ?? startDt ?? minDt ?? DateTime.now()).startOf("day").toJSDate(),
+  const [endDate, setEndDate] = useState<Date>(() =>
+    (endDt ?? startDt ?? minDt ?? DateTime.now()).startOf("day").toJSDate(),
   );
   const [startTime, setStartTime] = useState(() => startDt?.toFormat("HH:mm") ?? "09:00");
   const [endTime, setEndTime] = useState(() => endDt?.toFormat("HH:mm") ?? "10:00");
@@ -189,13 +189,13 @@ export function DateTimeRangeField({
   }
 
   // Pre-fill a sensible default so a new form isn't empty.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // biome-ignore lint/correctness/useExhaustiveDependencies: deps intentionally narrowed to avoid re-sync loops
   useEffect(() => {
     if (!startValue && !endValue) emitFrom(startDate, startTime, endDate, endTime);
   }, []);
 
   // Re-sync from external value changes.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // biome-ignore lint/correctness/useExhaustiveDependencies: deps intentionally narrowed to avoid re-sync loops
   useEffect(() => {
     if (startDt) {
       setStartDate(startDt.startOf("day").toJSDate());
@@ -253,7 +253,11 @@ export function DateTimeRangeField({
         onSelect={changeStartDate}
       />
       <div className="w-[7rem]">
-        <Select aria-label="Start time" value={startTime} onChange={(e) => changeStartTime(e.target.value)}>
+        <Select
+          aria-label="Start time"
+          value={startTime}
+          onChange={(e) => changeStartTime(e.target.value)}
+        >
           {timeSlots.map((t) => (
             <option key={t} value={t}>
               {fmt12(t)}

--- a/apps/web/lib/ai/memory/extractors.ts
+++ b/apps/web/lib/ai/memory/extractors.ts
@@ -28,7 +28,12 @@ function mode<T>(items: T[]): { value: T; share: number } | null {
   for (const i of items) counts.set(i, (counts.get(i) ?? 0) + 1);
   let best: T | null = null;
   let bestN = 0;
-  for (const [k, n] of counts) if (n > bestN) (best = k), (bestN = n);
+  for (const [k, n] of counts) {
+    if (n > bestN) {
+      best = k;
+      bestN = n;
+    }
+  }
   return best === null ? null : { value: best, share: bestN / items.length };
 }
 

--- a/apps/web/lib/glossary.ts
+++ b/apps/web/lib/glossary.ts
@@ -228,7 +228,7 @@ export const GLOSSARY: GlossaryTerm[] = [
     short:
       "An assistant you ask in plain language to book, reschedule and protect time, which reads your real calendar to act.",
     body: [
-      "An AI scheduling assistant turns natural language - typed or spoken - into calendar actions. Instead of clicking through forms, you say \"find 30 minutes with Priya next week\" or \"hold two hours tomorrow morning for the deck,\" and it drafts the change against your real availability.",
+      'An AI scheduling assistant turns natural language - typed or spoken - into calendar actions. Instead of clicking through forms, you say "find 30 minutes with Priya next week" or "hold two hours tomorrow morning for the deck," and it drafts the change against your real availability.',
       "The trustworthy ones are confirm-first: they propose an editable action and wait for your approval rather than silently rearranging your day.",
     ],
     inDayOtter:
@@ -288,8 +288,7 @@ export const GLOSSARY: GlossaryTerm[] = [
     slug: "prepaid-package",
     term: "Prepaid session package",
     category: "Payments",
-    short:
-      "A bundle of sessions a client buys up front, then draws down one credit per booking.",
+    short: "A bundle of sessions a client buys up front, then draws down one credit per booking.",
     body: [
       "A prepaid package (or session pack) sells several appointments at once - say ten lessons or a block of coaching hours. The client pays once, receives a balance of credits, and each booking consumes one. It smooths cash flow, rewards commitment, and removes per-session payment friction.",
       "Packages pair naturally with recurring bookings and paid consultations for anyone selling their time.",
@@ -318,8 +317,7 @@ export const GLOSSARY: GlossaryTerm[] = [
     slug: "intake-form",
     term: "Intake form",
     category: "Scheduling",
-    short:
-      "Questions asked at booking time so you show up to the meeting already prepared.",
+    short: "Questions asked at booking time so you show up to the meeting already prepared.",
     body: [
       "An intake form collects context before the meeting - what the person wants to discuss, an account number, a link to review. Answers arrive with the booking, so you walk in prepared instead of spending the first ten minutes getting oriented.",
       "For qualification, the same questions can also drive routing - sending the booking to the right person based on the answers.",

--- a/apps/web/lib/integrations/jitsi.test.ts
+++ b/apps/web/lib/integrations/jitsi.test.ts
@@ -3,12 +3,14 @@ import { jitsiRoomUrl } from "./jitsi";
 
 const original = process.env.JITSI_BASE_URL;
 afterEach(() => {
+  // biome-ignore lint/performance/noDelete: delete is required for process.env (assignment stringifies)
   if (original === undefined) delete process.env.JITSI_BASE_URL;
   else process.env.JITSI_BASE_URL = original;
 });
 
 describe("jitsiRoomUrl", () => {
   it("defaults to public meet.jit.si with a per-booking room", () => {
+    // biome-ignore lint/performance/noDelete: delete is required for process.env (assignment stringifies)
     delete process.env.JITSI_BASE_URL;
     expect(jitsiRoomUrl("abc-123")).toBe("https://meet.jit.si/DayOtter-abc-123");
   });

--- a/apps/web/lib/og.tsx
+++ b/apps/web/lib/og.tsx
@@ -118,9 +118,7 @@ export function ogImage({
         >
           dayotter.com
         </div>
-        <div style={{ fontSize: 22, color: MUTED }}>
-          AI-native, open-source scheduling
-        </div>
+        <div style={{ fontSize: 22, color: MUTED }}>AI-native, open-source scheduling</div>
       </div>
     </div>,
     OG_SIZE,

--- a/apps/web/lib/voice/twiml.ts
+++ b/apps/web/lib/voice/twiml.ts
@@ -26,14 +26,10 @@ function doc(inner: string): Response {
  * lets the caller barge in over the prompt so it feels like a real conversation.
  */
 export function sayAndGather(say: string, actionPath: string): Response {
+  // A <Gather> that speaks the prompt, listens for speech, and (if the caller says
+  // nothing) re-prompts once by re-hitting the same action via <Redirect>.
   return doc(
-    `<Gather input="speech" speechTimeout="auto" speechModel="phone_call" enhanced="true"` +
-      ` language="en-US" bargeIn="true" hints="${esc(SPEECH_HINTS)}"` +
-      ` action="${esc(actionPath)}" method="POST">` +
-      `<Say ${VOICE}>${esc(say)}</Say>` +
-      `</Gather>` +
-      // If they say nothing, re-prompt once by re-hitting the same action.
-      `<Redirect method="POST">${esc(actionPath)}</Redirect>`,
+    `<Gather input="speech" speechTimeout="auto" speechModel="phone_call" enhanced="true" language="en-US" bargeIn="true" hints="${esc(SPEECH_HINTS)}" action="${esc(actionPath)}" method="POST"><Say ${VOICE}>${esc(say)}</Say></Gather><Redirect method="POST">${esc(actionPath)}</Redirect>`,
   );
 }
 

--- a/biome.json
+++ b/biome.json
@@ -38,7 +38,8 @@
       "a11y": {
         "noSvgWithoutTitle": "off",
         "useButtonType": "off",
-        "useKeyWithClickEvents": "off"
+        "useKeyWithClickEvents": "off",
+        "useSemanticElements": "off"
       }
     }
   },

--- a/packages/core/src/crypto.test.ts
+++ b/packages/core/src/crypto.test.ts
@@ -34,11 +34,13 @@ describe("crypto", () => {
 describe("getKey (via ENCRYPTION_KEY env)", () => {
   const saved = process.env.ENCRYPTION_KEY;
   afterEach(() => {
+    // biome-ignore lint/performance/noDelete: delete is required for process.env (assignment stringifies)
     if (saved === undefined) delete process.env.ENCRYPTION_KEY;
     else process.env.ENCRYPTION_KEY = saved;
   });
 
   it("throws when ENCRYPTION_KEY is unset", () => {
+    // biome-ignore lint/performance/noDelete: delete is required for process.env (assignment stringifies)
     delete process.env.ENCRYPTION_KEY;
     expect(() => encrypt("x")).toThrow(/not set/i);
   });

--- a/packages/embed-react/tsconfig.json
+++ b/packages/embed-react/tsconfig.json
@@ -1,5 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": { "rootDir": "src", "outDir": "dist", "jsx": "react-jsx", "lib": ["DOM", "ES2022"] },
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "jsx": "react-jsx",
+    "lib": ["DOM", "ES2022"]
+  },
   "include": ["src"]
 }

--- a/scripts/crop-illustrations.mjs
+++ b/scripts/crop-illustrations.mjs
@@ -18,9 +18,13 @@ fs.mkdirSync(webOut, { recursive: true });
 fs.mkdirSync(mobOut, { recursive: true });
 
 const roundedMask = (w, h, r) =>
-  Buffer.from(`<svg width="${w}" height="${h}"><rect width="${w}" height="${h}" rx="${r}" ry="${r}"/></svg>`);
+  Buffer.from(
+    `<svg width="${w}" height="${h}"><rect width="${w}" height="${h}" rx="${r}" ry="${r}"/></svg>`,
+  );
 const circleMask = (d, r = d / 2) =>
-  Buffer.from(`<svg width="${d}" height="${d}"><circle cx="${d / 2}" cy="${d / 2}" r="${r}"/></svg>`);
+  Buffer.from(
+    `<svg width="${d}" height="${d}"><circle cx="${d / 2}" cy="${d / 2}" r="${r}"/></svg>`,
+  );
 
 // --- 1. Onboarding scenes (1254² grid) ---
 const SCENES = {
@@ -67,7 +71,9 @@ await sharp(BANNERS)
 console.log("banner");
 
 // --- 4. OpenGraph image (1200×630) from the banner + scrim + wordmark ---
-const ogCrop = await sharp(BANNERS).extract({ left: 180, top: 16, width: 900, height: 474 }).toBuffer();
+const ogCrop = await sharp(BANNERS)
+  .extract({ left: 180, top: 16, width: 900, height: 474 })
+  .toBuffer();
 const scrim = Buffer.from(
   `<svg width="1200" height="630"><defs><linearGradient id="g" x1="0" y1="0" x2="0" y2="1">` +
     `<stop offset="0.4" stop-color="#0b1f47" stop-opacity="0"/><stop offset="1" stop-color="#0b1f47" stop-opacity="0.94"/>` +

--- a/scripts/feature-graphic.mjs
+++ b/scripts/feature-graphic.mjs
@@ -32,7 +32,9 @@ const svg = `
   <g fill="#ffffff" opacity="0.05">
     ${Array.from({ length: 6 })
       .flatMap((_, r) =>
-        Array.from({ length: 9 }).map((__, c) => `<circle cx="${70 + c * 60}" cy="${70 + r * 70}" r="2"/>`),
+        Array.from({ length: 9 }).map(
+          (__, c) => `<circle cx="${70 + c * 60}" cy="${70 + r * 70}" r="2"/>`,
+        ),
       )
       .join("")}
   </g>
@@ -64,4 +66,6 @@ await sharp(Buffer.from(svg))
   .toFile(out);
 
 const meta = await sharp(out).metadata();
-console.log(`wrote ${out} - ${meta.width}x${meta.height}, channels=${meta.channels}, alpha=${meta.hasAlpha}`);
+console.log(
+  `wrote ${out} - ${meta.width}x${meta.height}, channels=${meta.channels}, alpha=${meta.hasAlpha}`,
+);

--- a/scripts/play-normalize.mjs
+++ b/scripts/play-normalize.mjs
@@ -1,3 +1,6 @@
+import { mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 // Normalize raw phone screenshots to Google Play-compliant phone screenshots.
 //
 // Play rules: PNG/JPEG, each side 320–3840px, long:short ratio must not exceed
@@ -5,9 +8,6 @@
 // each onto a 1080x2160 (exactly 2:1) canvas in the app's cream background so no
 // content is cropped, and strip alpha.
 import sharp from "sharp";
-import { mkdirSync } from "node:fs";
-import { join } from "node:path";
-import { homedir } from "node:os";
 
 const BG = { r: 0xfa, g: 0xf9, b: 0xf6 }; // #FAF9F6 app background
 const CANVAS_W = 1080;


### PR DESCRIPTION
Clears the pre-existing Biome debt so the tree is clean and flips CI's Biome step from non-blocking to a **hard gate**.

### What changed
- **Removed unused/stale suppressions** — decorative-image `useAltText` ignores, an `noArrayIndexKey` ignore (rule is already off), a redundant hook ignore.
- **Real code fixes:** comma-operator → block statement (`extractors.ts`), string concat → template literal (mobile `ui.tsx`), collapsed `+`-concatenated TwiML into one template literal, `node:path` import protocol (`metro.config.js`), renamed the `error.tsx` route component `Error` → `ErrorBoundary` (was shadowing the global).
- **Justified suppressions** for genuinely intentional patterns: `delete process.env.*` in tests (assignment would stringify the value), the inline theme-script `dangerouslySetInnerHTML` (static string, prevents FOUC), and the date-picker hooks' intentionally-narrow deps.
- **`biome.json`:** turned off `a11y/useSemanticElements`, consistent with the other a11y rules the project already disables (`useButtonType`, `useKeyWithClickEvents`, `noSvgWithoutTitle`) for its custom dialog/Card-as-link components.
- **Format drift** applied across 16 files.

### CI
Dropped `continue-on-error` on the Biome step in `ci.yml` — it's now a hard gate on every PR. This also completes the remaining piece of #165 (Biome as a required check; typecheck + test were already gating).

### Verification
- `biome ci .` exits 0 (only 3 non-blocking `warn`-level diagnostics remain).
- `pnpm typecheck` 16/16, `@dayotter/web` + `@dayotter/core` tests pass.

Closes #166