### PR TITLE
feat(billing): consistent soft-gate previews across every Pro surface

### DIFF
--- a/apps/web/app/(app)/settings/automations/page.tsx
+++ b/apps/web/app/(app)/settings/automations/page.tsx
@@ -12,25 +12,29 @@ export const dynamic = "force-dynamic";
  */
 export default function AutomationsSettingsPage() {
   return (
-    <ProGate feature="automation">
-      <div className="flex flex-col gap-10">
-        <section>
-          <h2 className="text-lg font-semibold">Scheduling rules</h2>
-          <p className="mb-4 mt-1 text-sm text-[var(--color-muted)]">
-            Reserve prep time and buffers around your bookings, and hold recurring focus blocks.
-          </p>
+    <div className="flex flex-col gap-10">
+      <section>
+        <h2 className="text-lg font-semibold">Scheduling rules</h2>
+        <p className="mb-4 mt-1 text-sm text-[var(--color-muted)]">
+          Reserve prep time and buffers around your bookings, and hold recurring focus blocks.
+        </p>
+        {/* Gated as `automation` - the same key the save route enforces. */}
+        <ProGate feature="automation">
           <AutomationsForm />
-        </section>
+        </ProGate>
+      </section>
 
-        <section id="messages">
-          <h2 className="text-lg font-semibold">Attendee messages</h2>
-          <p className="mb-4 mt-1 text-sm text-[var(--color-muted)]">
-            Send automated emails before and after a meeting - reminders and follow-ups, on your own
-            templates.
-          </p>
+      <section id="messages">
+        <h2 className="text-lg font-semibold">Attendee messages</h2>
+        <p className="mb-4 mt-1 text-sm text-[var(--color-muted)]">
+          Send automated emails before and after a meeting - reminders and follow-ups, on your own
+          templates.
+        </p>
+        {/* Gated as `workflows` - matches /api/workflows, not `automation`. */}
+        <ProGate feature="workflows">
           <WorkflowsForm />
-        </section>
-      </div>
-    </ProGate>
+        </ProGate>
+      </section>
+    </div>
   );
 }

--- a/apps/web/components/event-type-form.tsx
+++ b/apps/web/components/event-type-form.tsx
@@ -6,6 +6,7 @@ import { ConfirmDialog } from "@/components/ui/dialog";
 import { FormError } from "@/components/ui/form";
 import { Input, Label } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
+import { ProLock } from "@/components/upgrade-prompt";
 import { track } from "@/lib/analytics";
 import {
   type BookingQuestionInput,
@@ -975,87 +976,92 @@ export function EventTypeForm({
                 ) : null}
 
                 {paymentsEnabled ? (
-                  <div className="mt-4 rounded-md border border-[var(--color-border)] p-3">
-                    <label className="flex items-center gap-2 text-sm text-[var(--color-text)]">
-                      <input
-                        type="checkbox"
-                        checked={priceOn}
-                        onChange={(e) => setPriceOn(e.target.checked)}
-                        className="accent-[var(--color-accent)]"
-                      />
-                      Require payment to book
-                    </label>
-                    {priceOn ? (
-                      <div className="mt-3 space-y-3">
-                        <div className="flex items-end gap-2">
-                          <div className="flex-1">
-                            <Label htmlFor="price">Price</Label>
+                  <ProLock
+                    feature="accept_payments"
+                    note="Charging attendees for a booking is a Pro feature."
+                  >
+                    <div className="mt-4 rounded-md border border-[var(--color-border)] p-3">
+                      <label className="flex items-center gap-2 text-sm text-[var(--color-text)]">
+                        <input
+                          type="checkbox"
+                          checked={priceOn}
+                          onChange={(e) => setPriceOn(e.target.checked)}
+                          className="accent-[var(--color-accent)]"
+                        />
+                        Require payment to book
+                      </label>
+                      {priceOn ? (
+                        <div className="mt-3 space-y-3">
+                          <div className="flex items-end gap-2">
+                            <div className="flex-1">
+                              <Label htmlFor="price">Price</Label>
+                              <div className="flex items-center gap-1">
+                                <span className="text-sm text-[var(--color-muted)]">
+                                  {CURRENCY_SYMBOL[currency as keyof typeof CURRENCY_SYMBOL]}
+                                </span>
+                                <Input
+                                  id="price"
+                                  type="number"
+                                  min={0}
+                                  step="0.01"
+                                  value={priceMajor}
+                                  onChange={(e) => setPriceMajor(e.target.value)}
+                                  placeholder="25.00"
+                                />
+                              </div>
+                            </div>
+                            <div className="w-28">
+                              <Label htmlFor="currency">Currency</Label>
+                              <Select
+                                id="currency"
+                                value={currency}
+                                onChange={(e) => setCurrency(e.target.value)}
+                              >
+                                {CURRENCIES.map((c) => (
+                                  <option key={c} value={c}>
+                                    {c.toUpperCase()}
+                                  </option>
+                                ))}
+                              </Select>
+                            </div>
+                          </div>
+                          <label className="flex items-center gap-2 text-sm text-[var(--color-muted)]">
+                            <input
+                              type="checkbox"
+                              checked={depositOn}
+                              onChange={(e) => setDepositOn(e.target.checked)}
+                              className="accent-[var(--color-accent)]"
+                            />
+                            Take a deposit instead of the full price
+                          </label>
+                          {depositOn ? (
                             <div className="flex items-center gap-1">
                               <span className="text-sm text-[var(--color-muted)]">
                                 {CURRENCY_SYMBOL[currency as keyof typeof CURRENCY_SYMBOL]}
                               </span>
                               <Input
-                                id="price"
+                                aria-label="Deposit amount"
                                 type="number"
                                 min={0}
                                 step="0.01"
-                                value={priceMajor}
-                                onChange={(e) => setPriceMajor(e.target.value)}
-                                placeholder="25.00"
+                                value={depositMajor}
+                                onChange={(e) => setDepositMajor(e.target.value)}
+                                placeholder="10.00"
+                                className="w-32"
                               />
+                              <span className="text-xs text-[var(--color-faint)]">
+                                charged to book
+                              </span>
                             </div>
-                          </div>
-                          <div className="w-28">
-                            <Label htmlFor="currency">Currency</Label>
-                            <Select
-                              id="currency"
-                              value={currency}
-                              onChange={(e) => setCurrency(e.target.value)}
-                            >
-                              {CURRENCIES.map((c) => (
-                                <option key={c} value={c}>
-                                  {c.toUpperCase()}
-                                </option>
-                              ))}
-                            </Select>
-                          </div>
+                          ) : null}
                         </div>
-                        <label className="flex items-center gap-2 text-sm text-[var(--color-muted)]">
-                          <input
-                            type="checkbox"
-                            checked={depositOn}
-                            onChange={(e) => setDepositOn(e.target.checked)}
-                            className="accent-[var(--color-accent)]"
-                          />
-                          Take a deposit instead of the full price
-                        </label>
-                        {depositOn ? (
-                          <div className="flex items-center gap-1">
-                            <span className="text-sm text-[var(--color-muted)]">
-                              {CURRENCY_SYMBOL[currency as keyof typeof CURRENCY_SYMBOL]}
-                            </span>
-                            <Input
-                              aria-label="Deposit amount"
-                              type="number"
-                              min={0}
-                              step="0.01"
-                              value={depositMajor}
-                              onChange={(e) => setDepositMajor(e.target.value)}
-                              placeholder="10.00"
-                              className="w-32"
-                            />
-                            <span className="text-xs text-[var(--color-faint)]">
-                              charged to book
-                            </span>
-                          </div>
-                        ) : null}
-                      </div>
-                    ) : (
-                      <p className="mt-1 text-xs text-[var(--color-faint)]">
-                        Collect payment via Stripe before the booking is confirmed.
-                      </p>
-                    )}
-                  </div>
+                      ) : (
+                        <p className="mt-1 text-xs text-[var(--color-faint)]">
+                          Collect payment via Stripe before the booking is confirmed.
+                        </p>
+                      )}
+                    </div>
+                  </ProLock>
                 ) : null}
               </div>
 

--- a/apps/web/components/notification-channels-form.tsx
+++ b/apps/web/components/notification-channels-form.tsx
@@ -7,6 +7,7 @@ import { FormError } from "@/components/ui/form";
 import { Input, Label } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
 import { useToast } from "@/components/ui/toast";
+import { useFeature } from "@/components/upgrade-prompt";
 import { track } from "@/lib/analytics";
 import { CHANNEL_LABELS } from "@/lib/notifications/channel-input";
 import {
@@ -71,6 +72,10 @@ export function NotificationChannelsForm({
   const [phone, setPhone] = useState("");
   const [pushToken, setPushToken] = useState("");
   const [adding, setAdding] = useState(false);
+  // SMS carries a real carrier cost, so it's the one Pro reminder channel (Slack
+  // + WhatsApp are free). Fails open, so self-host is never blocked.
+  const { allowed: smsAllowed } = useFeature("sms_reminders");
+  const smsLocked = type === "sms" && !smsAllowed;
   const { toast } = useToast();
   const [error, setError] = useState<string | null>(null);
   const [pendingDelete, setPendingDelete] = useState<Channel | null>(null);
@@ -324,6 +329,18 @@ export function NotificationChannelsForm({
               <p className="mt-1 text-xs text-[var(--color-faint)]">
                 International format, including country code.
               </p>
+              {smsLocked ? (
+                <p className="mt-2 text-xs text-[var(--color-muted)]">
+                  SMS reminders are a Pro feature (Slack and WhatsApp are free).{" "}
+                  <a
+                    href="/settings/billing"
+                    className="font-medium text-[var(--color-accent)] hover:underline"
+                  >
+                    Upgrade to Pro
+                  </a>{" "}
+                  to send them.
+                </p>
+              ) : null}
             </div>
           ) : null}
 
@@ -344,7 +361,7 @@ export function NotificationChannelsForm({
 
           <FormError>{error}</FormError>
 
-          <Button type="submit" disabled={adding}>
+          <Button type="submit" disabled={adding || smsLocked}>
             {adding ? (
               "Sending test…"
             ) : (

--- a/apps/web/components/preferences-form.tsx
+++ b/apps/web/components/preferences-form.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardBody } from "@/components/ui/card";
 import { Input, Label } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
+import { ProLock } from "@/components/upgrade-prompt";
 import { cn } from "@/lib/cn";
 import { type Locale, SUPPORTED_LOCALES } from "@/lib/i18n";
 import { Check, Monitor, Moon, Sun } from "lucide-react";
@@ -283,42 +284,44 @@ export function PreferencesForm({
             Time protection
           </p>
           <div className="pt-1">
-            <label className="flex items-start gap-2 text-sm text-[var(--color-text)]">
-              <input
-                type="checkbox"
-                checked={adaptive}
-                onChange={(e) => {
-                  setAdaptive(e.target.checked);
-                  setSaved(false);
-                }}
-                className="mt-0.5 accent-[var(--color-accent)]"
-              />
-              <span>
-                Focus protection (adaptive availability)
-                <span className="mt-0.5 block text-xs text-[var(--color-faint)]">
-                  On heavy days, stop offering slots once you hit your meeting cap - and
-                  hard-decline any booking that would push a day over it - so a full day doesn't get
-                  fuller and your focus time is protected.
-                </span>
-              </span>
-            </label>
-            {adaptive ? (
-              <div className="mt-3 flex items-center gap-2">
-                <Label htmlFor="max-per-day">Max meetings/day</Label>
-                <Input
-                  id="max-per-day"
-                  type="number"
-                  min={1}
-                  max={20}
-                  value={maxPerDay}
+            <ProLock feature="adaptive">
+              <label className="flex items-start gap-2 text-sm text-[var(--color-text)]">
+                <input
+                  type="checkbox"
+                  checked={adaptive}
                   onChange={(e) => {
-                    setMaxPerDay(Number(e.target.value) || 1);
+                    setAdaptive(e.target.checked);
                     setSaved(false);
                   }}
-                  className="w-20"
+                  className="mt-0.5 accent-[var(--color-accent)]"
                 />
-              </div>
-            ) : null}
+                <span>
+                  Focus protection (adaptive availability)
+                  <span className="mt-0.5 block text-xs text-[var(--color-faint)]">
+                    On heavy days, stop offering slots once you hit your meeting cap - and
+                    hard-decline any booking that would push a day over it - so a full day doesn't
+                    get fuller and your focus time is protected.
+                  </span>
+                </span>
+              </label>
+              {adaptive ? (
+                <div className="mt-3 flex items-center gap-2">
+                  <Label htmlFor="max-per-day">Max meetings/day</Label>
+                  <Input
+                    id="max-per-day"
+                    type="number"
+                    min={1}
+                    max={20}
+                    value={maxPerDay}
+                    onChange={(e) => {
+                      setMaxPerDay(Number(e.target.value) || 1);
+                      setSaved(false);
+                    }}
+                    className="w-20"
+                  />
+                </div>
+              ) : null}
+            </ProLock>
           </div>
 
           <div className="border-t border-[var(--color-border)] pt-4">
@@ -343,27 +346,29 @@ export function PreferencesForm({
           </div>
 
           <div className="border-t border-[var(--color-border)] pt-4">
-            <Label htmlFor="travel-buffer">Travel time for in-person meetings</Label>
-            <p className="mb-2 -mt-1 text-xs text-[var(--color-faint)]">
-              Reserve this much travel time before and after every in-person booking, so you're
-              never offered back-to-back slots with no room to get there. 0 = off.
-            </p>
-            <div className="flex items-center gap-2">
-              <Input
-                id="travel-buffer"
-                type="number"
-                min={0}
-                max={240}
-                step={5}
-                value={travelBuffer}
-                onChange={(e) => {
-                  setTravelBuffer(Math.max(0, Number(e.target.value) || 0));
-                  setSaved(false);
-                }}
-                className="w-24"
-              />
-              <span className="text-sm text-[var(--color-muted)]">minutes each way</span>
-            </div>
+            <ProLock feature="travel">
+              <Label htmlFor="travel-buffer">Travel time for in-person meetings</Label>
+              <p className="mb-2 -mt-1 text-xs text-[var(--color-faint)]">
+                Reserve this much travel time before and after every in-person booking, so you're
+                never offered back-to-back slots with no room to get there. 0 = off.
+              </p>
+              <div className="flex items-center gap-2">
+                <Input
+                  id="travel-buffer"
+                  type="number"
+                  min={0}
+                  max={240}
+                  step={5}
+                  value={travelBuffer}
+                  onChange={(e) => {
+                    setTravelBuffer(Math.max(0, Number(e.target.value) || 0));
+                    setSaved(false);
+                  }}
+                  className="w-24"
+                />
+                <span className="text-sm text-[var(--color-muted)]">minutes each way</span>
+              </div>
+            </ProLock>
           </div>
 
           <div className="border-t border-[var(--color-border)] pt-4">

--- a/apps/web/components/upgrade-prompt.tsx
+++ b/apps/web/components/upgrade-prompt.tsx
@@ -112,3 +112,43 @@ export function ProGate({
     </div>
   );
 }
+
+/**
+ * Inline soft-gate for a single control that lives INSIDE a larger form (a
+ * toggle, a field, a small block) - where a full blurred-preview card would be
+ * too heavy. Entitled (incl. every self-host account): renders the control
+ * normally. Not entitled: shows it dimmed and non-interactive with a one-line
+ * "this is Pro, upgrade" note beneath, so a cloud free plan sees the option
+ * exists instead of it silently 402-ing (or saving nothing) on submit.
+ */
+export function ProLock({
+  feature,
+  children,
+  note,
+}: {
+  feature: Feature;
+  children: React.ReactNode;
+  note?: string;
+}) {
+  const { loading, allowed } = useFeature(feature);
+  if (loading || allowed) return <>{children}</>;
+  return (
+    <div>
+      <div aria-hidden className="pointer-events-none select-none opacity-55">
+        {children}
+      </div>
+      <p className="mt-2 flex items-center gap-1.5 text-xs text-[var(--color-muted)]">
+        <Sparkles size={13} className="shrink-0 text-[var(--color-accent)]" />
+        <span>
+          {note ?? `${FEATURE_LABEL[feature]} is a Pro feature.`}{" "}
+          <Link
+            href="/settings/billing"
+            className="font-medium text-[var(--color-accent)] hover:underline"
+          >
+            Upgrade to Pro
+          </Link>
+        </span>
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
Follow-up to #267. That PR turned the three big Pro **pages** (analytics, automations, developer) into blurred previews. But several **inline** Pro controls were still inconsistent: some hard-blocked with a raw 402 only after you'd filled them in, and a few weren't gated at all. This makes the cloud paywall consistent across every surface. **Self-host is unaffected** - `useFeature` fails open and every feature is entitled, so none of these gates ever render.

### New primitive: `ProLock`
An inline soft-gate for a single control inside a larger form (a toggle, a field, a small block) where a full blurred-preview card would be too heavy. Entitled: renders normally. Not entitled: the control is shown dimmed + non-interactive with a one-line *'{Feature} is a Pro feature. Upgrade to Pro'* note beneath.

### Surfaces fixed
| Surface | Before | After |
|---|---|---|
| **Automations page** | both sections gated as `automation` | scheduling rules = `automation`, attendee messages = `workflows` (matches `/api/workflows`) |
| **Adaptive availability** (preferences) | **no gate at all** | `ProLock feature="adaptive"` |
| **Travel-time buffer** (preferences) | **no gate at all** | `ProLock feature="travel"` |
| **Accept payments** (event-type form) | gated only by Stripe being configured | `ProLock feature="accept_payments"` |
| **SMS channel** (notifications) | 402 only after entering a phone number | inline Pro note + submit disabled when locked |

### Note on server enforcement
`sms_reminders` and `workflows` are enforced server-side (402) already. `adaptive`, `travel`, and `accept_payments` currently have **no** server-side `requireFeature` - so on cloud these are now a *visible* Pro gate but still technically bypassable via direct API. I kept server enforcement out of this PR because it's a surgical, partial-update-sensitive change (e.g. the preferences route must not 402 a whole save just because one Pro field was touched) and arguably a billing-policy call. Happy to add it in a focused follow-up if we want these truly non-bypassable on cloud.

web typecheck + biome clean.