### PR TITLE
feat(email): weekly digest + first-booking celebration

### DIFF
--- a/apps/worker/src/workers/lifecycle-emails.ts
+++ b/apps/worker/src/workers/lifecycle-emails.ts
@@ -1,6 +1,13 @@
 import { hmacSha256hex, logger } from "@dayotter/core";
-import { and, eq, getDb, inArray, lt, ne, schema, sql } from "@dayotter/db";
-import { activationConnectCalendar, activationShareLink, sendEmail } from "@dayotter/emails";
+import { and, eq, getDb, gte, inArray, lt, lte, ne, schema, sql } from "@dayotter/db";
+import {
+  activationConnectCalendar,
+  activationShareLink,
+  firstBookingCelebration,
+  sendEmail,
+  weeklyDigest,
+} from "@dayotter/emails";
+import { DateTime } from "luxon";
 
 /**
  * Off by default. Set LIFECYCLE_EMAILS=1 to turn the activation nudges on - a
@@ -125,6 +132,194 @@ export async function sendActivationNudges(now = new Date()): Promise<number> {
         event: "lifecycle_email_failed",
         userId: u.id,
         kind,
+        err,
+      });
+    }
+  }
+  return sent;
+}
+
+/** APP_URL without a trailing slash. */
+function base(): string {
+  return APP_URL.replace(/\/$/, "");
+}
+
+/**
+ * Celebrate a host's FIRST booking, once. Scoped to hosts whose first booking was
+ * created recently, so turning the feature on doesn't retro-celebrate months-old
+ * bookings. Fires on the maintenance tick (a few minutes' latency is fine).
+ */
+export async function sendFirstBookingCelebrations(now = new Date()): Promise<number> {
+  if (!ENABLED) return 0;
+  const db = getDb();
+  const cutoff = new Date(now.getTime() - 14 * 86_400_000);
+
+  const firstByHost = await db
+    .select({
+      hostId: schema.bookings.hostId,
+      first: sql<string>`min(${schema.bookings.createdAt})`,
+    })
+    .from(schema.bookings)
+    .where(ne(schema.bookings.status, "cancelled"))
+    .groupBy(schema.bookings.hostId);
+  const ids = firstByHost.filter((r) => new Date(r.first) >= cutoff).map((r) => r.hostId);
+  if (ids.length === 0) return 0;
+
+  const [optedIn, sentRows] = await Promise.all([
+    db
+      .select({
+        id: schema.users.id,
+        name: schema.users.name,
+        email: schema.users.email,
+        handle: schema.users.handle,
+      })
+      .from(schema.users)
+      .innerJoin(schema.userPreferences, eq(schema.userPreferences.userId, schema.users.id))
+      .where(and(inArray(schema.users.id, ids), eq(schema.userPreferences.productEmails, true))),
+    db
+      .select({ userId: schema.lifecycleEmails.userId })
+      .from(schema.lifecycleEmails)
+      .where(
+        and(
+          inArray(schema.lifecycleEmails.userId, ids),
+          eq(schema.lifecycleEmails.kind, "first_booking"),
+        ),
+      ),
+  ]);
+  const already = new Set(sentRows.map((r) => r.userId));
+
+  let sent = 0;
+  for (const u of optedIn) {
+    if (already.has(u.id)) continue;
+    const claimed = await db
+      .insert(schema.lifecycleEmails)
+      .values({ userId: u.id, kind: "first_booking" })
+      .onConflictDoNothing()
+      .returning({ id: schema.lifecycleEmails.id });
+    if (claimed.length === 0) continue;
+    try {
+      await sendEmail({
+        to: u.email,
+        ...firstBookingCelebration({
+          name: u.name ?? "",
+          bookingUrl: `${base()}/${u.handle ?? ""}`,
+          manageUrl: `${base()}/dashboard`,
+          unsubscribeUrl: unsubscribeUrl(u.id),
+        }),
+      });
+      sent += 1;
+      logger.info("lifecycle email sent", {
+        event: "lifecycle_email_sent",
+        userId: u.id,
+        kind: "first_booking",
+      });
+    } catch (err) {
+      logger.error("lifecycle email failed", {
+        event: "lifecycle_email_failed",
+        userId: u.id,
+        kind: "first_booking",
+        err,
+      });
+    }
+  }
+  return sent;
+}
+
+/**
+ * Weekly "here's your week" digest. Sent Monday morning in each user's own
+ * timezone, once per ISO week (the ledger kind carries the week, so it can't
+ * double-send). Summarizes the week just gone (meetings hosted + hours + focus
+ * time protected) and what's on the books for the week ahead.
+ */
+export async function sendWeeklyDigests(now = new Date()): Promise<number> {
+  if (!ENABLED) return 0;
+  const db = getDb();
+
+  const users = await db
+    .select({
+      id: schema.users.id,
+      name: schema.users.name,
+      email: schema.users.email,
+      timezone: schema.users.timezone,
+    })
+    .from(schema.users)
+    .innerJoin(schema.userPreferences, eq(schema.userPreferences.userId, schema.users.id))
+    .where(eq(schema.userPreferences.productEmails, true));
+  if (users.length === 0) return 0;
+
+  let sent = 0;
+  for (const u of users) {
+    const tz = u.timezone || "UTC";
+    const local = DateTime.fromJSDate(now).setZone(tz);
+    // Monday, from 08:00 local. (Luxon weekday: 1 = Monday.)
+    if (local.weekday !== 1 || local.hour < 8) continue;
+
+    const kind = `weekly_digest:${local.toFormat("kkkk-'W'WW")}`;
+    const claimed = await db
+      .insert(schema.lifecycleEmails)
+      .values({ userId: u.id, kind })
+      .onConflictDoNothing()
+      .returning({ id: schema.lifecycleEmails.id });
+    if (claimed.length === 0) continue;
+
+    const weekStart = local.startOf("week"); // Monday 00:00 local
+    const lastWeekStart = weekStart.minus({ weeks: 1 });
+    const [pastMeetings, focusBlocks, upcomingRows] = await Promise.all([
+      db.query.bookings.findMany({
+        where: and(
+          eq(schema.bookings.hostId, u.id),
+          ne(schema.bookings.status, "cancelled"),
+          gte(schema.bookings.startsAt, lastWeekStart.toJSDate()),
+          lt(schema.bookings.startsAt, weekStart.toJSDate()),
+        ),
+        columns: { startsAt: true, endsAt: true },
+      }),
+      db.query.timeBlocks.findMany({
+        where: and(
+          eq(schema.timeBlocks.userId, u.id),
+          gte(schema.timeBlocks.startsAt, lastWeekStart.toJSDate()),
+          lt(schema.timeBlocks.startsAt, weekStart.toJSDate()),
+        ),
+        columns: { startsAt: true, endsAt: true },
+      }),
+      db.query.bookings.findMany({
+        where: and(
+          eq(schema.bookings.hostId, u.id),
+          ne(schema.bookings.status, "cancelled"),
+          gte(schema.bookings.startsAt, weekStart.toJSDate()),
+          lte(schema.bookings.startsAt, weekStart.plus({ days: 7 }).toJSDate()),
+        ),
+        columns: { id: true },
+      }),
+    ]);
+    const mins = (rows: { startsAt: Date; endsAt: Date }[]) =>
+      rows.reduce((m, r) => m + (r.endsAt.getTime() - r.startsAt.getTime()) / 60_000, 0);
+    const round = (n: number) => Math.round((n / 60) * 10) / 10;
+
+    try {
+      await sendEmail({
+        to: u.email,
+        ...weeklyDigest({
+          name: u.name ?? "",
+          meetings: pastMeetings.length,
+          hours: round(mins(pastMeetings)),
+          focusHours: round(mins(focusBlocks)),
+          upcoming: upcomingRows.length,
+          manageUrl: `${base()}/dashboard`,
+          unsubscribeUrl: unsubscribeUrl(u.id),
+        }),
+      });
+      sent += 1;
+      logger.info("lifecycle email sent", {
+        event: "lifecycle_email_sent",
+        userId: u.id,
+        kind: "weekly_digest",
+      });
+    } catch (err) {
+      logger.error("lifecycle email failed", {
+        event: "lifecycle_email_failed",
+        userId: u.id,
+        kind: "weekly_digest",
         err,
       });
     }

--- a/apps/worker/src/workers/maintenance.ts
+++ b/apps/worker/src/workers/maintenance.ts
@@ -3,7 +3,11 @@ import { and, eq, getDb, lt, schema } from "@dayotter/db";
 import { QUEUE_NAMES, connection, enqueueSync } from "@dayotter/jobs";
 import { Worker } from "bullmq";
 import { materializeWeeklyBlocks } from "./automation-weekly";
-import { sendActivationNudges } from "./lifecycle-emails";
+import {
+  sendActivationNudges,
+  sendFirstBookingCelebrations,
+  sendWeeklyDigests,
+} from "./lifecycle-emails";
 import { sendDueBriefings } from "./morning-briefing";
 import { sendDueTeamBriefings } from "./team-briefing";
 
@@ -58,10 +62,21 @@ export function startMaintenanceWorker(): Worker {
       await sendDueTeamBriefings().catch((err) => {
         logger.error("team briefing tick failed", { event: "team_briefing_tick_failed", err });
       });
-      // Activation nudges (off unless LIFECYCLE_EMAILS=1). Idempotent per user+kind.
-      await sendActivationNudges().catch((err) => {
-        logger.error("lifecycle email tick failed", { event: "lifecycle_tick_failed", err });
-      });
+      // Lifecycle emails (off unless LIFECYCLE_EMAILS=1). All idempotent per
+      // user+kind: activation nudges, first-booking celebration, weekly digest.
+      for (const [label, run] of [
+        ["activation", sendActivationNudges],
+        ["first_booking", sendFirstBookingCelebrations],
+        ["weekly_digest", sendWeeklyDigests],
+      ] as const) {
+        await run().catch((err) => {
+          logger.error("lifecycle email tick failed", {
+            event: "lifecycle_tick_failed",
+            kind: label,
+            err,
+          });
+        });
+      }
     },
     { connection, concurrency: 1 },
   );

--- a/packages/emails/src/index.ts
+++ b/packages/emails/src/index.ts
@@ -18,6 +18,8 @@ export {
   guardrailAlert,
   activationShareLink,
   activationConnectCalendar,
+  weeklyDigest,
+  firstBookingCelebration,
   applyTemplateVars,
   WORKFLOW_VARIABLES,
   type BookingEmailData,
@@ -26,4 +28,5 @@ export {
   type MeetingRecapData,
   type GuardrailAlertData,
   type ActivationEmailData,
+  type WeeklyDigestData,
 } from "./templates";

--- a/packages/emails/src/templates.ts
+++ b/packages/emails/src/templates.ts
@@ -550,3 +550,76 @@ export function activationConnectCalendar(d: ActivationEmailData): Rendered {
     ),
   };
 }
+
+export interface WeeklyDigestData {
+  name: string;
+  /** Meetings hosted in the week just gone. */
+  meetings: number;
+  /** Hours in those meetings (rounded to 0.1). */
+  hours: number;
+  /** Hours of focus/held time protected in the week (rounded to 0.1). */
+  focusHours: number;
+  /** Meetings already on the books for the week ahead. */
+  upcoming: number;
+  manageUrl: string;
+  unsubscribeUrl: string;
+}
+
+/**
+ * Weekly retention digest: a calm "here's your week" recap sent Monday morning.
+ * Reinforces the value (time booked + focus protected) and pulls the host back in.
+ */
+export function weeklyDigest(d: WeeklyDigestData): Rendered {
+  const hi = d.name ? `Hi ${esc(d.name)},` : "Hi,";
+  const quiet = d.meetings === 0 && d.focusHours === 0;
+  const lines = quiet
+    ? [
+        `${hi} last week was quiet on DayOtter, no meetings booked.`,
+        "If your link isn't out there yet, this is a good week to share it. One link, and people can grab a time that works for both of you.",
+      ]
+    : [
+        `${hi} here's your week just gone:`,
+        `<strong>${d.meetings}</strong> meeting${d.meetings === 1 ? "" : "s"} hosted, about <strong>${d.hours}</strong> hour${d.hours === 1 ? "" : "s"} of your time.`,
+        d.focusHours > 0
+          ? `<strong>${d.focusHours}</strong> hour${d.focusHours === 1 ? "" : "s"} of focus time protected.`
+          : "",
+        d.upcoming > 0
+          ? `${d.upcoming} already on the books for the week ahead.`
+          : "Nothing booked yet for the week ahead.",
+      ].filter(Boolean);
+  return {
+    subject: quiet
+      ? "Your week on DayOtter"
+      : `Your week on DayOtter: ${d.meetings} meeting${d.meetings === 1 ? "" : "s"}`,
+    text: `${d.name ? `Hi ${d.name},` : "Hi,"}\n\nLast week: ${d.meetings} meetings (${d.hours}h), ${d.focusHours}h focus protected. ${d.upcoming} coming up.\n\nOpen DayOtter: ${d.manageUrl}\n\nUnsubscribe from tips: ${d.unsubscribeUrl}`,
+    html: shell(
+      "Your week on DayOtter",
+      lines,
+      { label: "Open DayOtter", url: d.manageUrl },
+      d.unsubscribeUrl,
+    ),
+  };
+}
+
+/**
+ * Celebrates a host's first booking - the activation "aha". Warm, and nudges the
+ * repeat behaviour (share more, connect a calendar if they haven't).
+ */
+export function firstBookingCelebration(d: ActivationEmailData): Rendered {
+  const hi = d.name ? `${esc(d.name)}, ` : "";
+  const lines = [
+    `${hi}you just got your first booking on DayOtter. That's the whole thing working: someone picked a time, and it's on your calendar.`,
+    "Keep the link handy and it'll keep happening. The people who share it in their signature or bio get booked the most.",
+    `Your link: <a href="${esc(safeUrl(d.bookingUrl))}">${esc(d.bookingUrl)}</a>`,
+  ];
+  return {
+    subject: "🎉 Your first booking is in",
+    text: `${d.name ? `${d.name}, ` : ""}you just got your first booking on DayOtter.\n\nKeep sharing your link: ${d.bookingUrl}\n\nOpen DayOtter: ${d.manageUrl}\n\nUnsubscribe from tips: ${d.unsubscribeUrl}`,
+    html: shell(
+      "Your first booking is in 🎉",
+      lines,
+      { label: "See it on your dashboard", url: d.manageUrl },
+      d.unsubscribeUrl,
+    ),
+  };
+}


### PR DESCRIPTION
Extends the activation email system (#262). Still **gated off** by `LIFECYCLE_EMAILS`.

- **Weekly digest** — a Monday-morning "here's your week" recap (meetings hosted + hours + focus time protected + what's on the books for the week ahead). Sent in each user's own timezone, once per ISO week (ledger kind carries the week). Retention lever.
- **First-booking celebration** — fires once when a host gets their first booking, reinforcing the activation aha. Scoped to first-bookings created in the **last 14 days**, so flipping the feature on doesn't retro-celebrate months-old bookings.
- Both run on the maintenance tick beside the activation nudges; each idempotent per `(user, kind)`, respecting `product_emails` opt-out + the unsubscribe link.

## Verify
- biome + `@dayotter/emails`, `worker`, `web` typecheck clean.
- Live send pending (we'll smoke-test on staging together); send path is the same Resend `sendEmail` as every transactional email.