### PR TITLE
feat(teams): public collective member selection

### DIFF
--- a/apps/web/app/api/availability/[eventTypeId]/route.ts
+++ b/apps/web/app/api/availability/[eventTypeId]/route.ts
@@ -9,7 +9,11 @@ const querySchema = z.object({
   from: z.string().datetime().optional(),
   to: z.string().datetime().optional(),
   duration: z.coerce.number().int().min(5).max(1440).optional(),
+  /** Comma-separated host user ids for collective member-selection. */
+  hosts: z.string().max(1000).optional(),
 });
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export async function GET(
   request: Request,
@@ -28,6 +32,7 @@ export async function GET(
     from: url.searchParams.get("from") ?? undefined,
     to: url.searchParams.get("to") ?? undefined,
     duration: url.searchParams.get("duration") ?? undefined,
+    hosts: url.searchParams.get("hosts") ?? undefined,
   });
   if (!parsed.success) {
     return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
@@ -45,7 +50,18 @@ export async function GET(
   }
   const to = new Date(Math.min(requestedTo.getTime(), from.getTime() + MAX_WINDOW_MS));
 
-  const slots = await getEventTypeAvailability(eventTypeId, from, to, parsed.data.duration);
+  const selectedHostIds = parsed.data.hosts
+    ?.split(",")
+    .map((s) => s.trim())
+    .filter((s) => UUID_RE.test(s))
+    .slice(0, 50);
+  const slots = await getEventTypeAvailability(
+    eventTypeId,
+    from,
+    to,
+    parsed.data.duration,
+    selectedHostIds && selectedHostIds.length > 0 ? selectedHostIds : undefined,
+  );
   if (slots === null) {
     return NextResponse.json({ error: "Event type not found" }, { status: 404 });
   }

--- a/apps/web/app/api/book/route.ts
+++ b/apps/web/app/api/book/route.ts
@@ -20,6 +20,8 @@ const schema = z.object({
     timezone: z.string().min(1),
   }),
   guests: z.array(z.string().email()).max(10).optional(),
+  /** Collective member-selection: chosen team host user ids (server re-validates). */
+  selectedHostIds: z.array(z.string().uuid()).max(50).optional(),
   notes: z.string().max(2000).optional(),
   // Intake answers, keyed by question id. Bounded so an unauthenticated caller
   // can't persist a multi-MB blob into bookings.responses: at most 50 answers,
@@ -73,6 +75,7 @@ export async function POST(request: Request) {
     start: parsed.data.start,
     attendee: parsed.data.attendee,
     guests: parsed.data.guests,
+    selectedHostIds: parsed.data.selectedHostIds,
     notes: parsed.data.notes,
     responses: parsed.data.responses,
     durationMinutes: parsed.data.durationMinutes,

--- a/apps/web/app/team/[teamSlug]/[slug]/page.tsx
+++ b/apps/web/app/team/[teamSlug]/[slug]/page.tsx
@@ -34,6 +34,21 @@ export default async function TeamBookingPage({
   });
   if (!eventType) notFound();
 
+  // Collective events let the booker pick which members to meet. Offer only the
+  // publicly-bookable hosts of this event; a picker needs at least two of them.
+  const eventHostRows =
+    eventType.schedulingType === "collective"
+      ? await db.query.eventTypeHosts.findMany({
+          where: eq(schema.eventTypeHosts.eventTypeId, eventType.id),
+          columns: { userId: true },
+        })
+      : [];
+  const eventHostIds = new Set(eventHostRows.map((h) => h.userId));
+  const teamHosts = team.members
+    .filter((m) => m.publicBookable && m.user && eventHostIds.has(m.userId))
+    .map((m) => ({ id: m.userId, name: m.user?.name ?? m.user?.email ?? "Team member" }));
+  const selectableHosts = teamHosts.length >= 2 ? teamHosts : [];
+
   return (
     <main className="mx-auto max-w-3xl px-4 py-8 sm:px-6 sm:py-12">
       <Card>
@@ -81,6 +96,7 @@ export default async function TeamBookingPage({
               eventTypeId={eventType.id}
               defaultDuration={eventType.durationMinutes}
               durationOptions={eventType.durationOptions ?? []}
+              teamHosts={selectableHosts}
             />
           </CardBody>
         </div>

--- a/apps/web/components/slot-grid.tsx
+++ b/apps/web/components/slot-grid.tsx
@@ -27,11 +27,14 @@ export function SlotGrid({
   eventTypeId,
   onSelect,
   duration,
+  selectedHostIds,
 }: {
   eventTypeId: string;
   onSelect: (slot: Slot) => void;
   /** Chosen duration for multi-duration event types (refetches when it changes). */
   duration?: number;
+  /** Collective member-selection: only these hosts' shared availability (refetches). */
+  selectedHostIds?: string[];
 }) {
   const zone = useLocalZone();
   const locale = useBookingLocale();
@@ -48,13 +51,17 @@ export function SlotGrid({
   const [overlayError, setOverlayError] = useState<string | null>(null);
   const [busy, setBusy] = useState<{ s: number; e: number }[]>([]);
 
+  // Stable string key so the effect only refetches when the selection changes.
+  const hostsKey = selectedHostIds && selectedHostIds.length > 0 ? selectedHostIds.join(",") : "";
+
   useEffect(() => {
     setLoading(true);
     const from = new Date().toISOString();
     const to = new Date(Date.now() + 14 * 86_400_000).toISOString();
     const durationParam = duration ? `&duration=${duration}` : "";
+    const hostsParam = hostsKey ? `&hosts=${hostsKey}` : "";
     let active = true;
-    fetch(`/api/availability/${eventTypeId}?from=${from}&to=${to}${durationParam}`)
+    fetch(`/api/availability/${eventTypeId}?from=${from}&to=${to}${durationParam}${hostsParam}`)
       .then((r) => r.json())
       .then((data) => {
         if (!active) return;
@@ -70,7 +77,7 @@ export function SlotGrid({
     return () => {
       active = false;
     };
-  }, [eventTypeId, duration]);
+  }, [eventTypeId, duration, hostsKey]);
 
   async function applyOverlay() {
     if (!overlayUrl.trim()) return;

--- a/apps/web/components/slot-picker.tsx
+++ b/apps/web/components/slot-picker.tsx
@@ -11,7 +11,7 @@ import { track } from "@/lib/analytics";
 import type { BookingQuestionInput } from "@/lib/booking/event-type-input";
 import { type Locale, t } from "@/lib/i18n/booking";
 import { useBookingLocale } from "@/lib/i18n/use-locale";
-import { ArrowLeft, Lock } from "lucide-react";
+import { ArrowLeft, Check, Lock, Users } from "lucide-react";
 import { DateTime } from "luxon";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -27,6 +27,7 @@ export function SlotPicker({
   assistantEnabled = false,
   locations = [],
   embed = false,
+  teamHosts = [],
 }: {
   eventTypeId: string;
   questions?: BookingQuestionInput[];
@@ -43,6 +44,8 @@ export function SlotPicker({
   assistantEnabled?: boolean;
   /** Rendered inside an embed iframe: relay booking success to the parent page. */
   embed?: boolean;
+  /** Collective team event: hosts the booker may pick from. Empty = no picker. */
+  teamHosts?: { id: string; name: string }[];
 }) {
   const router = useRouter();
   const zone = useLocalZone();
@@ -61,6 +64,22 @@ export function SlotPicker({
   const [captchaToken, setCaptchaToken] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Collective member-selection: everyone selected by default. Never empties
+  // below one (unselecting the last host is a no-op).
+  const [selectedHostIds, setSelectedHostIds] = useState<string[]>(() =>
+    teamHosts.map((h) => h.id),
+  );
+  const wholeTeam =
+    teamHosts.length > 0 &&
+    selectedHostIds.length === teamHosts.length &&
+    teamHosts.every((h) => selectedHostIds.includes(h.id));
+
+  function toggleHost(id: string) {
+    setSelectedHostIds((cur) => {
+      if (!cur.includes(id)) return [...cur, id];
+      return cur.length === 1 ? cur : cur.filter((x) => x !== id);
+    });
+  }
 
   function setAnswer(id: string, value: string | boolean) {
     setAnswers((a) => ({ ...a, [id]: value }));
@@ -99,6 +118,7 @@ export function SlotPicker({
         start: selected.start,
         attendee: { name, email, timezone: zone },
         guests: guests.length ? guests : undefined,
+        selectedHostIds: teamHosts.length ? selectedHostIds : undefined,
         notes: notes || undefined,
         responses: questions.length ? answers : undefined,
         durationMinutes: hasDurations ? duration : undefined,
@@ -168,10 +188,60 @@ export function SlotPicker({
     return (
       <div>
         {durationSelector}
+        {teamHosts.length > 0 ? (
+          <div className="mb-5 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-2)]/60 p-3">
+            <div className="mb-2 flex items-center justify-between gap-3">
+              <div>
+                <p className="flex items-center gap-1.5 text-sm font-semibold">
+                  <Users size={15} /> Who would you like to meet?
+                </p>
+                <p className="mt-0.5 text-xs text-[var(--color-faint)]">
+                  The times below are when everyone selected is free.
+                </p>
+              </div>
+              <button
+                type="button"
+                aria-pressed={wholeTeam}
+                onClick={() =>
+                  setSelectedHostIds(wholeTeam ? [teamHosts[0]!.id] : teamHosts.map((h) => h.id))
+                }
+                className={
+                  wholeTeam
+                    ? "shrink-0 rounded-full bg-[var(--color-accent)] px-3 py-1.5 text-xs font-medium text-white"
+                    : "shrink-0 rounded-full border border-[var(--color-border-strong)] px-3 py-1.5 text-xs font-medium text-[var(--color-muted)] hover:text-[var(--color-text)]"
+                }
+              >
+                {wholeTeam ? "Just one" : `Whole team (${teamHosts.length})`}
+              </button>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {teamHosts.map((host) => {
+                const active = selectedHostIds.includes(host.id);
+                return (
+                  <button
+                    key={host.id}
+                    type="button"
+                    aria-pressed={active}
+                    onClick={() => toggleHost(host.id)}
+                    className={
+                      active
+                        ? "inline-flex items-center gap-1.5 rounded-full border border-[var(--color-accent)] bg-[var(--color-accent-soft)] px-3 py-1.5 text-xs font-medium text-[var(--color-accent)]"
+                        : "inline-flex items-center gap-1.5 rounded-full border border-[var(--color-border-strong)] px-3 py-1.5 text-xs text-[var(--color-muted)] hover:text-[var(--color-text)]"
+                    }
+                  >
+                    {active ? <Check size={13} /> : null}
+                    {host.name}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        ) : null}
         <SlotGrid
           eventTypeId={eventTypeId}
           onSelect={setSelected}
           duration={hasDurations ? duration : undefined}
+          selectedHostIds={teamHosts.length ? selectedHostIds : undefined}
         />
         {assistantEnabled ? (
           <BookingAssistant

--- a/apps/web/lib/booking/availability.ts
+++ b/apps/web/lib/booking/availability.ts
@@ -505,7 +505,10 @@ export async function troubleshootHostDay(
   return explainDay(input);
 }
 
-export async function eventTypeHostIds(eventType: EventTypeRow): Promise<string[]> {
+export async function eventTypeHostIds(
+  eventType: EventTypeRow,
+  selectedHostIds?: string[],
+): Promise<string[]> {
   if (eventType.ownerId) return [eventType.ownerId];
   const db = getDb();
   const hosts = await db.query.eventTypeHosts.findMany({
@@ -525,7 +528,14 @@ export async function eventTypeHostIds(eventType: EventTypeRow): Promise<string[
     columns: { userId: true },
   });
   const excluded = new Set(off.map((m) => m.userId));
-  const filtered = ids.filter((id) => !excluded.has(id));
+  let filtered = ids.filter((id) => !excluded.has(id));
+  // Collective member-selection: the booker chose a subset of the team to meet.
+  // Intersect with the offered hosts; ignore an empty/invalid selection.
+  if (selectedHostIds && selectedHostIds.length > 0) {
+    const chosen = new Set(selectedHostIds);
+    const narrowed = filtered.filter((id) => chosen.has(id));
+    if (narrowed.length > 0) filtered = narrowed;
+  }
   return filtered.length > 0 ? filtered : ids;
 }
 
@@ -539,6 +549,7 @@ export async function eventTypeHostSlots(
   rangeStart: Date,
   rangeEnd: Date,
   durationOverride?: number,
+  selectedHostIds?: string[],
 ): Promise<{ hostIds: string[]; perHost: Slot[][] }> {
   const base = eventConstraints(eventType);
   // Multiple durations: recompute slots for the booker's chosen (allowed) length.
@@ -568,7 +579,7 @@ export async function eventTypeHostSlots(
     return { hostIds: [eventType.ownerId], perHost: [slots] };
   }
 
-  const hostIds = await eventTypeHostIds(eventType);
+  const hostIds = await eventTypeHostIds(eventType, selectedHostIds);
   const perHost = await Promise.all(
     hostIds.map((id) => hostSlots(id, null, event, rangeStart, rangeEnd, gap)),
   );
@@ -592,6 +603,7 @@ export async function getEventTypeAvailability(
   rangeStart: Date,
   rangeEnd: Date,
   durationOverride?: number,
+  selectedHostIds?: string[],
 ): Promise<Slot[] | null> {
   const eventType = await getDb().query.eventTypes.findFirst({
     where: eq(schema.eventTypes.id, eventTypeId),
@@ -603,7 +615,15 @@ export async function getEventTypeAvailability(
     durationOverride && isAllowedDuration(eventType, durationOverride)
       ? durationOverride
       : undefined;
-  const { perHost } = await eventTypeHostSlots(eventType, rangeStart, rangeEnd, duration);
+  // Member selection only narrows a collective team event; ignore it otherwise.
+  const selection = eventType.schedulingType === "collective" ? selectedHostIds : undefined;
+  const { perHost } = await eventTypeHostSlots(
+    eventType,
+    rangeStart,
+    rangeEnd,
+    duration,
+    selection,
+  );
   return combineHostSlots(perHost, eventType.schedulingType);
 }
 

--- a/apps/web/lib/booking/create-booking.ts
+++ b/apps/web/lib/booking/create-booking.ts
@@ -64,11 +64,15 @@ async function resolveHost(
   }
 
   if (eventType.schedulingType === "collective") {
-    const primary = bookable[0];
+    // Use the resolved host set (which already applied publicBookable + the
+    // booker's member selection) as the source of truth, in its order.
+    const byId = new Map(bookable.map((h) => [h.userId, h]));
+    const ordered = hostIds.map((id) => byId.get(id)).filter((h) => Boolean(h?.user));
+    const primary = ordered[0];
     if (!primary?.user) throw new BookingError("Host not found", 404);
-    const coHostEmails = bookable
+    const coHostEmails = ordered
       .slice(1)
-      .map((h) => h.user?.email)
+      .map((h) => h?.user?.email)
       .filter((e): e is string => Boolean(e));
     return { host: primary.user, coHostEmails };
   }
@@ -120,6 +124,9 @@ export interface CreateBookingInput {
   start: string; // ISO instant of the chosen slot
   attendee: { name: string; email: string; timezone: string };
   guests?: string[];
+  /** Collective member-selection: the subset of team hosts the booker chose to
+   * meet. Only valid for collective team events; ignored elsewhere. */
+  selectedHostIds?: string[];
   notes?: string;
   responses?: Record<string, unknown>;
   /** The booker's chosen duration for multi-duration event types (minutes). */
@@ -198,6 +205,16 @@ export async function createBooking(
     ? (resolveChosenLocation(eventType, null) ?? chosenLocation)
     : chosenLocation;
 
+  // Collective member-selection: honour the booker's chosen subset of hosts, but
+  // only for collective team events (it makes no sense for round-robin/individual).
+  const selectedHostIds =
+    eventType.schedulingType === "collective" && input.selectedHostIds?.length
+      ? input.selectedHostIds
+      : undefined;
+  if (input.selectedHostIds?.length && eventType.schedulingType !== "collective") {
+    throw new BookingError("Choosing team members isn't available for this event type", 400);
+  }
+
   // Re-validate server-side (the picker may be stale / manipulated). Compute the
   // per-host slots once (for the chosen duration) and reuse them for the check
   // and host resolution.
@@ -206,6 +223,7 @@ export async function createBooking(
     new Date(start.getTime() - SLOT_REVALIDATION_WINDOW_MS),
     new Date(start.getTime() + SLOT_REVALIDATION_WINDOW_MS),
     duration,
+    selectedHostIds,
   );
   const combined = combineHostSlots(perHost, eventType.schedulingType);
   if (!combined.some((s) => s.start.getTime() === start.getTime())) {


### PR DESCRIPTION
Adapted from **Naude Opperman's fork**. On a collective team booking page, the booker can now choose **which members to meet**, and the calendar shows only the shared availability of the people selected.

## Changes
- Booking page: a **"Who would you like to meet?"** chip picker (the event's publicly-bookable hosts; shown only when there are 2+). Everyone selected by default, with a whole-team / just-one toggle.
- `SlotGrid` passes the selection to the availability API (`?hosts=…`); `eventTypeHostIds` → `eventTypeHostSlots` → `getEventTypeAvailability` narrow the collective host set to the selection (still honoring `publicBookable`; never zero hosts).
- `create-booking` validates it (collective only), re-checks the intersection server-side, resolves the primary + co-hosts from the selection, and records exactly the selected hosts in `booking_hosts` (the #248 table).

## Verified end-to-end (local Postgres + Chrome) ✅
- All three members selected → no times (a member with no schedule empties the intersection — correct).
- Just Ada selected → her availability appears; booked a slot.
- DB check: `booking_hosts` recorded **exactly the selected host**.
- biome + `@dayotter/web` typecheck clean; web tests green (183).

Screenshots of the picker + confirmed booking available on request.