### PR TITLE
feat(onboarding): shareable booking link out of the box

### DIFF
--- a/apps/web/app/(app)/dashboard/page.tsx
+++ b/apps/web/app/(app)/dashboard/page.tsx
@@ -13,6 +13,7 @@ import { Card } from "@/components/ui/card";
 import { aiEnabled } from "@/lib/ai/llm";
 import { getSession } from "@/lib/auth/session";
 import { eventColorVar } from "@/lib/booking/event-type-input";
+import { ensureUserWorkspace } from "@/lib/bootstrap";
 import { and, asc, eq, getDb, gt, gte, lte, schema } from "@dayotter/db";
 import {
   BarChart3,
@@ -33,6 +34,10 @@ export default async function DashboardPage() {
   const session = await getSession();
   const userId = session!.user.id;
   const tz = (session!.user as { timezone?: string }).timezone ?? "UTC";
+
+  // First login lands here: make sure the user has a workspace, a handle, a
+  // schedule and a starter event type, so their booking link works immediately.
+  await ensureUserWorkspace(userId);
 
   const db = getDb();
   const now = new Date();

--- a/apps/web/lib/bootstrap.ts
+++ b/apps/web/lib/bootstrap.ts
@@ -80,6 +80,26 @@ export async function ensureUserWorkspace(userId: string): Promise<{
         endTime: "17:00:00",
       })),
     );
+
+    // 4. A starter event type, created once with the workspace, so a brand-new
+    // user has a working, shareable booking link straight away - before (or
+    // without) connecting a calendar. Tied to first bootstrap, so deleting all
+    // event types later never resurrects one. Guarded in case one already exists.
+    const hasEventType = await db.query.eventTypes.findFirst({
+      where: eq(schema.eventTypes.ownerId, userId),
+      columns: { id: true },
+    });
+    if (!hasEventType) {
+      await db.insert(schema.eventTypes).values({
+        organizationId: membership!.organizationId,
+        ownerId: userId,
+        scheduleId: schedule!.id,
+        slug: "30min",
+        title: "30 Minute Meeting",
+        description: "A quick 30-minute call.",
+        durationMinutes: 30,
+      });
+    }
   }
 
   return { organizationId: membership!.organizationId, scheduleId: schedule!.id, handle };


### PR DESCRIPTION
The activation data showed users who connect a calendar but never get booked. A big reason: a fresh account has a handle + availability but **no event type**, so `/{handle}` has nothing to book and there's no working link to share. Calendar-connect becomes the wall.

## Changes
- `ensureUserWorkspace` now creates a starter **"30 Minute Meeting"** event type on first bootstrap (inside the schedule-creation branch, so it's created exactly once and deleting all event types later never resurrects one; guarded against duplicates).
- The **dashboard** (where first login lands) now calls `ensureUserWorkspace`, so a new user's workspace + handle + schedule + starter type all exist on first view instead of lazily on a later page.

Result: a new user can copy and share a working booking link in seconds, and connecting a calendar becomes optional polish rather than a blocker. Existing users are unaffected (tied to first bootstrap).

## Verify
- `@dayotter/web` typecheck clean; biome clean.
- (Live click-through pending — Docker/DB is down in this env; logic verified by reading the bootstrap + dashboard paths.)