### PR TITLE
feat(ai): let Otter author multiple locations per booking type

### DIFF
--- a/apps/web/lib/ai/tools/exec.ts
+++ b/apps/web/lib/ai/tools/exec.ts
@@ -467,6 +467,8 @@ export async function executeActionTool(
           durationMinutes: input.durationMinutes,
           description: input.description,
           location: input.location,
+          locationDetail: input.locationDetail,
+          locations: input.locations,
           color: input.color,
         });
         if (!et.success) return { ok: false, message: "Those booking-type details aren't valid." };
@@ -483,8 +485,13 @@ export async function executeActionTool(
             slug: d.slug,
             durationMinutes: d.durationMinutes,
             description: d.description,
-            location: d.location,
-            locationDetail: d.locationDetail,
+            // A non-empty `locations` menu drives everything: its first entry
+            // mirrors into the single location columns so older readers still work.
+            location: d.locations?.length ? d.locations[0]!.type : d.location,
+            locationDetail: d.locations?.length
+              ? (d.locations[0]!.detail ?? null)
+              : d.locationDetail,
+            locations: d.locations?.length ? d.locations : null,
             bufferBeforeMinutes: d.bufferBeforeMinutes,
             bufferAfterMinutes: d.bufferAfterMinutes,
             minimumNoticeMinutes: d.minimumNoticeMinutes,
@@ -1016,6 +1023,19 @@ export async function executeActionTool(
           "isPrivate",
         ] as const) {
           if (input[k] !== undefined) set[k] = input[k];
+        }
+        // A non-empty `locations` menu drives the location columns (first entry
+        // mirrors into the single columns); an empty array clears the menu back
+        // to the single `location`; omitting it leaves the stored menu untouched.
+        if (input.locations !== undefined) {
+          const locs = input.locations as { type: string; detail?: string | null }[];
+          if (locs.length > 0) {
+            set.location = locs[0]!.type;
+            set.locationDetail = locs[0]!.detail ?? null;
+            set.locations = locs;
+          } else {
+            set.locations = null;
+          }
         }
         if (Object.keys(set).length === 0) {
           return { ok: false, message: "Tell me what to change on that booking type." };

--- a/apps/web/lib/ai/tools/registry.ts
+++ b/apps/web/lib/ai/tools/registry.ts
@@ -543,6 +543,24 @@ export const TOOLS: AiToolDef[] = [
           description: "Optional description shown on the booking page.",
         },
         location: { type: "string", enum: LOCATIONS as unknown as string[] },
+        locations: {
+          type: "array",
+          description:
+            "Optional menu of locations the booker chooses from (overrides the single location). Up to 6; each { type, detail? }.",
+          maxItems: 6,
+          items: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+              type: { type: "string", enum: LOCATIONS as unknown as string[] },
+              detail: {
+                type: "string",
+                description: "URL, phone number, or address for custom/phone/in_person.",
+              },
+            },
+            required: ["type"],
+          },
+        },
         color: { type: "string", enum: COLORS as unknown as string[] },
       },
       required: ["title", "slug", "durationMinutes"],
@@ -557,6 +575,10 @@ export const TOOLS: AiToolDef[] = [
       durationMinutes: z.number().int().min(5).max(480),
       description: z.string().max(2000).optional(),
       location: z.enum(LOCATIONS).optional(),
+      locations: z
+        .array(z.object({ type: z.enum(LOCATIONS), detail: z.string().max(500).nullish() }))
+        .max(6)
+        .optional(),
       color: z.enum(COLORS).optional(),
     }),
     title: "Create booking type",
@@ -565,7 +587,7 @@ export const TOOLS: AiToolDef[] = [
   {
     name: "update_booking_type",
     description:
-      "Update fields on an existing booking type by id. Only the fields you pass change; the rest are preserved. Get the id and current values from get_booking_type / list_booking_types first. You can change its title, description, duration, colour, location, buffers before/after, minimum notice, how far ahead people can book (bookingWindowDays), daily/weekly booking limits, group capacity (maxAttendees), whether it requires confirmation, and whether it's private (link-only).",
+      "Update fields on an existing booking type by id. Only the fields you pass change; the rest are preserved. Get the id and current values from get_booking_type / list_booking_types first. You can change its title, description, duration, colour, location (a single location, or a menu of locations via `locations`), buffers before/after, minimum notice, how far ahead people can book (bookingWindowDays), daily/weekly booking limits, group capacity (maxAttendees), whether it requires confirmation, and whether it's private (link-only).",
     kind: "write",
     confirmLevel: "confirm",
     schema: {
@@ -578,6 +600,24 @@ export const TOOLS: AiToolDef[] = [
         durationMinutes: { type: "integer", description: "5–480." },
         color: { type: "string", enum: COLORS as unknown as string[] },
         location: { type: "string", enum: LOCATIONS as unknown as string[] },
+        locations: {
+          type: "array",
+          description:
+            "Optional menu of locations the booker chooses from (overrides the single location). Pass an empty array to clear the menu back to a single location. Up to 6; each { type, detail? }.",
+          maxItems: 6,
+          items: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+              type: { type: "string", enum: LOCATIONS as unknown as string[] },
+              detail: {
+                type: "string",
+                description: "URL, phone number, or address for custom/phone/in_person.",
+              },
+            },
+            required: ["type"],
+          },
+        },
         bufferBeforeMinutes: { type: "integer", description: "Gap held before, 0–120." },
         bufferAfterMinutes: { type: "integer", description: "Gap held after, 0–120." },
         minimumNoticeMinutes: {
@@ -606,6 +646,10 @@ export const TOOLS: AiToolDef[] = [
       durationMinutes: z.number().int().min(5).max(480).optional(),
       color: z.enum(COLORS).optional(),
       location: z.enum(LOCATIONS).optional(),
+      locations: z
+        .array(z.object({ type: z.enum(LOCATIONS), detail: z.string().max(500).nullish() }))
+        .max(6)
+        .optional(),
       bufferBeforeMinutes: z.number().int().min(0).max(120).optional(),
       bufferAfterMinutes: z.number().int().min(0).max(120).optional(),
       minimumNoticeMinutes: z.number().int().min(0).max(20_160).optional(),


### PR DESCRIPTION
Closes #170.

## What

Otter can already set a single location on a booking type. This lets it author a **menu of locations** the booker chooses from (Zoom OR phone OR in-person, etc.) via the AI tools, matching what the web editor and booking page already support (#103).

## Changes

- **`registry.ts`** — add an optional `locations` array (up to 6, each `{ type, detail? }`) to both the `create_booking_type` and `update_booking_type` tool schemas (JSON + zod).
- **`exec.ts`** — persist it with the same contract as the `PUT /event-types/[id]` route:
  - a non-empty `locations` menu drives the location columns, mirroring its first entry into the single `location`/`locationDetail` columns so older readers still work;
  - on update, an empty array clears the menu back to a single location; omitting `locations` preserves the stored menu;
  - create re-validates through `eventTypeInputSchema` (reusing `locationOptionSchema`).

## Verify

- `biome check` clean on both files
- `pnpm --filter @dayotter/web typecheck` clean
- web test suite green (172 passed)