### PR TITLE
perf: parallelize independent awaits (Calendly export + AI read tools) (#143)

### DIFF
--- a/apps/web/lib/ai/agent.ts
+++ b/apps/web/lib/ai/agent.ts
@@ -121,15 +121,17 @@ You also have a read-only tool, find_free_slots, that returns times the host is 
     if (reads.length === 0) break; // no tool call and no proposal → give up to the fallback
 
     history.push({ role: "assistant_raw", raw: res.assistant });
-    const results: AgentToolResult[] = [];
-    for (const call of reads) {
-      const text = await findFreeSlots(
-        params.userId,
-        call.input as { durationMinutes: number; fromISO: string; toISO: string },
-        params.timezone,
-      ).catch(() => "Could not look up availability.");
-      results.push({ id: call.id, content: text });
-    }
+    // Independent availability reads; run concurrently (order preserved).
+    const results: AgentToolResult[] = await Promise.all(
+      reads.map(async (call) => {
+        const text = await findFreeSlots(
+          params.userId,
+          call.input as { durationMinutes: number; fromISO: string; toISO: string },
+          params.timezone,
+        ).catch(() => "Could not look up availability.");
+        return { id: call.id, content: text };
+      }),
+    );
     history.push({ role: "tool_results", results });
   }
 

--- a/apps/web/lib/ai/chat.ts
+++ b/apps/web/lib/ai/chat.ts
@@ -261,25 +261,29 @@ export async function streamAssistant(params: {
     if (reads.length === 0) break; // plain conversational answer-done
 
     history.push({ role: "assistant_raw", raw: res.assistant });
-    const results: AgentToolResult[] = [];
-    for (const call of reads) {
-      const input = call.input;
-      let content: string;
-      if (call.name === "find_free_slots") {
-        content = await findFreeSlots(
-          userId,
-          call.input as { durationMinutes: number; fromISO: string; toISO: string },
-          tz,
-        ).catch(() => "Could not look up availability.");
-      } else if (getTool(call.name)?.kind === "read") {
-        content = await executeReadTool(userId, call.name, input).catch(
-          () => "Could not read that.",
-        );
-      } else {
-        content = await runPluginTool(call.name, userId, input).catch(() => "Could not run that.");
-      }
-      results.push({ id: call.id, content });
-    }
+    // Reads are independent; run them concurrently. Promise.all preserves order.
+    const results: AgentToolResult[] = await Promise.all(
+      reads.map(async (call) => {
+        const input = call.input;
+        let content: string;
+        if (call.name === "find_free_slots") {
+          content = await findFreeSlots(
+            userId,
+            call.input as { durationMinutes: number; fromISO: string; toISO: string },
+            tz,
+          ).catch(() => "Could not look up availability.");
+        } else if (getTool(call.name)?.kind === "read") {
+          content = await executeReadTool(userId, call.name, input).catch(
+            () => "Could not read that.",
+          );
+        } else {
+          content = await runPluginTool(call.name, userId, input).catch(
+            () => "Could not run that.",
+          );
+        }
+        return { id: call.id, content };
+      }),
+    );
     history.push({ role: "tool_results", results });
   }
 

--- a/apps/web/lib/import/calendly-client.ts
+++ b/apps/web/lib/import/calendly-client.ts
@@ -102,16 +102,20 @@ export async function fetchCalendlyExport(token: string): Promise<RawCalendlyExp
   const userUri = me.resource.uri;
   const userParam = encodeURIComponent(userUri);
 
-  const eventTypes = await collectAll<CalendlyEventType>(
-    token,
-    `${CALENDLY_API}/event_types?user=${userParam}&count=100`,
-    MAX_EVENT_TYPES,
-  );
-  const schedules = await collectAll<CalendlyAvailabilitySchedule>(
-    token,
-    `${CALENDLY_API}/user_availability_schedules?user=${userParam}`,
-    MAX_SCHEDULES,
-  );
+  // Event types and availability schedules are independent once we have userUri;
+  // pull them concurrently rather than one after the other.
+  const [eventTypes, schedules] = await Promise.all([
+    collectAll<CalendlyEventType>(
+      token,
+      `${CALENDLY_API}/event_types?user=${userParam}&count=100`,
+      MAX_EVENT_TYPES,
+    ),
+    collectAll<CalendlyAvailabilitySchedule>(
+      token,
+      `${CALENDLY_API}/user_availability_schedules?user=${userParam}`,
+      MAX_SCHEDULES,
+    ),
+  ]);
 
   return { user: { name: me.resource.name ?? "", uri: userUri }, eventTypes, schedules };
 }


### PR DESCRIPTION
From the perf audit. Three independent awaits that ran in series now run concurrently.

- **`calendly-client.ts`** — event types and availability schedules are independent once `userUri` is known; `Promise.all` them (one fewer round-trip of latency per import).
- **`ai/chat.ts` + `ai/agent.ts`** — a single turn's independent read tools (`find_free_slots`, registry/plugin reads) resolved sequentially in an awaited `for` loop; now `Promise.all` over the reads. `Promise.all` preserves array order, so the model sees the same result ordering as before.

Low-frequency paths (once per import / rare multi-tool turn), so this is latency polish, not a hot-path fix.

### Verification
- `biome ci` clean, `pnpm typecheck` passes, 172/172 web tests pass.
- Behavior-preserving: reads are independent and idempotent; order is preserved.

Closes #143