### PR TITLE
fix(a11y): keyboard focus ring, reduced motion, and an unscoped global transition

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -118,9 +118,43 @@
   ::selection {
     background: color-mix(in srgb, var(--color-accent) 22%, transparent);
   }
-  body,
-  body * {
+  /* Theme changes cross-fade the whole page. This is scoped to the ~220ms the
+     toggle keeps `.theme-transition` on <html> - as a permanent rule on every
+     element it also delayed hover, focus and selection feedback by 120-180ms,
+     which made ordinary interaction feel soft. */
+  html.theme-transition,
+  html.theme-transition * {
     transition: background-color 0.18s ease, border-color 0.18s ease, color 0.12s ease;
+  }
+
+  /* Keyboard focus. Without this the browser default ring is the only thing
+     marking focus outside the handful of components that style it themselves,
+     and it is close to invisible on the warm surfaces. */
+  :focus-visible {
+    /* Longhands, not the `outline` shorthand: through the shorthand the accent
+       is dropped and the ring falls back to currentColor, which on muted text is
+       the low-contrast ring this rule exists to replace. */
+    outline-style: solid;
+    outline-width: 2px;
+    outline-color: var(--color-accent);
+    outline-offset: 2px;
+    border-radius: var(--radius-sm);
+  }
+  /* Pointer interaction never draws the ring, only keyboard/AT focus does. */
+  :focus:not(:focus-visible) {
+    outline: none;
+  }
+
+  /* Browser chrome that ships with no design: the caret and link underlines. */
+  input,
+  textarea,
+  select,
+  [contenteditable] {
+    caret-color: var(--color-accent);
+  }
+  a {
+    text-underline-offset: 0.18em;
+    text-decoration-thickness: from-font;
   }
 }
 

--- a/apps/web/components/marketing/motion.tsx
+++ b/apps/web/components/marketing/motion.tsx
@@ -1,9 +1,16 @@
 "use client";
 
-import { type Variants, motion } from "framer-motion";
+import { type Variants, motion, useReducedMotion } from "framer-motion";
 import type { ReactNode } from "react";
 
 const ease = [0.22, 1, 0.36, 1] as const;
+
+/*
+ * Every helper here bails out to a plain, already-visible <div> under
+ * `prefers-reduced-motion: reduce`. Reveal/Stagger start at opacity 0, and Float
+ * loops forever - without this the whole marketing site animates at a reader who
+ * asked it not to, and the looping one never settles.
+ */
 
 /** Fade + rise into view on scroll. */
 export function Reveal({
@@ -17,6 +24,8 @@ export function Reveal({
   y?: number;
   className?: string;
 }) {
+  const reduce = useReducedMotion();
+  if (reduce) return <div className={className}>{children}</div>;
   return (
     <motion.div
       className={className}
@@ -41,6 +50,8 @@ const item: Variants = {
 
 /** Staggered entrance for a group of children (use with <Stagger.Item>). */
 export function Stagger({ children, className }: { children: ReactNode; className?: string }) {
+  const reduce = useReducedMotion();
+  if (reduce) return <div className={className}>{children}</div>;
   return (
     <motion.div
       className={className}
@@ -61,6 +72,8 @@ Stagger.Item = function StaggerItem({
   children: ReactNode;
   className?: string;
 }) {
+  const reduce = useReducedMotion();
+  if (reduce) return <div className={className}>{children}</div>;
   return (
     <motion.div className={className} variants={item}>
       {children}
@@ -78,6 +91,8 @@ export function FadeUp({
   delay?: number;
   className?: string;
 }) {
+  const reduce = useReducedMotion();
+  if (reduce) return <div className={className}>{children}</div>;
   return (
     <motion.div
       className={className}
@@ -92,6 +107,8 @@ export function FadeUp({
 
 /** Gentle continuous float for hero visuals. */
 export function Float({ children, className }: { children: ReactNode; className?: string }) {
+  const reduce = useReducedMotion();
+  if (reduce) return <div className={className}>{children}</div>;
   return (
     <motion.div
       className={className}

--- a/apps/web/components/theme-toggle.tsx
+++ b/apps/web/components/theme-toggle.tsx
@@ -6,11 +6,21 @@ import { useEffect, useState } from "react";
 
 type Theme = "light" | "dark" | "system";
 
+/** Duration of the cross-fade in globals.css `html.theme-transition`. */
+const THEME_FADE_MS = 220;
+let fadeTimer: ReturnType<typeof setTimeout> | undefined;
+
 function apply(theme: Theme) {
   const dark =
     theme === "dark" ||
     (theme === "system" && window.matchMedia("(prefers-color-scheme: dark)").matches);
-  document.documentElement.classList.toggle("dark", dark);
+  const root = document.documentElement;
+  // Colour transitions are opt-in for exactly this moment, so switching themes
+  // cross-fades without every hover on the site inheriting a 180ms lag.
+  root.classList.add("theme-transition");
+  clearTimeout(fadeTimer);
+  fadeTimer = setTimeout(() => root.classList.remove("theme-transition"), THEME_FADE_MS);
+  root.classList.toggle("dark", dark);
 }
 
 const OPTIONS: { value: Theme; icon: typeof Sun; label: string }[] = [


### PR DESCRIPTION
## What & why

Closes #252

Three related gaps in how the app responds to the person using it.

**No focus ring.** `globals.css` defined none, so outside the ~19 components that style their own, keyboard focus fell back to the browser default — close to invisible on the warm ivory surfaces. Added one built from `--color-accent`.

**Marketing motion ignored `prefers-reduced-motion`.** `Reveal`, `Stagger`, `FadeUp` and `Float` now render static for a reader who asked for less motion. `Float` matters most: it is an infinite loop, so it never settled.

**A transition on `body *`.** It existed for the theme cross-fade, but as a permanent rule on every element it also delayed every hover, focus and selection by 120–180ms. Scoped to the ~220ms the toggle keeps `.theme-transition` on `<html>`; deliberate per-component transitions are untouched.

Also themed the caret colour and link underline offset — browser chrome that shipped with no design.

## How I verified it

- [x] `pnpm turbo typecheck` passes (16/16 tasks)
- [x] `pnpm biome check` passes (formatted + linted)
- [x] Verified the change by driving the actual flow / endpoint
- [ ] Added/updated a DB migration — n/a, no schema change
- [ ] Updated docs / module README — n/a

Drove it with a real keyboard rather than `element.focus()`, which does not reliably match `:focus-visible`.

- **Focus ring:** tabbing to a control in dark mode gives `outline-color` `#9079f8` while `currentColor` on the same element is `#edeae3` — the ring is the accent, not inherited text colour. Also checked that components already setting `focus-visible:outline-none` still suppress it, so nothing double-rings.
- **Theme transition:** `body` `transition-duration` is now `0s` at rest (was `0.18s`), while a nav link keeps its own deliberate `0.15s`, and the cross-fade still runs on toggle — I caught it mid-fade in a screenshot.
- **Reduced motion:** confirmed the helpers take the animated path when the media query is false. I could not emulate `prefers-reduced-motion: reduce` in my browser harness, so the static branch is code-verified only.

## Notes for the reviewer

One trap worth knowing about before anyone tidies this: written as the `outline` shorthand, `outline: 2px solid var(--color-accent)`, the accent is dropped and `outline-color` falls back to `currentColor` — which reproduces exactly the low-contrast ring this rule exists to replace. I reproduced that in two environments before switching to the `outline-style` / `outline-width` / `outline-color` longhands, and left a comment in the CSS saying so.

Happy to split this into three PRs if you would rather review them separately.


---

By submitting this PR I confirm I wrote this code (or have the right to contribute it) and agree to license it under **AGPLv3**.