### PR TITLE
ci: gate PRs on the production build too (closes #165)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,28 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+  # Exercise the real production build on every PR. Previously the Next.js build
+  # ran only inside the Docker deploy pipeline, so a build-only break (e.g. an
+  # empty NEXT_PUBLIC_APP_URL making `new URL("")` throw, #261) slipped past CI
+  # and failed at deploy time. This catches it on the PR instead. Runs with no
+  # app secrets - a clean build must not depend on any, exactly as Docker builds.
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.24.0
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build


### PR DESCRIPTION
Closes #165 (the '+ build' part; lint/typecheck/test were already in `ci.yml`).

## Why
CI ran lint + typecheck + test but **not** the production build - the Next.js build ran only inside the Docker deploy pipeline. So a build-only break passed CI green and only blew up at deploy. **#261 was exactly this**: a contributor PR set `ENV NEXT_PUBLIC_APP_URL=$NEXT_PUBLIC_APP_URL`, which resolved to an empty string at build, and `"" ?? default` -> `new URL("")` threw during `next build`. typecheck and tests were both green; nothing caught it until the deploy build failed.

## What
A parallel `build` job that runs `pnpm build` on every PR. Only `apps/web` has a `build` script, so `turbo run build` is a single targeted `next build` - not a heavyweight Expo/mobile build. It runs with **no app secrets**, mirroring how the Docker image builds: a clean production build must not depend on any.

## Verification
Ran the web build locally in a stripped environment (`env -i`, no app env) -> **exit 0**, full route table emitted. So the gate is reliable, and main is currently build-green.

Runs as its own job (parallel with `verify`) for independent, fail-fast signals.