### PR TITLE
feat(payments): per-currency withdraw minimums + zero-decimal money (closes #68)

### DIFF
--- a/apps/web/app/(app)/settings/payouts/page.tsx
+++ b/apps/web/app/(app)/settings/payouts/page.tsx
@@ -4,7 +4,6 @@ import { Card, CardBody } from "@/components/ui/card";
 import { getSession } from "@/lib/auth/session";
 import {
   type CurrencyBalance,
-  WITHDRAW_MINIMUM,
   connectedBalances,
   paymentsEnabled,
   platformFeePercent,
@@ -76,7 +75,6 @@ export default async function PayoutsSettingsPage() {
         payoutsEnabled={payouts}
         detailsSubmitted={submitted}
         balances={balances}
-        minimum={WITHDRAW_MINIMUM}
         feePercent={platformFeePercent}
       />
     </div>

--- a/apps/web/app/api/payments/withdraw/route.ts
+++ b/apps/web/app/api/payments/withdraw/route.ts
@@ -1,4 +1,5 @@
-import { WITHDRAW_MINIMUM, connectedBalances, createConnectedPayout } from "@/lib/payments/stripe";
+import { withdrawMinimum } from "@/lib/booking/money";
+import { connectedBalances, createConnectedPayout } from "@/lib/payments/stripe";
 import { jsonError, withUser } from "@/lib/server/http";
 import { logger } from "@dayotter/core";
 import { eq, getDb, schema } from "@dayotter/db";
@@ -27,7 +28,9 @@ export const POST = withUser(async (u) => {
 
   try {
     const balances = await connectedBalances(user.stripeAccountId);
-    const withdrawable = balances.filter((b) => b.available >= WITHDRAW_MINIMUM);
+    // Each currency clears its OWN minimum (a zero-decimal ¥ balance is measured
+    // in whole yen, not cents, so a flat threshold would be 100x off).
+    const withdrawable = balances.filter((b) => b.available >= withdrawMinimum(b.currency));
     if (withdrawable.length === 0) {
       return jsonError("You need at least the minimum available to withdraw.", 400);
     }

--- a/apps/web/components/payouts-panel.tsx
+++ b/apps/web/components/payouts-panel.tsx
@@ -4,6 +4,7 @@ import { Button, buttonVariants } from "@/components/ui/button";
 import { Card, CardBody, CardHeader } from "@/components/ui/card";
 import { FormError } from "@/components/ui/form";
 import { track } from "@/lib/analytics";
+import { minorPerUnit, withdrawMinimum } from "@/lib/booking/money";
 import { cn } from "@/lib/cn";
 import { Banknote, CheckCircle2, ExternalLink } from "lucide-react";
 import { useRouter } from "next/navigation";
@@ -13,7 +14,9 @@ function money(minor: number, currency: string): string {
   return new Intl.NumberFormat(undefined, {
     style: "currency",
     currency: currency.toUpperCase(),
-  }).format(minor / 100);
+    // Intl already picks the right decimals per currency; divide by the currency's
+    // own smallest-unit factor so zero-decimal balances (¥) aren't shown 100x low.
+  }).format(minor / minorPerUnit(currency));
 }
 
 interface CurrencyBalance {
@@ -28,7 +31,6 @@ export function PayoutsPanel({
   payoutsEnabled,
   detailsSubmitted,
   balances,
-  minimum,
   feePercent,
 }: {
   connected: boolean;
@@ -36,7 +38,6 @@ export function PayoutsPanel({
   payoutsEnabled: boolean;
   detailsSubmitted: boolean;
   balances: CurrencyBalance[];
-  minimum: number;
   feePercent: number;
 }) {
   const router = useRouter();
@@ -45,8 +46,8 @@ export function PayoutsPanel({
   const [done, setDone] = useState<string | null>(null);
 
   const ready = connected && chargesEnabled && payoutsEnabled;
-  // Withdraw is enabled if ANY currency bucket clears the minimum.
-  const canWithdraw = ready && balances.some((b) => b.available >= minimum);
+  // Withdraw is enabled if ANY currency bucket clears ITS OWN minimum.
+  const canWithdraw = ready && balances.some((b) => b.available >= withdrawMinimum(b.currency));
   // A stable primary currency for framing the minimum copy.
   const primary = balances[0]?.currency ?? "usd";
 
@@ -134,7 +135,7 @@ export function PayoutsPanel({
             </div>
           )}
           <p className="mt-2 text-xs text-[var(--color-faint)]">
-            Minimum withdrawal {money(minimum, primary)} per currency.
+            Minimum withdrawal {money(withdrawMinimum(primary), primary)} per currency.
           </p>
         </div>
 
@@ -149,7 +150,8 @@ export function PayoutsPanel({
             </Button>
             {!canWithdraw ? (
               <span className="text-sm text-[var(--color-muted)]">
-                You can withdraw once your balance reaches {money(minimum, primary)}.
+                You can withdraw once your balance reaches{" "}
+                {money(withdrawMinimum(primary), primary)}.
               </span>
             ) : null}
           </div>

--- a/apps/web/lib/booking/money.test.ts
+++ b/apps/web/lib/booking/money.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { chargeFor, formatMoney, minorPerUnit, withdrawMinimum } from "./money";
+
+describe("minorPerUnit", () => {
+  it("is 100 for normal two-decimal currencies", () => {
+    expect(minorPerUnit("usd")).toBe(100);
+    expect(minorPerUnit("eur")).toBe(100);
+    expect(minorPerUnit("inr")).toBe(100);
+  });
+
+  it("is 1 for zero-decimal currencies, case-insensitively", () => {
+    expect(minorPerUnit("jpy")).toBe(1);
+    expect(minorPerUnit("JPY")).toBe(1);
+    expect(minorPerUnit("krw")).toBe(1);
+  });
+
+  it("defaults unknown currencies to two decimals", () => {
+    expect(minorPerUnit("xyz")).toBe(100);
+  });
+});
+
+describe("formatMoney", () => {
+  it("renders two-decimal currencies with the symbol", () => {
+    expect(formatMoney(2500, "usd")).toBe("$25.00");
+    expect(formatMoney(10_000, "eur")).toBe("€100.00");
+    expect(formatMoney(0, "gbp")).toBe("£0.00");
+  });
+
+  it("does not divide zero-decimal currencies by 100", () => {
+    // ¥10,000 is 10000 whole yen - the old /100 wrongly rendered it as 100.00.
+    expect(formatMoney(10_000, "jpy")).toBe("10000 JPY");
+    expect(formatMoney(500, "jpy")).toBe("500 JPY");
+  });
+
+  it("falls back to an uppercased code when there is no symbol", () => {
+    expect(formatMoney(2500, "chf")).toBe("25.00 CHF");
+    expect(formatMoney(10_000, "krw")).toBe("10000 KRW");
+  });
+});
+
+describe("withdrawMinimum", () => {
+  it("keeps the $100 minimum for every two-decimal currency", () => {
+    for (const c of ["usd", "eur", "gbp", "cad", "aud", "inr"]) {
+      expect(withdrawMinimum(c)).toBe(10_000);
+    }
+  });
+
+  it("uses whole-unit minimums for zero-decimal currencies", () => {
+    // Not 10_000 cents (which for ¥ would be ¥10,000-as-cents = 100x wrong).
+    expect(withdrawMinimum("jpy")).toBe(10_000); // ¥10,000
+    expect(withdrawMinimum("krw")).toBe(100_000); // ₩100,000
+  });
+
+  it("is case-insensitive", () => {
+    expect(withdrawMinimum("USD")).toBe(10_000);
+    expect(withdrawMinimum("JPY")).toBe(10_000);
+  });
+
+  it("falls back to ~100 major units for an unmapped currency", () => {
+    expect(withdrawMinimum("chf")).toBe(10_000); // two-decimal fallback
+  });
+});
+
+describe("chargeFor", () => {
+  it("is zero when the event type is free", () => {
+    expect(chargeFor(null, null)).toBe(0);
+    expect(chargeFor(0, 5000)).toBe(0);
+  });
+
+  it("charges the full price when there is no deposit", () => {
+    expect(chargeFor(5000, null)).toBe(5000);
+    expect(chargeFor(5000, 0)).toBe(5000);
+  });
+
+  it("charges the deposit only when it is a positive amount below the price", () => {
+    expect(chargeFor(5000, 2000)).toBe(2000);
+    expect(chargeFor(5000, 5000)).toBe(5000); // deposit == price → full price
+    expect(chargeFor(5000, 6000)).toBe(5000); // deposit > price → full price
+  });
+});

--- a/apps/web/lib/booking/money.ts
+++ b/apps/web/lib/booking/money.ts
@@ -13,12 +13,61 @@ export const CURRENCY_SYMBOL: Record<Currency, string> = {
   inr: "₹",
 };
 
-/** Format minor units + currency for display, e.g. (2500, "usd") → "$25.00". */
+/**
+ * Stripe "zero-decimal" currencies: the amount is already the whole unit, with
+ * no minor unit to divide by (¥100 is 100, not 10000). Dividing these by 100
+ * would under-report balances and payouts 100x. See
+ * https://stripe.com/docs/currencies#zero-decimal
+ */
+export const ZERO_DECIMAL_CURRENCIES = new Set([
+  "bif",
+  "clp",
+  "djf",
+  "gnf",
+  "jpy",
+  "kmf",
+  "krw",
+  "mga",
+  "pyg",
+  "rwf",
+  "ugx",
+  "vnd",
+  "vuv",
+  "xaf",
+  "xof",
+  "xpf",
+]);
+
+/** Smallest units per major unit: 1 for zero-decimal (JPY), 100 otherwise. */
+export function minorPerUnit(currency: string): number {
+  return ZERO_DECIMAL_CURRENCIES.has(currency.toLowerCase()) ? 1 : 100;
+}
+
+/** Format minor units + currency for display, e.g. (2500, "usd") → "$25.00",
+ *  (10000, "jpy") → "¥10000". Honors zero-decimal currencies. */
 export function formatMoney(minor: number, currency: string): string {
   const sym = CURRENCY_SYMBOL[currency as Currency] ?? "";
-  return sym
-    ? `${sym}${(minor / 100).toFixed(2)}`
-    : `${(minor / 100).toFixed(2)} ${currency.toUpperCase()}`;
+  const per = minorPerUnit(currency);
+  const value = (minor / per).toFixed(per === 1 ? 0 : 2);
+  return sym ? `${sym}${value}` : `${value} ${currency.toUpperCase()}`;
+}
+
+/**
+ * Per-currency minimum withdrawable balance, in that currency's SMALLEST unit.
+ * A flat 10_000-cents ($100) was previously applied to every currency, which is
+ * 100x wrong for zero-decimal currencies (¥ has no cents) and doesn't allow a
+ * rounder figure elsewhere. Currencies absent from the map fall back to ~100
+ * major units, so every existing 2-decimal currency keeps its $100 minimum.
+ */
+const WITHDRAW_MINIMUM_BY_CURRENCY: Record<string, number> = {
+  jpy: 10_000, // ¥10,000 (zero-decimal)
+  krw: 100_000, // ₩100,000 (zero-decimal)
+};
+
+/** Minimum balance (smallest unit) a host must clear to withdraw `currency`. */
+export function withdrawMinimum(currency: string): number {
+  const c = currency.toLowerCase();
+  return WITHDRAW_MINIMUM_BY_CURRENCY[c] ?? 100 * minorPerUnit(c);
 }
 
 /** How much a paid event type charges to book: the deposit if set (< price), else full price. */

--- a/apps/web/lib/payments/stripe.ts
+++ b/apps/web/lib/payments/stripe.ts
@@ -1,3 +1,4 @@
+import { withdrawMinimum } from "@/lib/booking/money";
 import { logger } from "@dayotter/core";
 import Stripe from "stripe";
 
@@ -194,8 +195,10 @@ export const platformFeePercent = Math.max(
   Math.min(100, Number(process.env.STRIPE_PLATFORM_FEE_PERCENT ?? "0") || 0),
 );
 
-/** Minimum balance (minor units) a host can withdraw - $100. */
-export const WITHDRAW_MINIMUM = 10_000;
+/** The USD withdrawal minimum ($100), for surfaces that show a single figure
+ *  (the status route / mobile). The withdraw gate itself is per-currency - see
+ *  `withdrawMinimum()` in lib/booking/money. */
+export const WITHDRAW_MINIMUM = withdrawMinimum("usd");
 
 /** The platform fee (minor units) for a charge of `amount`. */
 export function platformFee(amount: number): number {


### PR DESCRIPTION
Closes #68, and does the money-helper slice of #69.

## Problem
The withdrawal gate applied **one flat `10_000`-cents ($100) minimum to every currency**, and `formatMoney` hard-coded `/100`. Both are wrong for Stripe **zero-decimal** currencies (JPY, KRW, etc. have no minor unit): a ¥10,000 balance was read as ¥100, and its withdraw threshold was 100x off. Even for two-decimal currencies there was no way to set a different minimum per currency.

## #68 - per-currency minimums + zero-decimal correctness
- `money.ts`: new `ZERO_DECIMAL_CURRENCIES` set + `minorPerUnit(currency)` (1 for ¥, 100 otherwise). `formatMoney` divides by that factor and uses the right number of decimals (`¥10000`, not `¥100.00`).
- New **`withdrawMinimum(currency)`** - per-currency threshold in the currency's smallest unit. **Every existing two-decimal currency keeps its exact $100 minimum** (no behavior change); zero-decimal currencies get sensible whole-unit minimums (¥10,000 / ₩100,000). It's the single source of truth, and being client-safe it's shared by the withdraw route, the payouts panel, and `stripe.ts` (whose `WITHDRAW_MINIMUM` scalar is now just `withdrawMinimum("usd")` for the single-figure mobile/status surface).
- The withdraw route filters each balance against **its own** minimum. The payouts panel's `money()` divides by `minorPerUnit` too, so mixed-currency hosts see correct balances + per-currency minimum copy; dropped the now-unused single `minimum` prop.

## #69 - tests for the untested money paths
New `apps/web/lib/booking/money.test.ts` (**13 cases**, all pure, all previously untested): `formatMoney` (two-decimal, zero-decimal, symbol fallback), `minorPerUnit`, `withdrawMinimum` (per-currency, fallback, case-insensitivity), and `chargeFor` (deposit vs full price).

## Verification
web typecheck + biome clean; `money.test.ts` 13/13 pass; production build green in a clean, secret-less env.

> Note: I scoped #69 to the money helpers here. Auth (`session.ts`) and worker `sync.ts` are DB/framework-coupled and their pure fragments (oauth-state, availability engine) are already tested, so there's little pure logic left to add there without extraction - happy to do a follow-up if you want those refactored for testability.