### PR TITLE
fix(build): empty NEXT_PUBLIC_APP_URL crashes the Docker build

### DIFF
--- a/apps/web/lib/marketing.ts
+++ b/apps/web/lib/marketing.ts
@@ -3,8 +3,11 @@
 export const BRAND = {
   name: "DayOtter",
   tagline: "The calm home for your time.",
-  /** Canonical site origin - drives metadataBase, sitemap, canonical URLs, JSON-LD. */
-  url: process.env.NEXT_PUBLIC_APP_URL ?? "https://dayotter.com",
+  /** Canonical site origin - drives metadataBase, sitemap, canonical URLs, JSON-LD.
+   * Use `||`, not `??`: the Docker build sets NEXT_PUBLIC_APP_URL to an EMPTY
+   * string when it isn't provided, and `"" ?? default` keeps the empty string,
+   * which makes `new URL(BRAND.url)` in the root layout throw at build time. */
+  url: process.env.NEXT_PUBLIC_APP_URL?.trim() || "https://dayotter.com",
   email: "hello@dayotter.com",
   github: "https://github.com/Dayotter/dayotter",
   githubLicense: "https://github.com/Dayotter/dayotter/blob/main/LICENSE",


### PR DESCRIPTION
Hotfix — the current `main` fails `next build` in Docker with:

```
[Error: Failed to collect configuration for /_not-found]
  cause: TypeError: Invalid URL ... code: 'ERR_INVALID_URL', input: ''
```

## Cause
#255 added `ENV NEXT_PUBLIC_APP_URL=$NEXT_PUBLIC_APP_URL` to the Dockerfile (good — it makes the value available at build for SEO). But when a deploy doesn't pass it, the build now sees an **empty string** instead of `undefined`. `BRAND.url` (`lib/marketing.ts`) used `process.env.NEXT_PUBLIC_APP_URL ?? "https://dayotter.com"`, and `"" ?? x` yields `""` — so `new URL(BRAND.url)` (the `metadataBase` in the root layout) throws while collecting `/_not-found`.

## Fix
One line: `process.env.NEXT_PUBLIC_APP_URL?.trim() || "https://dayotter.com"` — an empty/blank value falls back to the default. (Also more correct in general: a blank env var should behave like an unset one.)

## Verify
Reproduced and fixed locally: `NEXT_PUBLIC_APP_URL="" pnpm --filter @dayotter/web build` failed at `/_not-found` before, and **exits 0** after. Setting a real `NEXT_PUBLIC_APP_URL` still works (it's used verbatim).