### PR TITLE
feat(ai): daily cost ceiling for the public booking assistant

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -125,6 +125,13 @@ ANTHROPIC_API_KEY=
 # OPENAI_MODEL_DEEP=gpt-4.1
 # OPENAI_MODEL_FAST=gpt-4.1-mini
 
+# Daily LLM-call ceilings for the public booking-page assistant, on top of the
+# per-IP rate limit - caps the model spend a public page can run up. Per-host and
+# global (whole deployment); over budget it falls back to showing the soonest
+# open slots without the model. Rolling 24h windows.
+# BOOKING_ASSISTANT_HOST_DAILY=200
+# BOOKING_ASSISTANT_GLOBAL_DAILY=2000
+
 # ---- Reminder channels (optional) ----
 # Slack and mobile push need no server creds - the destination is stored per-user.
 # WhatsApp + SMS reminders use Twilio; leave blank to hide those channel types.

--- a/apps/web/app/api/public/booking-assistant/route.ts
+++ b/apps/web/app/api/public/booking-assistant/route.ts
@@ -3,12 +3,20 @@ import { aiEnabled, extract } from "@/lib/ai/llm";
 import { getEventTypeAvailability } from "@/lib/booking/availability";
 import { enforceRateLimit } from "@/lib/server/rate-limit";
 import { eq, getDb, schema } from "@dayotter/db";
+import { rateLimit } from "@dayotter/jobs";
 import { DateTime } from "luxon";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
+
+// Daily LLM-call ceilings, on top of the per-IP rate limit. Bounds the model
+// spend a public booking page can run up: one budget per host (a single busy or
+// abused page can't drain the bill) and one global backstop for the deployment.
+// A rolling 24h window; over budget falls back to showing the soonest slots.
+const HOST_DAILY_LIMIT = Number(process.env.BOOKING_ASSISTANT_HOST_DAILY) || 200;
+const GLOBAL_DAILY_LIMIT = Number(process.env.BOOKING_ASSISTANT_GLOBAL_DAILY) || 2000;
 
 const body = z.object({
   eventTypeId: z.string().uuid(),
@@ -83,6 +91,24 @@ export async function POST(request: Request) {
 
   // Cap the list fed to the model; label each in the visitor's timezone.
   const capped = slots.slice(0, 60);
+
+  // Daily cost ceilings (per host + global). Only requests that would actually
+  // call the model reach here (guardrail / no-slots / disabled all return above),
+  // so this counts model-bound requests. Over budget: still help the visitor with
+  // the soonest open times, just without the model ranking them.
+  const [hostBudget, globalBudget] = await Promise.all([
+    rateLimit(`ba-host:${et.ownerId}`, HOST_DAILY_LIMIT, 86_400),
+    rateLimit("ba-global", GLOBAL_DAILY_LIMIT, 86_400),
+  ]);
+  if (!hostBudget.ok || !globalBudget.ok) {
+    return NextResponse.json({
+      message: "Here are the soonest open times - pick whichever works for you.",
+      slots: capped
+        .slice(0, 5)
+        .map((s) => ({ start: s.start.toISOString(), end: s.end.toISOString() })),
+    });
+  }
+
   const zone = DateTime.now().setZone(tz).isValid ? tz : "UTC";
   const numbered = capped
     .map(


### PR DESCRIPTION
Closes #67.

The public booking-page assistant (`/api/public/booking-assistant`) was rate-limited **per IP only**, so a single busy — or abused — booking page could run up unbounded LLM spend across many IPs.

## Fix
- Adds a **per-host** and a **global** daily ceiling on model-bound requests, using the existing Redis fixed-window limiter (rolling 24h window).
- The check sits after the guardrail / no-slots / disabled short-circuits, so it only counts requests that would actually call the model.
- **Graceful degradation:** over budget, the visitor still gets the soonest open slots to choose from — just without the model ranking them — rather than an error.
- Configurable: `BOOKING_ASSISTANT_HOST_DAILY` (default 200), `BOOKING_ASSISTANT_GLOBAL_DAILY` (default 2000); both documented in `.env.example`.

## Verify
- `biome check` + `@dayotter/web` typecheck clean.