### PR TITLE
fix(teams): remove a member / leave a team

### DIFF
--- a/apps/web/app/(app)/teams/[id]/page.tsx
+++ b/apps/web/app/(app)/teams/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { MemberWeight } from "@/components/member-weight";
 import { PageHeader } from "@/components/page-header";
 import { TeamBriefingSettings } from "@/components/team-briefing-settings";
-import { AddMemberForm, CreateTeamEventForm } from "@/components/team-forms";
+import { AddMemberForm, CreateTeamEventForm, RemoveMember } from "@/components/team-forms";
 import { TeamRules } from "@/components/team-rules";
 import { TeamScheduleView } from "@/components/team-schedule-view";
 import { Card, CardBody, CardHeader } from "@/components/ui/card";
@@ -105,6 +105,14 @@ export default async function TeamDetailPage({ params }: { params: Promise<{ id:
                     initial={m.priority}
                     editable={canManage}
                   />
+                  {m.role !== "owner" && (canManage || m.userId === session!.user.id) ? (
+                    <RemoveMember
+                      teamId={team.id}
+                      memberId={m.id}
+                      memberName={m.user?.name ?? m.user?.email ?? "This member"}
+                      isSelf={m.userId === session!.user.id}
+                    />
+                  ) : null}
                 </li>
               ))}
             </ul>

--- a/apps/web/app/api/teams/[id]/members/[memberId]/route.ts
+++ b/apps/web/app/api/teams/[id]/members/[memberId]/route.ts
@@ -66,7 +66,11 @@ export async function PATCH(
   return NextResponse.json({ ok: true });
 }
 
-/** Remove a member from the team. Admins/owners only; owners can't be removed. */
+/**
+ * Remove a member from the team. Admins/owners can remove anyone; any member can
+ * remove (leave) themselves. The owner can't leave or be removed - they must
+ * transfer ownership or delete the team first.
+ */
 export async function DELETE(
   _request: Request,
   { params }: { params: Promise<{ id: string; memberId: string }> },
@@ -82,16 +86,28 @@ export async function DELETE(
       eq(schema.teamMembers.userId, session.user.id),
     ),
   });
-  if (!caller || (caller.role !== "owner" && caller.role !== "admin")) {
-    return NextResponse.json({ error: "Only team admins can remove members" }, { status: 403 });
+  if (!caller) {
+    return NextResponse.json({ error: "You're not a member of this team" }, { status: 403 });
   }
 
   const member = await db.query.teamMembers.findFirst({
     where: and(eq(schema.teamMembers.id, memberId), eq(schema.teamMembers.teamId, teamId)),
   });
   if (!member) return NextResponse.json({ error: "Member not found" }, { status: 404 });
+
+  // Admins/owners can remove anyone; a member may always remove themselves.
+  const isSelf = member.userId === session.user.id;
+  const isAdmin = caller.role === "owner" || caller.role === "admin";
+  if (!isAdmin && !isSelf) {
+    return NextResponse.json({ error: "Only team admins can remove members" }, { status: 403 });
+  }
   if (member.role === "owner") {
-    return NextResponse.json({ error: "The team owner can't be removed" }, { status: 400 });
+    return NextResponse.json(
+      {
+        error: "The team owner can't leave or be removed - transfer ownership or delete the team.",
+      },
+      { status: 400 },
+    );
   }
 
   await db.delete(schema.teamMembers).where(eq(schema.teamMembers.id, memberId));

--- a/apps/web/components/team-forms.tsx
+++ b/apps/web/components/team-forms.tsx
@@ -122,6 +122,83 @@ export function AddMemberForm({ teamId }: { teamId: string }) {
   );
 }
 
+/**
+ * Remove a member from a team, or leave it yourself. Admins/owners see this on
+ * every non-owner member; a regular member sees it only on their own row (as
+ * "Leave"). Two-click confirm so a single tap can't drop someone by accident.
+ */
+export function RemoveMember({
+  teamId,
+  memberId,
+  memberName,
+  isSelf,
+}: {
+  teamId: string;
+  memberId: string;
+  memberName: string;
+  isSelf: boolean;
+}) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [confirming, setConfirming] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  async function remove() {
+    setLoading(true);
+    const res = await fetch(`/api/teams/${teamId}/members/${memberId}`, { method: "DELETE" });
+    const data = await res.json().catch(() => ({}));
+    setLoading(false);
+    if (res.ok) {
+      toast({
+        title: isSelf ? "You left the team" : `${memberName} removed from the team`,
+        variant: "success",
+      });
+      // Leaving revokes access to this page - go back to the teams list.
+      if (isSelf) router.push("/teams");
+      else router.refresh();
+      return;
+    }
+    setConfirming(false);
+    toast({
+      title: isSelf ? "Couldn't leave the team" : "Couldn't remove member",
+      description: typeof data.error === "string" ? data.error : undefined,
+      variant: "error",
+    });
+  }
+
+  if (!confirming) {
+    return (
+      <button
+        type="button"
+        onClick={() => setConfirming(true)}
+        className="text-xs text-[var(--color-muted)] transition-colors hover:text-[var(--color-danger)]"
+      >
+        {isSelf ? "Leave" : "Remove"}
+      </button>
+    );
+  }
+  return (
+    <span className="flex items-center gap-2 text-xs">
+      <button
+        type="button"
+        onClick={remove}
+        disabled={loading}
+        className="font-medium text-[var(--color-danger)] hover:underline disabled:opacity-50"
+      >
+        {loading ? "Removing…" : isSelf ? "Confirm leave" : "Confirm remove"}
+      </button>
+      <button
+        type="button"
+        onClick={() => setConfirming(false)}
+        disabled={loading}
+        className="text-[var(--color-muted)] transition-colors hover:text-[var(--color-text)]"
+      >
+        Cancel
+      </button>
+    </span>
+  );
+}
+
 const DURATIONS = [15, 30, 45, 60];
 
 export function CreateTeamEventForm({ teamId }: { teamId: string }) {


### PR DESCRIPTION
Fixes a user-reported bug: on a team you can add a member but can't remove one, and a member can't remove themselves.

## Cause
The team detail page listed each member with only the round-robin **weight** control — there was no remove affordance at all. And the `DELETE /api/teams/[id]/members/[memberId]` endpoint required the caller to be an **owner/admin**, so a regular member could never remove *themselves* even if the UI had let them.

## Fix
- **API** — self-removal is now allowed: a member can always remove their own row (leave). Admins/owners can still remove anyone. The **owner** still can't be removed or leave (they must transfer ownership or delete the team) — returns a clear message instead of a silent failure.
- **UI** — new `RemoveMember` control on each member row:
  - Admins/owners see **Remove** on every non-owner member.
  - Any member sees **Leave** on their own row.
  - Two-click confirm (Remove → Confirm) so one tap can't drop someone by accident. Leaving redirects to the teams list; removing refreshes in place. Removal also drops the member's host rows from the team's round-robin event types (already handled server-side).

## Verify
- `biome check` clean; `pnpm --filter @dayotter/web typecheck` clean; web tests green (172)
- Not exercised in the live preview here (the authed teams page needs a provisioned Postgres, which isn't available in this environment) — logic verified by types + reading. Happy to add a screenshot against a seeded DB if useful.

Reported by a user (Naude).