### PR TITLE
feat(teams): transfer team ownership

### DIFF
--- a/apps/web/app/(app)/teams/[id]/page.tsx
+++ b/apps/web/app/(app)/teams/[id]/page.tsx
@@ -4,6 +4,7 @@ import { TeamBriefingSettings } from "@/components/team-briefing-settings";
 import { AddMemberForm, CreateTeamEventForm, RemoveMember } from "@/components/team-forms";
 import { TeamRules } from "@/components/team-rules";
 import { TeamScheduleView } from "@/components/team-schedule-view";
+import { TransferTeamOwnership } from "@/components/transfer-team-ownership";
 import { Card, CardBody, CardHeader } from "@/components/ui/card";
 import { getSession } from "@/lib/auth/session";
 import { teamSchedule } from "@/lib/booking/team-schedule";
@@ -96,7 +97,14 @@ export default async function TeamDetailPage({ params }: { params: Promise<{ id:
                     {(m.user?.name ?? m.user?.email ?? "?").charAt(0).toUpperCase()}
                   </div>
                   <div className="min-w-0">
-                    <p className="text-sm font-medium">{m.user?.name ?? "Member"}</p>
+                    <p className="flex items-center gap-2 text-sm font-medium">
+                      {m.user?.name ?? "Member"}
+                      {m.role !== "member" ? (
+                        <span className="rounded-full bg-[var(--color-surface-2)] px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-[var(--color-muted)]">
+                          {m.role}
+                        </span>
+                      ) : null}
+                    </p>
                     <p className="truncate text-xs text-[var(--color-muted)]">{m.user?.email}</p>
                   </div>
                   <MemberWeight
@@ -105,6 +113,13 @@ export default async function TeamDetailPage({ params }: { params: Promise<{ id:
                     initial={m.priority}
                     editable={canManage}
                   />
+                  {myRole === "owner" && m.role !== "owner" ? (
+                    <TransferTeamOwnership
+                      teamId={team.id}
+                      memberId={m.id}
+                      name={m.user?.name ?? m.user?.email ?? "this member"}
+                    />
+                  ) : null}
                   {m.role !== "owner" && (canManage || m.userId === session!.user.id) ? (
                     <RemoveMember
                       teamId={team.id}

--- a/apps/web/app/api/teams/[id]/members/[memberId]/route.ts
+++ b/apps/web/app/api/teams/[id]/members/[memberId]/route.ts
@@ -5,12 +5,15 @@ import { z } from "zod";
 
 export const dynamic = "force-dynamic";
 
-const body = z.object({ priority: z.number().int().min(0).max(10) });
+const body = z.union([
+  z.object({ priority: z.number().int().min(0).max(10) }),
+  z.object({ role: z.literal("owner") }),
+]);
 
 /**
- * Update a team member's round-robin weight. Higher = assigned more often; 0 =
- * paused from the rotation. Propagates to the member's host rows on the team's
- * existing round-robin event types so the change takes effect immediately.
+ * Update a team member: change their round-robin weight (admins/owners), or - via
+ * `{ role: "owner" }` - transfer ownership to them (owner only). A weight change
+ * propagates to the member's host rows on the team's existing event types.
  */
 export async function PATCH(
   request: Request,
@@ -27,17 +30,46 @@ export async function PATCH(
       eq(schema.teamMembers.userId, session.user.id),
     ),
   });
-  if (!caller || (caller.role !== "owner" && caller.role !== "admin")) {
-    return NextResponse.json({ error: "Only team admins can change weights" }, { status: 403 });
-  }
+  if (!caller)
+    return NextResponse.json({ error: "You're not a member of this team" }, { status: 403 });
 
   const parsed = body.safeParse(await request.json().catch(() => null));
-  if (!parsed.success) return NextResponse.json({ error: "Invalid weight" }, { status: 400 });
+  if (!parsed.success)
+    return NextResponse.json({ error: "Invalid member update" }, { status: 400 });
 
   const member = await db.query.teamMembers.findFirst({
     where: and(eq(schema.teamMembers.id, memberId), eq(schema.teamMembers.teamId, teamId)),
   });
   if (!member) return NextResponse.json({ error: "Member not found" }, { status: 404 });
+
+  // Transfer ownership: only the current owner can, and it demotes them to admin
+  // (so they can then leave the team) while promoting the target to owner. Done
+  // in one transaction so a team always has exactly one owner.
+  if ("role" in parsed.data) {
+    if (caller.role !== "owner") {
+      return NextResponse.json(
+        { error: "Only the team owner can transfer ownership" },
+        { status: 403 },
+      );
+    }
+    if (member.id === caller.id) return NextResponse.json({ ok: true });
+    await db.transaction(async (tx) => {
+      await tx
+        .update(schema.teamMembers)
+        .set({ role: "admin" })
+        .where(eq(schema.teamMembers.id, caller.id));
+      await tx
+        .update(schema.teamMembers)
+        .set({ role: "owner" })
+        .where(eq(schema.teamMembers.id, member.id));
+    });
+    return NextResponse.json({ ok: true });
+  }
+
+  // Weight change: admins/owners only.
+  if (caller.role !== "owner" && caller.role !== "admin") {
+    return NextResponse.json({ error: "Only team admins can change weights" }, { status: 403 });
+  }
 
   await db
     .update(schema.teamMembers)

--- a/apps/web/components/transfer-team-ownership.tsx
+++ b/apps/web/components/transfer-team-ownership.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { ConfirmDialog } from "@/components/ui/dialog";
+import { useToast } from "@/components/ui/toast";
+import { Crown } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+/**
+ * Hand the team over to another member. Owner-only. The current owner becomes an
+ * admin afterwards, which is what lets them then leave the team (the owner can't
+ * leave directly). Confirm-first, since ownership is a one-way handover.
+ */
+export function TransferTeamOwnership({
+  teamId,
+  memberId,
+  name,
+}: {
+  teamId: string;
+  memberId: string;
+  name: string;
+}) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  async function transfer() {
+    setBusy(true);
+    const res = await fetch(`/api/teams/${teamId}/members/${memberId}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ role: "owner" }),
+    });
+    const data = await res.json().catch(() => ({}));
+    setBusy(false);
+    if (!res.ok) {
+      toast({
+        title: "Couldn't transfer ownership",
+        description: typeof data.error === "string" ? data.error : undefined,
+        variant: "error",
+      });
+      return;
+    }
+    setOpen(false);
+    toast({ title: `${name} is now the team owner`, variant: "success" });
+    router.refresh();
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="text-xs text-[var(--color-muted)] transition-colors hover:text-[var(--color-text)]"
+      >
+        <span className="inline-flex items-center gap-1">
+          <Crown size={13} /> Make owner
+        </span>
+      </button>
+      <ConfirmDialog
+        open={open}
+        onClose={() => setOpen(false)}
+        onConfirm={transfer}
+        title={`Make ${name} the team owner?`}
+        description="You'll become an admin, and can then leave the team if you need to. This can't be undone by you - only the new owner can transfer it back."
+        confirmLabel="Transfer ownership"
+        loading={busy}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
Completes the team-management flow started in #237. After remove/leave landed, the **owner still couldn't leave** — there was no way to hand the team off.

## What
- `PATCH /api/teams/[id]/members/[memberId]` now accepts `{ role: "owner" }` (owner-only). In a single transaction it demotes the current owner to **admin** and promotes the target to **owner**, so a team always has exactly one owner — and the former owner can then leave via the existing flow.
- UI: a confirm-first **"Make owner"** control on each other member (visible only to the owner), and an **Owner/Admin** role badge on the member list for clarity.

## Provenance
Adapted from a feature in a user's fork (Naude Opperman) — re-implemented against current `main` and matched to our conventions (reuses our `ConfirmDialog`). Naude's own remove/leave code turned out nearly identical to #237, so this is the natural missing piece.

## Verify
- `biome check` + `@dayotter/web` typecheck clean; web tests green.