### PR TITLE
feat(ai): carry ad-hoc location + hold reminders on the create path

### DIFF
--- a/apps/mobile/src/components/otter-launcher.tsx
+++ b/apps/mobile/src/components/otter-launcher.tsx
@@ -40,6 +40,9 @@ interface Draft {
   notes: string;
   /** Slug of a matched event type, so the booking maps to the real type. */
   eventTypeSlug?: string;
+  /** Ad-hoc meeting location the request named, when there's no matched type. */
+  location?: string;
+  locationDetail?: string;
   newStartISO: string;
   message: string;
 }
@@ -256,6 +259,9 @@ function OtterSheet({ onClose }: { onClose: () => void }) {
           eventTypeSlug: draft.eventTypeSlug || undefined,
           // "focus" is held as a personal focus block, not a meeting.
           kind: draft.kind,
+          // Ad-hoc location ("on Zoom / Meet / phone") when there's no matched type.
+          location: draft.location || undefined,
+          locationDetail: draft.locationDetail || undefined,
         });
         finish("Added to your calendar.");
       } else if (draft.intent === "reschedule" && target) {

--- a/apps/web/app/api/ai/schedule/create/route.ts
+++ b/apps/web/app/api/ai/schedule/create/route.ts
@@ -1,4 +1,5 @@
 import { aiEnabled } from "@/lib/ai/schedule-parse";
+import { LOCATION_TYPES } from "@/lib/booking/event-type-input";
 import { createHostBooking } from "@/lib/booking/host-booking";
 import { writeBookingToCalendar } from "@/lib/calendar/host-calendar";
 import { jsonError, withUser } from "@/lib/server/http";
@@ -23,6 +24,10 @@ const body = z.object({
   eventTypeSlug: z.string().max(200).optional(),
   /** "focus" is held as a personal focus block (not a meeting/booking). */
   kind: z.enum(["meeting", "focus", "reminder"]).optional(),
+  /** Ad-hoc meeting location ("on Zoom / Meet / phone") when there's no event type.
+   * Lenient: an unexpected value falls back to no location rather than 400-ing. */
+  location: z.enum(LOCATION_TYPES).optional().catch(undefined),
+  locationDetail: z.string().max(500).optional(),
 });
 
 /**
@@ -61,15 +66,17 @@ export const POST = withUser(async (u, request) => {
 
   const timezone = user?.timezone ?? "UTC";
 
-  // A "focus" draft is a personal hold, not a meeting: write it as a focus
-  // time_block (blocks bookable availability, no attendees/reminders/invite) and
+  // A "focus" or "reminder" draft is a personal hold, not a meeting: write it as
+  // a time_block (blocks bookable availability, no attendees/reminders/invite) and
   // best-effort mirror it to the calendar - the same shape as protect_focus_time.
-  if (d.kind === "focus") {
+  // A reminder is a lightweight personal hold; focus is deep-work time.
+  if (d.kind === "focus" || d.kind === "reminder") {
+    const blockKind = d.kind === "reminder" ? "personal" : "focus";
     try {
       await getDb().insert(schema.timeBlocks).values({
         userId: u.id,
         title: d.title,
-        kind: "focus",
+        kind: blockKind,
         startsAt: start,
         endsAt: end,
         seriesId: null,
@@ -81,15 +88,20 @@ export const POST = withUser(async (u, request) => {
         timezone,
         attendees: [],
       }).catch(() => null);
-      logger.info("ai focus block created", { event: "ai_focus_block_created", userId: u.id });
+      logger.info("ai hold created", {
+        event: "ai_hold_created",
+        userId: u.id,
+        kind: blockKind,
+      });
       return NextResponse.json({ ok: true });
     } catch (err) {
-      logger.error("ai focus block create failed", {
-        event: "ai_focus_block_failed",
+      logger.error("ai hold create failed", {
+        event: "ai_hold_failed",
         userId: u.id,
+        kind: blockKind,
         err,
       });
-      return jsonError("Couldn't hold that focus time. Please try again.", 502);
+      return jsonError("Couldn't hold that time. Please try again.", 502);
     }
   }
 
@@ -103,6 +115,8 @@ export const POST = withUser(async (u, request) => {
       notes: d.notes,
       attendees,
       eventTypeSlug: d.eventTypeSlug,
+      location: d.location,
+      locationDetail: d.locationDetail,
     });
     if (!result) return jsonError("Couldn't add the event. Please try again.", 502);
     logger.info("ai event created", { event: "ai_event_created", userId: u.id });

--- a/apps/web/components/ai-assistant.tsx
+++ b/apps/web/components/ai-assistant.tsx
@@ -236,6 +236,9 @@ export function AiAssistant({
         eventTypeSlug: action.matchedEventType?.slug,
         // "focus" is held as a personal focus block, not a meeting.
         kind: action.draft.kind,
+        // Ad-hoc location ("on Zoom / Meet / phone") when there's no matched type.
+        location: action.draft.location || undefined,
+        locationDetail: action.draft.locationDetail || undefined,
       }),
     });
     setBusy(false);

--- a/apps/web/lib/ai/agent.ts
+++ b/apps/web/lib/ai/agent.ts
@@ -148,6 +148,8 @@ You also have a read-only tool, find_free_slots, that returns times the host is 
     attendees: [],
     notes: "",
     eventTypeSlug: "",
+    location: "",
+    locationDetail: "",
     bookingRef: 0,
     newStartISO: "",
     message: "I couldn't work that out. Try naming a specific time, or manage it manually.",

--- a/apps/web/lib/ai/command-parse.ts
+++ b/apps/web/lib/ai/command-parse.ts
@@ -1,3 +1,4 @@
+import { LOCATION_TYPES } from "@/lib/booking/event-type-input";
 import { z } from "zod";
 import { GUARDRAIL_PREAMBLE } from "./guardrails";
 import { extract } from "./llm";
@@ -39,6 +40,11 @@ export const commandDraftSchema = z.object({
   notes: z.string(),
   /** Slug of the matching event type when the request clearly names one, else "". */
   eventTypeSlug: z.string(),
+  /** Ad-hoc meeting location type the request names ("on Zoom / Meet / phone"),
+   * else "". Lenient here (the create route validates against the enum). */
+  location: z.string(),
+  /** Its detail: a URL, phone number, or address, when the request gives one. */
+  locationDetail: z.string(),
   // reschedule / cancel fields
   bookingRef: z.number().int().min(0),
   newStartISO: z.string(),
@@ -64,6 +70,7 @@ Rules:
 - For create: kind, a short title, startISO, durationMinutes, attendees (name + email if given, else empty email), notes.
 - Attendees are only INVITED if you have their email address - an attendee with an empty email is dropped and gets no invite. If the user clearly wants to invite a named person but gives no email (e.g. "book a call with Dana"), don't invent one: either ask for their email (intent "none", put the question in message), or, if they just want the time held, proceed and make clear in message that that person won't be emailed. Never silently imply someone was invited when they weren't.
 - Event types: you are given the user's event types (title + default duration). If a create request clearly matches one (e.g. "book a sync" → the "Sync" type), set eventTypeSlug to its slug and use that type's default duration. Otherwise eventTypeSlug = "" and default durationMinutes to 30 (meeting) / 60 (focus).
+- Location (create with NO matching event type only): if the request names where the meeting happens, set location to the type - "on Zoom"→zoom, "on Meet/Google Meet"→google_meet, "on Teams"→ms_teams, "over the phone/call me"→phone, "in person/at the office/at <place>"→in_person, anything else specific→custom. Put a given link/number/address in locationDetail. If no location is mentioned, or a matching event type was found (it carries its own location), leave both "". Location does not apply to focus or reminder holds.
 - For reschedule/cancel: set bookingRef to the exact ref of the intended booking. If several bookings could match and you can't tell, use intent "none" and ask which one in message.
 - bookingRef must be 0 for create/none.
 - message: for "none", one short sentence - either that you only help with scheduling, or a clarifying question naming the ambiguous options. Otherwise empty.`;
@@ -97,6 +104,17 @@ export const commandInputSchema = {
       type: "string",
       description: "Slug of the matching event type for a create request, or empty string.",
     },
+    location: {
+      type: "string",
+      enum: ["", ...LOCATION_TYPES],
+      description:
+        "Meeting location type when the request names one ('on Zoom' → zoom, 'over the phone' → phone, 'at the office' → in_person), else empty string. Only for a create with no matching event type.",
+    },
+    locationDetail: {
+      type: "string",
+      description:
+        "The location's detail (Zoom/meet link, phone number, or address) if given, else empty string.",
+    },
     bookingRef: { type: "integer", description: "1-based ref of the target booking, or 0" },
     newStartISO: { type: "string", description: "ISO-8601 instant for a reschedule, else empty" },
     message: { type: "string" },
@@ -112,6 +130,8 @@ export const commandInputSchema = {
     "attendees",
     "notes",
     "eventTypeSlug",
+    "location",
+    "locationDetail",
     "bookingRef",
     "newStartISO",
     "message",

--- a/apps/web/lib/ai/interpret.ts
+++ b/apps/web/lib/ai/interpret.ts
@@ -44,6 +44,8 @@ function noneDraft(message: string): CommandDraft {
     attendees: [],
     notes: "",
     eventTypeSlug: "",
+    location: "",
+    locationDetail: "",
     bookingRef: 0,
     newStartISO: "",
     message,

--- a/apps/web/lib/booking/event-type-input.test.ts
+++ b/apps/web/lib/booking/event-type-input.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { eventTypeInputSchema } from "./event-type-input";
+import { calendarLocationFields, eventTypeInputSchema } from "./event-type-input";
 
 const valid = {
   title: "Intro Call",
@@ -58,5 +58,29 @@ describe("eventTypeInputSchema", () => {
       questions: [{ id: "q1", label: "x", type: "nope", required: true }],
     };
     expect(eventTypeInputSchema.safeParse(badType).success).toBe(false);
+  });
+});
+
+describe("calendarLocationFields", () => {
+  it("requests a provider conference for auto-conference types", () => {
+    expect(calendarLocationFields("google_meet")).toEqual({ createConference: true });
+    expect(calendarLocationFields("ms_teams", "ignored")).toEqual({ createConference: true });
+  });
+
+  it("carries the detail as location text for the rest", () => {
+    expect(calendarLocationFields("zoom", "https://zoom.us/j/1")).toEqual({
+      location: "https://zoom.us/j/1",
+    });
+    expect(calendarLocationFields("in_person", "123 Main St")).toEqual({ location: "123 Main St" });
+  });
+
+  it("falls back to a human label when no detail is given", () => {
+    expect(calendarLocationFields("phone")).toEqual({ location: "Phone call" });
+    expect(calendarLocationFields("zoom", "  ")).toEqual({ location: "Zoom" });
+  });
+
+  it("returns nothing when there's no location", () => {
+    expect(calendarLocationFields(null)).toEqual({});
+    expect(calendarLocationFields(undefined, "x")).toEqual({});
   });
 });

--- a/apps/web/lib/booking/event-type-input.ts
+++ b/apps/web/lib/booking/event-type-input.ts
@@ -83,6 +83,22 @@ export function resolveChosenLocation(
   return offered.find((o) => o.type === chosen) ?? null;
 }
 
+/**
+ * Map a chosen location to the fields a calendar write understands. Auto-conference
+ * types (Meet / Teams) request a provider-generated link; everything else carries its
+ * detail (or a human label) as the event's location text. Best-effort - the richer
+ * Zoom/Jitsi link minting only runs on the public booking path (see finalize-booking).
+ */
+export function calendarLocationFields(
+  type?: LocationTypeValue | null,
+  detail?: string | null,
+): { location?: string; createConference?: boolean } {
+  if (!type) return {};
+  if (AUTO_CONFERENCE.includes(type)) return { createConference: true };
+  const text = detail?.trim();
+  return { location: text && text.length > 0 ? text : LOCATION_LABELS[type] };
+}
+
 export const LOCATION_DETAIL_PLACEHOLDER: Record<LocationTypeValue, string> = {
   google_meet: "",
   ms_teams: "",

--- a/apps/web/lib/booking/host-booking.ts
+++ b/apps/web/lib/booking/host-booking.ts
@@ -3,6 +3,8 @@ import { primaryOrg } from "@/lib/billing/entitlements";
 import { writeBookingToCalendar } from "@/lib/calendar/host-calendar";
 import { logger } from "@dayotter/core";
 import { and, eq, getDb, schema } from "@dayotter/db";
+import { calendarLocationFields } from "./event-type-input";
+import type { LocationTypeValue } from "./event-type-input";
 import { PERSONAL_EVENT_TYPE_SLUG } from "./personal-event-type";
 import {
   hostWantsOverflowNotice,
@@ -51,6 +53,11 @@ export interface HostBookingInput {
   /** Slug of a real event type this maps to (so its workflows apply); else the
    * hidden Personal type. */
   eventTypeSlug?: string;
+  /** Ad-hoc meeting location the host asked for ("on Zoom / Meet / phone"), when
+   * this isn't tied to an event type's own location. Auto-conference types get a
+   * provider link; the rest carry `locationDetail` (a URL / number / address). */
+  location?: LocationTypeValue;
+  locationDetail?: string;
 }
 
 export interface HostBookingResult {
@@ -101,6 +108,8 @@ export async function createHostBooking(
       endsAt: input.end,
       timezone: input.timezone,
       status: "confirmed",
+      locationType: input.location ?? null,
+      location: input.locationDetail ?? null,
       uid,
     })
     .returning();
@@ -128,6 +137,7 @@ export async function createHostBooking(
       end: input.end,
       timezone: input.timezone,
       attendees: attendees.map((a) => ({ email: a.email, name: a.name })),
+      ...calendarLocationFields(input.location, input.locationDetail),
     });
     if (written) {
       meetingUrl = written.meetingUrl;

--- a/apps/web/lib/messaging/otter-sms.ts
+++ b/apps/web/lib/messaging/otter-sms.ts
@@ -1,5 +1,6 @@
 import { interpretOtterCommand } from "@/lib/ai/interpret";
 import { cancelBooking } from "@/lib/booking/cancel-booking";
+import { LOCATION_TYPES, type LocationTypeValue } from "@/lib/booking/event-type-input";
 import { createHostBooking } from "@/lib/booking/host-booking";
 import { rescheduleBooking } from "@/lib/booking/reschedule-booking";
 import { writeBookingToCalendar } from "@/lib/calendar/host-calendar";
@@ -24,6 +25,9 @@ export type PendingAction =
       eventTypeSlug?: string;
       /** "focus" is held as a personal focus block, not a meeting. */
       kind?: "meeting" | "focus" | "reminder";
+      /** Ad-hoc meeting location, when the request named one and there's no event type. */
+      location?: LocationTypeValue;
+      locationDetail?: string;
     }
   | { intent: "reschedule"; uid: string; newStartISO: string; title: string; timezone: string }
   | { intent: "cancel"; uid: string; title: string };
@@ -61,6 +65,10 @@ export async function interpretForSms(userId: string, text: string): Promise<Int
 
   if (draft.intent === "create") {
     const when = whenLabel(draft.startISO, tz);
+    // Keep only a valid location type (the draft field is a lenient string).
+    const location = LOCATION_TYPES.includes(draft.location as LocationTypeValue)
+      ? (draft.location as LocationTypeValue)
+      : undefined;
     return {
       reply: `I'll add "${draft.title}" on ${when} (${draft.durationMinutes} min). Reply YES to confirm, or NO to cancel.`,
       pending: {
@@ -73,6 +81,8 @@ export async function interpretForSms(userId: string, text: string): Promise<Int
         timezone: tz,
         eventTypeSlug: draft.eventTypeSlug || undefined,
         kind: draft.kind,
+        location,
+        locationDetail: draft.locationDetail || undefined,
       },
     };
   }
@@ -109,12 +119,13 @@ export async function executePending(userId: string, pending: PendingAction): Pr
       const start = new Date(pending.startISO);
       const end = new Date(start.getTime() + pending.durationMinutes * 60_000);
 
-      // A "focus" hold is a personal focus block, not a meeting/booking.
-      if (pending.kind === "focus") {
+      // A "focus" or "reminder" hold is a personal time block, not a meeting/booking.
+      if (pending.kind === "focus" || pending.kind === "reminder") {
+        const blockKind = pending.kind === "reminder" ? "personal" : "focus";
         await getDb().insert(schema.timeBlocks).values({
           userId,
           title: pending.title,
-          kind: "focus",
+          kind: blockKind,
           startsAt: start,
           endsAt: end,
           seriesId: null,
@@ -126,7 +137,8 @@ export async function executePending(userId: string, pending: PendingAction): Pr
           timezone: pending.timezone,
           attendees: [],
         }).catch(() => null);
-        return `Done ✓ Focus time "${pending.title}" is held for ${whenLabel(pending.startISO, pending.timezone)}.`;
+        const label = pending.kind === "reminder" ? "Reminder" : "Focus time";
+        return `Done ✓ ${label} "${pending.title}" is held for ${whenLabel(pending.startISO, pending.timezone)}.`;
       }
 
       const attendees = pending.attendees
@@ -141,6 +153,8 @@ export async function executePending(userId: string, pending: PendingAction): Pr
         notes: pending.notes || undefined,
         attendees,
         eventTypeSlug: pending.eventTypeSlug,
+        location: pending.location,
+        locationDetail: pending.locationDetail,
       });
       if (!result) return "I couldn't add that right now - please try again, or use the app.";
       return `Done ✓ "${pending.title}" is on your calendar for ${whenLabel(pending.startISO, pending.timezone)}.`;


### PR DESCRIPTION
Closes #188.

Two create-path gaps from the Otter coverage audit (after the event-type passthrough in #184):

## 1. Ad-hoc location was dropped
"schedule a 45-min review **on Zoom**" with no matching event type lost the location — `HostBookingInput`, the create route, and the draft/card had no location field. Now:

- The draft carries a **location type + detail** (`command-parse.ts`), guided by the model prompt ("on Zoom"→zoom, "over the phone"→phone, "at the office"→in_person, …).
- It flows end-to-end through the **web confirm card**, **mobile launcher**, and **SMS** confirm to the create route.
- `createHostBooking` persists `locationType`/`location` on the booking and passes best-effort calendar fields via a new shared **`calendarLocationFields()`** helper — auto-conference types (Meet/Teams) request a provider link; the rest carry the detail (or a human label) as the event's location text.
- The route is lenient (an unexpected location value falls back to no-location rather than 400-ing).

## 2. `reminder` kind became a full meeting
Only `focus` was special-cased into a `time_block`; a `reminder` fell through to `createHostBooking` and became a full event with an invite. Now a reminder writes a lightweight **personal** `time_block` (no attendees/invite/reminders), like focus. Covers C7 "remind me to…". Applied on both the web route and the SMS path.

## Verify
- `biome check` clean; `pnpm --filter @dayotter/web typecheck` + `--filter @dayotter/mobile typecheck` clean
- web tests green (176 passed) — added `calendarLocationFields` unit tests