### PR TITLE
fix(i18n): a missing key blanks the booking page instead of degrading

### DIFF
--- a/apps/web/lib/i18n/booking.test.ts
+++ b/apps/web/lib/i18n/booking.test.ts
@@ -36,4 +36,13 @@ describe("t", () => {
     // @ts-expect-error - exercising the runtime fallback path
     expect(t("zz", "selectTime")).toBe("Select a time");
   });
+
+  it("falls back to the key rather than throwing when no catalogue has it", () => {
+    // A key present in no catalogue used to reach interpolate() as undefined,
+    // where `.replace` threw and the error boundary blanked the booking page.
+    // @ts-expect-error - exercising the runtime fallback path
+    expect(() => t("en", "notARealKey")).not.toThrow();
+    // @ts-expect-error - exercising the runtime fallback path
+    expect(t("en", "notARealKey", { n: 3 })).toBe("notARealKey");
+  });
 });

--- a/apps/web/lib/i18n/booking.ts
+++ b/apps/web/lib/i18n/booking.ts
@@ -37,6 +37,10 @@ const MESSAGES: Record<Locale, Record<BookingKey, string>> = {
 
 /** Translate a booking-surface key, interpolating `{name}` placeholders. */
 export function t(locale: Locale, key: BookingKey, vars?: Record<string, string | number>): string {
-  const s = (MESSAGES[locale] ?? MESSAGES.en)[key] ?? MESSAGES.en[key];
+  // Falling back to the key itself matters more than it looks: without it a key
+  // that is missing from every catalogue reaches interpolate() as undefined,
+  // `.replace` throws, and the error boundary takes down the whole booking page.
+  // A visible key is a bad string; a blank page is a lost booking.
+  const s = (MESSAGES[locale] ?? MESSAGES.en)[key] ?? MESSAGES.en[key] ?? key;
   return interpolate(s, vars);
 }


### PR DESCRIPTION
## What & why

`t()` looks a key up in the requested catalogue, falls back to English, and passes the result straight to `interpolate()`:

```ts
const s = (MESSAGES[locale] ?? MESSAGES.en)[key] ?? MESSAGES.en[key];
return interpolate(s, vars);
```

With a key present in neither, `s` is `undefined` and `interpolate` calls `.replace` on it. It throws, the error boundary catches it, and the booker gets a blank page instead of a booking form — one missing string takes down the whole public surface.

It now falls back to the key itself. A visible key is a bad string; a blank page is a lost booking.

## How I verified it

- [x] `pnpm turbo typecheck` passes (16/16 tasks)
- [x] `pnpm biome check` passes (formatted + linted)
- [x] Verified the change by driving the actual flow / endpoint
- [ ] Added/updated a DB migration — n/a, no schema change
- [ ] Updated docs / module README — n/a

I hit this for real rather than reasoning about it. A long-running dev server was holding a stale copy of a locale JSON from before a key was added, and the booking page went white with `TypeError: Cannot read properties of undefined (reading 'replace')` originating in `<SlotGrid>`. A production build has every key, so it never surfaces there — but the fragility is not environment-specific, and any catalogue drift reproduces it.

Regression test added next to the existing locale-fallback one; 184 tests pass.

## Notes for the reviewer

The fallback returns the raw key (`"selectTime"`) rather than an empty string on purpose — a visible key tells whoever sees it exactly which string is missing, where a blank would just look like a layout bug.


---

By submitting this PR I confirm I wrote this code (or have the right to contribute it) and agree to license it under **AGPLv3**.