### PR TITLE
feat(teams): embeddable team availability calendar

### DIFF
--- a/apps/web/app/embed/team/[teamSlug]/calendar/[token]/page.tsx
+++ b/apps/web/app/embed/team/[teamSlug]/calendar/[token]/page.tsx
@@ -1,0 +1,45 @@
+import { EmbedBridge } from "@/components/embed-bridge";
+import { TeamScheduleView } from "@/components/team-schedule-view";
+import { loadSharedTeamCalendar } from "@/lib/booking/shared-team-calendar";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Team availability",
+  robots: { index: false, follow: false },
+};
+
+/**
+ * Chrome-less version of the shared team availability calendar, for embedding in
+ * an iframe (via the copyable snippet in team settings, or embed.js). Same
+ * token-gated, privacy-stripped data as the public page, minus the site shell,
+ * plus an EmbedBridge that relays height to the parent so the frame can auto-size.
+ * `?theme=light|dark|auto` matches the booking embed.
+ */
+export default async function EmbedTeamCalendarPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ teamSlug: string; token: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const { teamSlug, token } = await params;
+  const data = await loadSharedTeamCalendar(teamSlug, token);
+  if (!data) notFound();
+
+  const themeParam = (await searchParams).theme;
+  const theme = themeParam === "dark" ? "dark" : themeParam === "light" ? "light" : "auto";
+
+  return (
+    <div className="bg-[var(--color-bg)] p-3">
+      <EmbedBridge theme={theme} />
+      <TeamScheduleView
+        schedule={data.schedule}
+        timezone={data.timezone}
+        rangeStart={data.rangeStart}
+      />
+    </div>
+  );
+}

--- a/apps/web/app/team/[teamSlug]/calendar/[token]/page.tsx
+++ b/apps/web/app/team/[teamSlug]/calendar/[token]/page.tsx
@@ -1,6 +1,5 @@
 import { TeamScheduleView } from "@/components/team-schedule-view";
-import { teamSchedule } from "@/lib/booking/team-schedule";
-import { eq, getDb, schema } from "@dayotter/db";
+import { loadSharedTeamCalendar } from "@/lib/booking/shared-team-calendar";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
@@ -24,37 +23,8 @@ export default async function TeamSharedCalendarPage({
   params: Promise<{ teamSlug: string; token: string }>;
 }) {
   const { teamSlug, token } = await params;
-  if (!token) notFound();
-
-  const db = getDb();
-  const team = await db.query.teams.findFirst({
-    where: eq(schema.teams.publicScheduleToken, token),
-    with: { members: { with: { user: true } } },
-  });
-  // Token is the capability; the slug must also match so the URL is coherent.
-  if (!team || !team.publicScheduleToken || team.slug !== teamSlug) notFound();
-
-  const owner = team.members.find((m) => m.role === "owner");
-  const tz = (owner?.user as { timezone?: string } | undefined)?.timezone ?? "UTC";
-
-  const now = new Date();
-  const weekEnd = new Date(now.getTime() + 7 * 86_400_000);
-  const raw = await teamSchedule(
-    team.members.map((m) => ({
-      userId: m.userId,
-      name: m.user?.name ?? "Member",
-      email: m.user?.email ?? "",
-    })),
-    now,
-    weekEnd,
-  );
-  // Public link → busy/free only. Drop meeting titles and emails.
-  const schedule = raw.map((m) => ({
-    userId: m.userId,
-    name: m.name,
-    email: "",
-    intervals: m.intervals.map((i) => ({ start: i.start, end: i.end })),
-  }));
+  const data = await loadSharedTeamCalendar(teamSlug, token);
+  if (!data) notFound();
 
   return (
     <main className="mx-auto max-w-4xl px-4 py-10">
@@ -62,13 +32,17 @@ export default async function TeamSharedCalendarPage({
         <p className="text-xs font-medium uppercase tracking-wide text-[var(--color-muted)]">
           Team availability
         </p>
-        <h1 className="text-2xl font-semibold text-[var(--color-text)]">{team.name}</h1>
+        <h1 className="text-2xl font-semibold text-[var(--color-text)]">{data.team.name}</h1>
         <p className="mt-1 text-sm text-[var(--color-muted)]">
-          When the team is busy over the next 7 days, shown in {tz.replace(/_/g, " ")}.
+          When the team is busy over the next 7 days, shown in {data.timezone.replace(/_/g, " ")}.
         </p>
       </header>
       <div className="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-4 shadow-[var(--shadow-card)]">
-        <TeamScheduleView schedule={schedule} timezone={tz} rangeStart={now} />
+        <TeamScheduleView
+          schedule={data.schedule}
+          timezone={data.timezone}
+          rangeStart={data.rangeStart}
+        />
       </div>
     </main>
   );

--- a/apps/web/components/team-calendar-sharing.tsx
+++ b/apps/web/components/team-calendar-sharing.tsx
@@ -25,9 +25,13 @@ export function TeamCalendarSharing({
   const [origin, setOrigin] = useState("");
   const [busy, setBusy] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [copiedEmbed, setCopiedEmbed] = useState(false);
 
   useEffect(() => setOrigin(window.location.origin), []);
   const url = token ? `${origin}/team/${teamSlug}/calendar/${token}` : "";
+  const embedCode = token
+    ? `<iframe src="${origin}/embed/team/${teamSlug}/calendar/${token}" style="width:100%;border:0;min-height:520px" loading="lazy" title="Team availability"></iframe>`
+    : "";
 
   async function generate() {
     setBusy(true);
@@ -55,6 +59,13 @@ export function TeamCalendarSharing({
     }
     setToken(null);
     toast({ title: "Sharing turned off", variant: "success" });
+  }
+
+  async function copyEmbed() {
+    if (!embedCode) return;
+    await navigator.clipboard.writeText(embedCode).catch(() => {});
+    setCopiedEmbed(true);
+    setTimeout(() => setCopiedEmbed(false), 1500);
   }
 
   async function copy() {
@@ -86,6 +97,22 @@ export function TeamCalendarSharing({
           {copied ? <Check size={15} /> : <Copy size={15} />}
           {copied ? "Copied" : "Copy"}
         </Button>
+      </div>
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between">
+          <span className="text-xs font-medium text-[var(--color-muted)]">Embed on your site</span>
+          <button
+            type="button"
+            onClick={copyEmbed}
+            className="inline-flex items-center gap-1 text-xs text-[var(--color-accent)] hover:underline"
+          >
+            {copiedEmbed ? <Check size={13} /> : <Copy size={13} />}
+            {copiedEmbed ? "Copied" : "Copy code"}
+          </button>
+        </div>
+        <pre className="overflow-x-auto rounded-md border border-[var(--color-border)] bg-[var(--color-surface-2)] p-2 text-[11px] text-[var(--color-muted)]">
+          <code>{embedCode}</code>
+        </pre>
       </div>
       <div className="flex gap-2">
         <Button size="sm" variant="ghost" onClick={generate} disabled={busy}>

--- a/apps/web/lib/booking/shared-team-calendar.ts
+++ b/apps/web/lib/booking/shared-team-calendar.ts
@@ -1,0 +1,62 @@
+import { eq, getDb, schema } from "@dayotter/db";
+import { teamSchedule } from "./team-schedule";
+
+export interface SharedTeamCalendar {
+  team: { id: string; name: string; slug: string };
+  timezone: string;
+  rangeStart: Date;
+  /** Busy/free only - meeting titles and emails are stripped for the public view. */
+  schedule: {
+    userId: string;
+    name: string;
+    email: string;
+    intervals: { start: Date; end: Date }[];
+  }[];
+}
+
+/**
+ * Load a team's public shared-availability calendar by (slug, token), or null if
+ * the token doesn't match or sharing is off. The token is the capability; the
+ * slug must also match so the URL is coherent. Privacy-preserving: the returned
+ * schedule carries busy/free blocks only - no meeting titles, no email addresses.
+ * Shared by the public page and the chrome-less embed page.
+ */
+export async function loadSharedTeamCalendar(
+  teamSlug: string,
+  token: string,
+): Promise<SharedTeamCalendar | null> {
+  if (!token) return null;
+  const db = getDb();
+  const team = await db.query.teams.findFirst({
+    where: eq(schema.teams.publicScheduleToken, token),
+    with: { members: { with: { user: true } } },
+  });
+  if (!team || !team.publicScheduleToken || team.slug !== teamSlug) return null;
+
+  const owner = team.members.find((m) => m.role === "owner");
+  const timezone = (owner?.user as { timezone?: string } | undefined)?.timezone ?? "UTC";
+
+  const now = new Date();
+  const weekEnd = new Date(now.getTime() + 7 * 86_400_000);
+  const raw = await teamSchedule(
+    team.members.map((m) => ({
+      userId: m.userId,
+      name: m.user?.name ?? "Member",
+      email: m.user?.email ?? "",
+    })),
+    now,
+    weekEnd,
+  );
+
+  return {
+    team: { id: team.id, name: team.name, slug: team.slug },
+    timezone,
+    rangeStart: now,
+    schedule: raw.map((m) => ({
+      userId: m.userId,
+      name: m.name,
+      email: "",
+      intervals: m.intervals.map((i) => ({ start: i.start, end: i.end })),
+    })),
+  };
+}


### PR DESCRIPTION
The **embeddable** half of the calendar work (adapted from Naude Opperman's fork). Builds directly on the shareable team calendar (#246).

## Changes
- New chrome-less **`/embed/team/[teamSlug]/calendar/[token]`** page — same token-gated, privacy-stripped (busy/free only, no titles/emails) data as the public page, minus the site shell, plus our `EmbedBridge` to relay height so the parent frame auto-sizes. Honors `?theme=light|dark|auto` like the booking embed. `noindex`.
- Extracted a shared **`loadSharedTeamCalendar`** loader; the public page (#246) is refactored onto it with no behavior change, so both stay in sync.
- The team settings **Share** card now offers a copy-paste `<iframe>` embed snippet next to the link.

Reuses our existing embed conventions (`EmbedBridge`, the theme param) rather than porting the fork's separate embed plumbing.

## Verify
- `biome check` + `@dayotter/web` typecheck clean; web tests green (183).
- Not exercised in a live browser here (needs a provisioned Postgres for the team + a parent page to iframe it) — verified by types + reading, consistent with the earlier team PRs.

## Note on the rest of this group
The **unified dashboard calendar** rework from the fork (~740 lines across `bookings-calendar` + a new `availability-calendar`) is a large UI change I'd rather validate in a real preview than ship on typecheck alone — recommend doing it in a session where the dev server + browser are available. Same for the whole-team booking flow (it changes the no-double-book DB constraint).