### PR TITLE
fix(email): over-send safety valves + preview script

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "start": "tsx src/index.ts",
+    "email:preview": "tsx src/scripts/email-preview.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/worker/src/scripts/email-preview.ts
+++ b/apps/worker/src/scripts/email-preview.ts
@@ -1,0 +1,64 @@
+/**
+ * Send ONE lifecycle email to ONE address, for previewing. Does not touch the
+ * batch, the ledger, or any user - it just renders the chosen template with
+ * sample data and sends it through the normal mailer (Resend / SMTP), so you can
+ * see exactly what a real recipient would get.
+ *
+ *   pnpm --filter @dayotter/worker email:preview you@example.com share_link
+ *
+ * Kinds: share_link | connect_calendar | first_booking | weekly_digest
+ * Needs RESEND_API_KEY (or SMTP_URL) + EMAIL_FROM set, same as any email.
+ */
+import {
+  activationConnectCalendar,
+  activationShareLink,
+  firstBookingCelebration,
+  sendEmail,
+  weeklyDigest,
+} from "@dayotter/emails";
+
+const KINDS = ["share_link", "connect_calendar", "first_booking", "weekly_digest"] as const;
+type Kind = (typeof KINDS)[number];
+
+async function main() {
+  const [to, kindArg] = process.argv.slice(2);
+  const kind = kindArg as Kind;
+  if (!to || !KINDS.includes(kind)) {
+    console.error(`Usage: email:preview <to-email> <${KINDS.join(" | ")}>`);
+    process.exit(1);
+  }
+
+  const base = (process.env.APP_URL ?? "https://dayotter.com").replace(/\/$/, "");
+  const activation = {
+    name: "there",
+    bookingUrl: `${base}/you`,
+    manageUrl: `${base}/dashboard`,
+    // A dead sample link - preview only, so it doesn't unsubscribe anyone real.
+    unsubscribeUrl: `${base}/api/email/unsubscribe?u=preview&t=preview`,
+  };
+
+  const email =
+    kind === "share_link"
+      ? activationShareLink(activation)
+      : kind === "connect_calendar"
+        ? activationConnectCalendar(activation)
+        : kind === "first_booking"
+          ? firstBookingCelebration(activation)
+          : weeklyDigest({
+              name: "there",
+              meetings: 4,
+              hours: 2.5,
+              focusHours: 6,
+              upcoming: 2,
+              manageUrl: activation.manageUrl,
+              unsubscribeUrl: activation.unsubscribeUrl,
+            });
+
+  await sendEmail({ to, ...email });
+  console.log(`Sent "${kind}" preview to ${to} (subject: ${email.subject}).`);
+}
+
+main().catch((err) => {
+  console.error("email:preview failed:", err);
+  process.exit(1);
+});

--- a/apps/worker/src/workers/lifecycle-emails.ts
+++ b/apps/worker/src/workers/lifecycle-emails.ts
@@ -20,6 +20,32 @@ const APP_URL = process.env.APP_URL ?? "http://localhost:3000";
 /** Give a new signup room to activate on their own before nudging. */
 const MIN_AGE_MS = 2 * 86_400_000;
 
+// ---- Over-send safety valves (belt-and-suspenders on top of the per-(user,kind)
+// ledger, which is the real "at most once" guarantee). ----
+/** Hard ceiling on total lifecycle emails sent per UTC day, across all kinds and
+ * runs. A runaway bug can never blast the whole list. Override with
+ * LIFECYCLE_EMAILS_DAILY_CAP. */
+const DAILY_CAP = Number(process.env.LIFECYCLE_EMAILS_DAILY_CAP) || 500;
+/** Ceiling on emails a single scan can send, so one tick can't burst. */
+const MAX_PER_RUN = 150;
+
+/**
+ * How many lifecycle emails may still go out this tick: the smaller of the
+ * per-run cap and (daily cap − already sent today). The `lifecycle_emails` ledger
+ * IS the record of every send, so counting today's rows is exact - no separate
+ * counter to drift. Returns 0 when the day's budget is spent.
+ */
+async function remainingBudget(db: ReturnType<typeof getDb>): Promise<number> {
+  const startOfDay = new Date();
+  startOfDay.setUTCHours(0, 0, 0, 0);
+  const [row] = await db
+    .select({ n: sql<number>`count(*)::int` })
+    .from(schema.lifecycleEmails)
+    .where(gte(schema.lifecycleEmails.createdAt, startOfDay));
+  const sentToday = row?.n ?? 0;
+  return Math.max(0, Math.min(MAX_PER_RUN, DAILY_CAP - sentToday));
+}
+
 export type NudgeKind = "connect_calendar" | "share_link";
 
 /**
@@ -56,6 +82,8 @@ function unsubscribeUrl(userId: string): string {
 export async function sendActivationNudges(now = new Date()): Promise<number> {
   if (!ENABLED) return 0;
   const db = getDb();
+  let budget = await remainingBudget(db);
+  if (budget <= 0) return 0;
   const cutoff = new Date(now.getTime() - MIN_AGE_MS);
 
   // Users old enough to nudge who still receive product emails.
@@ -106,6 +134,7 @@ export async function sendActivationNudges(now = new Date()): Promise<number> {
       sent: sentByUser.get(u.id) ?? new Set(),
     });
     if (!kind) continue;
+    if (budget <= 0) break;
 
     // Claim the send first (unique index = the lock); skip if another run took it.
     const claimed = await db
@@ -126,6 +155,7 @@ export async function sendActivationNudges(now = new Date()): Promise<number> {
     try {
       await sendEmail({ to: u.email, ...email });
       sent += 1;
+      budget -= 1;
       logger.info("lifecycle email sent", { event: "lifecycle_email_sent", userId: u.id, kind });
     } catch (err) {
       logger.error("lifecycle email failed", {
@@ -152,6 +182,8 @@ function base(): string {
 export async function sendFirstBookingCelebrations(now = new Date()): Promise<number> {
   if (!ENABLED) return 0;
   const db = getDb();
+  let budget = await remainingBudget(db);
+  if (budget <= 0) return 0;
   const cutoff = new Date(now.getTime() - 14 * 86_400_000);
 
   const firstByHost = await db
@@ -191,6 +223,7 @@ export async function sendFirstBookingCelebrations(now = new Date()): Promise<nu
   let sent = 0;
   for (const u of optedIn) {
     if (already.has(u.id)) continue;
+    if (budget <= 0) break;
     const claimed = await db
       .insert(schema.lifecycleEmails)
       .values({ userId: u.id, kind: "first_booking" })
@@ -208,6 +241,7 @@ export async function sendFirstBookingCelebrations(now = new Date()): Promise<nu
         }),
       });
       sent += 1;
+      budget -= 1;
       logger.info("lifecycle email sent", {
         event: "lifecycle_email_sent",
         userId: u.id,
@@ -234,6 +268,8 @@ export async function sendFirstBookingCelebrations(now = new Date()): Promise<nu
 export async function sendWeeklyDigests(now = new Date()): Promise<number> {
   if (!ENABLED) return 0;
   const db = getDb();
+  let budget = await remainingBudget(db);
+  if (budget <= 0) return 0;
 
   const users = await db
     .select({
@@ -253,6 +289,7 @@ export async function sendWeeklyDigests(now = new Date()): Promise<number> {
     const local = DateTime.fromJSDate(now).setZone(tz);
     // Monday, from 08:00 local. (Luxon weekday: 1 = Monday.)
     if (local.weekday !== 1 || local.hour < 8) continue;
+    if (budget <= 0) break;
 
     const kind = `weekly_digest:${local.toFormat("kkkk-'W'WW")}`;
     const claimed = await db
@@ -310,6 +347,7 @@ export async function sendWeeklyDigests(now = new Date()): Promise<number> {
         }),
       });
       sent += 1;
+      budget -= 1;
       logger.info("lifecycle email sent", {
         event: "lifecycle_email_sent",
         userId: u.id,


### PR DESCRIPTION
You flagged the big risk: the same email going out too many times. The system was already **at-most-once per (user, kind)** via a unique-index ledger + claim-before-send, but this adds hard safety valves so a bug can't blast the list, plus a way to preview a single email before enabling the batch.

## Safety
- **Global daily cap** — at most `LIFECYCLE_EMAILS_DAILY_CAP` (default **500**) lifecycle emails per UTC day, across all kinds and runs. Counted directly off the `lifecycle_emails` ledger (which records every send), so it's exact — no separate counter to drift.
- **Per-run cap** — at most **150** per maintenance tick, so one tick can't burst.
- Each scan stops the instant the budget is spent, **before** claiming a ledger row, so a skipped user is never marked-sent-but-not-emailed.
- Unchanged and still the real guarantee: the unique `(user, kind)` ledger row is claimed *before* the send, so no user gets the same email twice — even across concurrent workers or retried ticks.

## Preview
```bash
pnpm --filter @dayotter/worker email:preview you@example.com share_link
```
Renders one lifecycle email (`share_link` | `connect_calendar` | `first_booking` | `weekly_digest`) with sample data and sends it to one address via the normal mailer. Touches no user, no ledger, no batch — just so you see exactly what recipients get.

biome + worker typecheck clean.