### PR TITLE
Hash event access codes with scrypt + per-code salt (#140)

### DIFF
--- a/apps/web/app/api/event-types/[id]/route.ts
+++ b/apps/web/app/api/event-types/[id]/route.ts
@@ -1,7 +1,7 @@
 import { getSession } from "@/lib/auth/session";
 import { eventTypeInputSchema } from "@/lib/booking/event-type-input";
 import { resolveScheduleId } from "@/lib/booking/schedule";
-import { sha256hex } from "@dayotter/core";
+import { hashAccessCode } from "@dayotter/core";
 import { and, eq, getDb, schema, sql } from "@dayotter/db";
 import { NextResponse } from "next/server";
 
@@ -208,7 +208,7 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
         // Access code: undefined = unchanged, null = remove, string = set.
         ...(d.accessCode === undefined
           ? {}
-          : { accessCodeHash: d.accessCode ? sha256hex(d.accessCode) : null }),
+          : { accessCodeHash: d.accessCode ? hashAccessCode(d.accessCode) : null }),
       })
       .where(eq(schema.eventTypes.id, id));
     return NextResponse.json({ ok: true });

--- a/apps/web/lib/booking/create-booking.ts
+++ b/apps/web/lib/booking/create-booking.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { consumeCredit } from "@/lib/packages/credits";
-import { logger, roundRobinPick, safeEqual, sha256hex } from "@dayotter/core";
+import { logger, roundRobinPick, verifyAccessCode } from "@dayotter/core";
 import { and, eq, getDb, gte, inArray, lt, schema, sql } from "@dayotter/db";
 import { bookingRequested, newBookingRequest, sendEmail } from "@dayotter/emails";
 import { DateTime } from "luxon";
@@ -152,7 +152,7 @@ export async function createBooking(
   // Password-protected event type: require a matching access code before booking.
   if (eventType.accessCodeHash) {
     const supplied = input.accessCode?.trim();
-    if (!supplied || !safeEqual(sha256hex(supplied), eventType.accessCodeHash)) {
+    if (!supplied || !verifyAccessCode(supplied, eventType.accessCodeHash)) {
       throw new BookingError("Enter the correct access code to book.", 403);
     }
   }

--- a/packages/core/src/crypto.test.ts
+++ b/packages/core/src/crypto.test.ts
@@ -1,8 +1,40 @@
 import { randomBytes } from "node:crypto";
 import { afterEach, describe, expect, it } from "vitest";
-import { decrypt, decryptJson, encrypt, encryptJson } from "./crypto";
+import {
+  decrypt,
+  decryptJson,
+  encrypt,
+  encryptJson,
+  hashAccessCode,
+  sha256hex,
+  verifyAccessCode,
+} from "./crypto";
 
 const key = randomBytes(32);
+
+describe("access codes (scrypt KDF)", () => {
+  it("verifies the right code and rejects a wrong one", () => {
+    const stored = hashAccessCode("open-sesame");
+    expect(verifyAccessCode("open-sesame", stored)).toBe(true);
+    expect(verifyAccessCode("wrong", stored)).toBe(false);
+  });
+
+  it("is salted: the same code hashes differently each time", () => {
+    expect(hashAccessCode("1234")).not.toBe(hashAccessCode("1234"));
+    expect(hashAccessCode("1234").startsWith("scrypt$")).toBe(true);
+  });
+
+  it("still verifies a legacy unsalted SHA-256 hash (upgrade-on-next-set)", () => {
+    const legacy = sha256hex("legacy-code");
+    expect(verifyAccessCode("legacy-code", legacy)).toBe(true);
+    expect(verifyAccessCode("nope", legacy)).toBe(false);
+  });
+
+  it("rejects a malformed scrypt value", () => {
+    expect(verifyAccessCode("x", "scrypt$")).toBe(false);
+    expect(verifyAccessCode("x", "scrypt$deadbeef")).toBe(false);
+  });
+});
 
 describe("crypto", () => {
   it("round-trips a string", () => {

--- a/packages/core/src/crypto.ts
+++ b/packages/core/src/crypto.ts
@@ -4,6 +4,7 @@ import {
   createHash,
   createHmac,
   randomBytes,
+  scryptSync,
   timingSafeEqual,
 } from "node:crypto";
 
@@ -30,6 +31,37 @@ export function hmacSha256hex(secret: string, body: string): string {
 /** Cryptographically-random URL-safe token (default 32 bytes → 43 chars). */
 export function randomToken(bytes = 32): string {
   return randomBytes(bytes).toString("base64url");
+}
+
+const SCRYPT_KEYLEN = 32;
+
+/**
+ * Hash a low-entropy secret (e.g. a human-typed event access code) with a slow,
+ * salted KDF (scrypt). Unlike an unsalted SHA-256, a leaked DB can't be reversed
+ * by rainbow tables or cheap offline brute force. Returns a self-describing
+ * `scrypt$<saltHex>$<hashHex>` string, so the salt lives in the value itself and
+ * no extra column is needed. Verify with {@link verifyAccessCode}.
+ */
+export function hashAccessCode(code: string): string {
+  const salt = randomBytes(16);
+  const hash = scryptSync(code, salt, SCRYPT_KEYLEN);
+  return `scrypt$${salt.toString("hex")}$${hash.toString("hex")}`;
+}
+
+/**
+ * Verify a code against a stored hash, constant-time. New codes are scrypt
+ * (`scrypt$…`); a legacy bare SHA-256 hex hash still verifies, so existing codes
+ * keep working and upgrade to scrypt the next time they're set.
+ */
+export function verifyAccessCode(code: string, stored: string): boolean {
+  if (stored.startsWith("scrypt$")) {
+    const [, saltHex, hashHex] = stored.split("$");
+    if (!saltHex || !hashHex) return false;
+    const expected = Buffer.from(hashHex, "hex");
+    const actual = scryptSync(code, Buffer.from(saltHex, "hex"), expected.length);
+    return actual.length === expected.length && timingSafeEqual(actual, expected);
+  }
+  return safeEqual(sha256hex(code), stored); // legacy unsalted SHA-256
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,8 @@ export {
   sha256hex,
   hmacSha256hex,
   randomToken,
+  hashAccessCode,
+  verifyAccessCode,
 } from "./crypto";
 export { roundRobinPick } from "./round-robin";
 export { DEFAULT_REMINDER_OFFSETS } from "./constants";


### PR DESCRIPTION
From the security audit. Event access codes were stored as **unsalted `sha256hex(code)`** — and codes are low-entropy human-typed strings, so a leaked DB allowed fast offline brute-force / rainbow-table recovery of every event's code.

### Change
- New `hashAccessCode()` / `verifyAccessCode()` in `@dayotter/core`: **scrypt** with a random 16-byte salt, stored self-describing as `scrypt$<saltHex>$<hashHex>`. The salt lives in the value, so **no schema change / migration**. Constant-time compare preserved.
- `verifyAccessCode()` falls back to the **legacy bare SHA-256** hash, so existing codes keep verifying and transparently **upgrade to scrypt the next time the code is set** (migrate-on-set).
- Wired the set path (`event-types` PUT) and the verify path (`create-booking`).

Impact was bounded (the code only gates *booking* a private event type, and verify already never returned the hash), so this is hardening, not an active-exploit fix.

### Verification
- New unit tests: round-trip, wrong-code rejection, salt uniqueness, **legacy SHA-256 fallback**, malformed-input rejection. `@dayotter/core` tests 43/43.
- `biome ci` clean, `pnpm typecheck` (core + web) passes.

Closes #140