### PR TITLE
feat(mobile): native date/time pickers in scheduling screens

### DIFF
--- a/apps/mobile/app/availability-troubleshooter.tsx
+++ b/apps/mobile/app/availability-troubleshooter.tsx
@@ -3,9 +3,10 @@ import { ErrorText, Loading } from "@/components/ui";
 import { useAsync } from "@/hooks";
 import { colors, radius } from "@/theme";
 import { Ionicons } from "@expo/vector-icons";
+import DateTimePicker from "@react-native-community/datetimepicker";
 import { Stack } from "expo-router";
 import { useEffect, useState } from "react";
-import { Pressable, ScrollView, StyleSheet, Text, TextInput, View } from "react-native";
+import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
 
 interface EventTypeLite {
   id: string;
@@ -24,10 +25,20 @@ interface DayDiagnosis {
   reasons: string[];
 }
 
-const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+/** YYYY-MM-DD from a Date's LOCAL parts (toISOString would shift by the UTC offset). */
+function toISODate(d: Date): string {
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${d.getFullYear()}-${m}-${day}`;
+}
 
-function todayISO() {
-  return new Date().toISOString().slice(0, 10);
+function fmtDate(d: Date): string {
+  return d.toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
 }
 
 /** Availability troubleshooter (#131): explain why a booking type does (or does
@@ -39,7 +50,8 @@ export default function TroubleshooterScreen() {
   }, []);
 
   const [eventTypeId, setEventTypeId] = useState("");
-  const [date, setDate] = useState(todayISO());
+  const [date, setDate] = useState<Date>(new Date());
+  const [showPicker, setShowPicker] = useState(false);
   const [running, setRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<DayDiagnosis | null>(null);
@@ -51,16 +63,12 @@ export default function TroubleshooterScreen() {
 
   async function run() {
     if (!eventTypeId) return;
-    if (!ISO_DATE.test(date)) {
-      setError("Enter the day as YYYY-MM-DD.");
-      return;
-    }
     setRunning(true);
     setError(null);
     setResult(null);
     try {
       const res = await api.get<{ diagnosis: DayDiagnosis }>(
-        `/api/availability/troubleshoot?eventTypeId=${eventTypeId}&date=${date}`,
+        `/api/availability/troubleshoot?eventTypeId=${eventTypeId}&date=${toISODate(date)}`,
       );
       setResult(res.diagnosis);
     } catch (e) {
@@ -100,15 +108,19 @@ export default function TroubleshooterScreen() {
           ) : null}
 
           <Text style={styles.label}>Day</Text>
-          <TextInput
-            style={styles.input}
-            value={date}
-            onChangeText={setDate}
-            placeholder="2026-08-01"
-            placeholderTextColor={colors.faint}
-            autoCapitalize="none"
-            maxLength={10}
-          />
+          <Pressable style={styles.input} onPress={() => setShowPicker(true)}>
+            <Text style={styles.inputText}>{fmtDate(date)}</Text>
+          </Pressable>
+          {showPicker ? (
+            <DateTimePicker
+              value={date}
+              mode="date"
+              onChange={(event, picked) => {
+                setShowPicker(false);
+                if (event.type !== "dismissed" && picked) setDate(picked);
+              }}
+            />
+          ) : null}
 
           {error ? <Text style={styles.error}>{error}</Text> : null}
           <Pressable style={styles.save} onPress={run} disabled={running || !eventTypeId}>
@@ -182,14 +194,14 @@ const styles = StyleSheet.create({
   chipTextOn: { color: colors.white, fontWeight: "600" },
   input: {
     height: 46,
+    justifyContent: "center",
     borderWidth: 1,
     borderColor: colors.borderStrong,
     borderRadius: radius.md,
     paddingHorizontal: 14,
-    fontSize: 15,
-    color: colors.text,
     backgroundColor: colors.surface,
   },
+  inputText: { fontSize: 15, color: colors.text },
   error: { color: colors.danger, marginTop: 14 },
   save: {
     marginTop: 18,

--- a/apps/mobile/app/availability.tsx
+++ b/apps/mobile/app/availability.tsx
@@ -3,6 +3,7 @@ import { ErrorText, Loading } from "@/components/ui";
 import type { Schedule } from "@/models";
 import { colors, radius } from "@/theme";
 import { Ionicons } from "@expo/vector-icons";
+import DateTimePicker from "@react-native-community/datetimepicker";
 import { Stack, useRouter } from "expo-router";
 import { useEffect, useState } from "react";
 import { Pressable, ScrollView, StyleSheet, Switch, Text, TextInput, View } from "react-native";
@@ -11,6 +12,24 @@ const ORDER = [1, 2, 3, 4, 5, 6, 0];
 const LABELS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
 type Range = { start: string; end: string };
 
+/** "HH:MM" -> a Date today at that time (for the native time picker). */
+function parseHM(hm: string): Date {
+  const [h, m] = hm.split(":").map((n) => Number.parseInt(n, 10));
+  const d = new Date();
+  d.setHours(Number.isFinite(h) ? h : 9, Number.isFinite(m) ? m : 0, 0, 0);
+  return d;
+}
+/** Date -> "HH:MM" (24h, the format the schedule API stores). */
+function toHM(d: Date): string {
+  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+}
+/** "HH:MM" -> a friendly localized label for the button (respects the device clock). */
+function fmtTime(hm: string): string {
+  return parseHM(hm).toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+}
+
+type Editing = { dow: number; idx: number; field: "start" | "end" };
+
 export default function AvailabilityScreen() {
   const router = useRouter();
   const [timezone, setTimezone] = useState("UTC");
@@ -18,6 +37,25 @@ export default function AvailabilityScreen() {
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
+  // A single screen-level time picker (which field it edits), mirroring polls/new.
+  const [editing, setEditing] = useState<Editing | null>(null);
+
+  function onPickTime(event: { type: string }, date?: Date) {
+    const ed = editing;
+    setEditing(null);
+    if (event.type === "dismissed" || !date || !ed) return;
+    const hm = toHM(date);
+    setDays((prev) =>
+      prev
+        ? prev.map((ranges, i) =>
+            i === ed.dow
+              ? ranges.map((x, j) => (j === ed.idx ? { ...x, [ed.field]: hm } : x))
+              : ranges,
+          )
+        : prev,
+    );
+    setSaved(false);
+  }
 
   useEffect(() => {
     api
@@ -70,7 +108,7 @@ export default function AvailabilityScreen() {
       });
       setSaved(true);
     } catch {
-      setError("Could not save. Check your times (HH:MM).");
+      setError("Could not save your availability. Please try again.");
     } finally {
       setSaving(false);
     }
@@ -95,6 +133,19 @@ export default function AvailabilityScreen() {
           placeholder="e.g. America/New_York"
           placeholderTextColor={colors.faint}
         />
+        <Pressable
+          style={styles.tzDetect}
+          onPress={() => {
+            const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+            if (tz) {
+              setTimezone(tz);
+              setSaved(false);
+            }
+          }}
+        >
+          <Ionicons name="locate-outline" size={15} color={colors.accent} />
+          <Text style={styles.tzDetectText}>Use device timezone</Text>
+        </Pressable>
 
         <View style={styles.presets}>
           {(
@@ -127,25 +178,19 @@ export default function AvailabilityScreen() {
                 <View style={styles.ranges}>
                   {ranges.map((r, i) => (
                     <View key={i} style={styles.rangeRow}>
-                      <TimeInput
-                        value={r.start}
-                        onChange={(v) =>
-                          update(
-                            dow,
-                            ranges.map((x, j) => (j === i ? { ...x, start: v } : x)),
-                          )
-                        }
-                      />
+                      <Pressable
+                        style={styles.timeInput}
+                        onPress={() => setEditing({ dow, idx: i, field: "start" })}
+                      >
+                        <Text style={styles.timeText}>{fmtTime(r.start)}</Text>
+                      </Pressable>
                       <Text style={styles.dash}>–</Text>
-                      <TimeInput
-                        value={r.end}
-                        onChange={(v) =>
-                          update(
-                            dow,
-                            ranges.map((x, j) => (j === i ? { ...x, end: v } : x)),
-                          )
-                        }
-                      />
+                      <Pressable
+                        style={styles.timeInput}
+                        onPress={() => setEditing({ dow, idx: i, field: "end" })}
+                      >
+                        <Text style={styles.timeText}>{fmtTime(r.end)}</Text>
+                      </Pressable>
                       <Pressable
                         onPress={() =>
                           update(
@@ -177,6 +222,14 @@ export default function AvailabilityScreen() {
           );
         })}
 
+        {editing ? (
+          <DateTimePicker
+            value={parseHM(days[editing.dow]?.[editing.idx]?.[editing.field] ?? "09:00")}
+            mode="time"
+            onChange={onPickTime}
+          />
+        ) : null}
+
         {error ? <Text style={styles.error}>{error}</Text> : null}
         <Pressable style={styles.save} onPress={save} disabled={saving}>
           <Text style={styles.saveText}>{saving ? "Saving…" : "Save availability"}</Text>
@@ -203,20 +256,6 @@ export default function AvailabilityScreen() {
   );
 }
 
-function TimeInput({ value, onChange }: { value: string; onChange: (v: string) => void }) {
-  return (
-    <TextInput
-      style={styles.timeInput}
-      value={value}
-      onChangeText={onChange}
-      placeholder="09:00"
-      placeholderTextColor={colors.faint}
-      maxLength={5}
-      autoCapitalize="none"
-    />
-  );
-}
-
 const styles = StyleSheet.create({
   safe: { flex: 1, backgroundColor: colors.bg },
   scroll: { padding: 20, paddingBottom: 40 },
@@ -230,25 +269,27 @@ const styles = StyleSheet.create({
     fontSize: 15,
     color: colors.text,
     backgroundColor: colors.surface,
-    marginBottom: 20,
+    marginBottom: 10,
   },
+  tzDetect: { flexDirection: "row", alignItems: "center", gap: 6, marginBottom: 20 },
+  tzDetectText: { color: colors.accent, fontSize: 13, fontWeight: "500" },
   day: { borderTopWidth: 1, borderTopColor: colors.border, paddingVertical: 14 },
   dayHeader: { flexDirection: "row", alignItems: "center", gap: 12 },
   dayName: { fontWeight: "500", color: colors.text },
   ranges: { marginTop: 10, marginLeft: 4, gap: 8 },
   rangeRow: { flexDirection: "row", alignItems: "center", gap: 8 },
   timeInput: {
-    width: 74,
+    width: 92,
     height: 40,
+    justifyContent: "center",
+    alignItems: "center",
     borderWidth: 1,
     borderColor: colors.borderStrong,
     borderRadius: radius.sm,
-    paddingHorizontal: 10,
-    fontSize: 14,
-    color: colors.text,
+    paddingHorizontal: 8,
     backgroundColor: colors.surface,
-    textAlign: "center",
   },
+  timeText: { fontSize: 14, color: colors.text },
   dash: { color: colors.muted },
   presets: { flexDirection: "row", flexWrap: "wrap", gap: 8, marginBottom: 4 },
   presetChip: {

--- a/apps/mobile/app/out-of-office.tsx
+++ b/apps/mobile/app/out-of-office.tsx
@@ -3,6 +3,7 @@ import { ErrorText, Loading } from "@/components/ui";
 import { useAsync } from "@/hooks";
 import { colors, radius } from "@/theme";
 import { Ionicons } from "@expo/vector-icons";
+import DateTimePicker from "@react-native-community/datetimepicker";
 import { Stack } from "expo-router";
 import { useState } from "react";
 import { Alert, Pressable, ScrollView, StyleSheet, Text, TextInput, View } from "react-native";
@@ -20,10 +21,21 @@ interface Period {
   delegate: Teammate | null;
 }
 
-const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
-
 function delegateName(t: Teammate) {
   return t.name ?? (t.handle ? `@${t.handle}` : "Teammate");
+}
+
+/** YYYY-MM-DD from a Date's LOCAL parts (toISOString would shift by the UTC offset). */
+function toISODate(d: Date): string {
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${d.getFullYear()}-${m}-${day}`;
+}
+
+function fmtDate(d: Date | null): string {
+  return d
+    ? d.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })
+    : "Select a date";
 }
 
 /** First-class out-of-office (#102): block a date range and optionally redirect
@@ -36,29 +48,43 @@ export default function OutOfOfficeScreen() {
     return api.get<{ periods: Period[]; teammates: Teammate[] }>("/api/out-of-office");
   }, []);
 
-  const [startDate, setStartDate] = useState("");
-  const [endDate, setEndDate] = useState("");
+  const [startDate, setStartDate] = useState<Date | null>(null);
+  const [endDate, setEndDate] = useState<Date | null>(null);
+  const [picker, setPicker] = useState<"start" | "end" | null>(null);
   const [reason, setReason] = useState("");
   const [delegateId, setDelegateId] = useState("");
   const [saving, setSaving] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
 
+  function onPickDate(event: { type: string }, date?: Date) {
+    const which = picker;
+    setPicker(null);
+    if (event.type === "dismissed" || !date) return;
+    if (which === "start") {
+      setStartDate(date);
+      // Keep the end on or after the new start.
+      setEndDate((e) => (e && e < date ? date : e));
+    } else {
+      setEndDate(date);
+    }
+  }
+
   async function add() {
     setFormError(null);
-    if (!ISO_DATE.test(startDate) || !ISO_DATE.test(endDate) || endDate < startDate) {
-      setFormError("Enter From and To as YYYY-MM-DD, with To on or after From.");
+    if (!startDate || !endDate || endDate < startDate) {
+      setFormError("Pick a From and To date, with To on or after From.");
       return;
     }
     setSaving(true);
     try {
       await api.post("/api/out-of-office", {
-        startDate,
-        endDate,
+        startDate: toISODate(startDate),
+        endDate: toISODate(endDate),
         reason: reason.trim() || undefined,
         delegateUserId: delegateId || null,
       });
-      setStartDate("");
-      setEndDate("");
+      setStartDate(null);
+      setEndDate(null);
       setReason("");
       setDelegateId("");
       reload();
@@ -133,29 +159,29 @@ export default function OutOfOfficeScreen() {
           <View style={styles.dateRow}>
             <View style={{ flex: 1 }}>
               <Text style={styles.label}>From</Text>
-              <TextInput
-                style={styles.input}
-                value={startDate}
-                onChangeText={setStartDate}
-                placeholder="2026-08-01"
-                placeholderTextColor={colors.faint}
-                autoCapitalize="none"
-                maxLength={10}
-              />
+              <Pressable style={styles.input} onPress={() => setPicker("start")}>
+                <Text style={startDate ? styles.inputText : styles.inputPlaceholder}>
+                  {fmtDate(startDate)}
+                </Text>
+              </Pressable>
             </View>
             <View style={{ flex: 1 }}>
               <Text style={styles.label}>To</Text>
-              <TextInput
-                style={styles.input}
-                value={endDate}
-                onChangeText={setEndDate}
-                placeholder="2026-08-05"
-                placeholderTextColor={colors.faint}
-                autoCapitalize="none"
-                maxLength={10}
-              />
+              <Pressable style={styles.input} onPress={() => setPicker("end")}>
+                <Text style={endDate ? styles.inputText : styles.inputPlaceholder}>
+                  {fmtDate(endDate)}
+                </Text>
+              </Pressable>
             </View>
           </View>
+          {picker ? (
+            <DateTimePicker
+              value={(picker === "start" ? startDate : endDate) ?? startDate ?? new Date()}
+              mode="date"
+              minimumDate={picker === "end" ? (startDate ?? undefined) : undefined}
+              onChange={onPickDate}
+            />
+          ) : null}
           <Text style={styles.label}>Reason (optional)</Text>
           <TextInput
             style={styles.input}
@@ -225,6 +251,7 @@ const styles = StyleSheet.create({
   label: { fontWeight: "500", fontSize: 14, marginBottom: 6, marginTop: 12, color: colors.text },
   input: {
     height: 46,
+    justifyContent: "center",
     borderWidth: 1,
     borderColor: colors.borderStrong,
     borderRadius: radius.md,
@@ -233,6 +260,8 @@ const styles = StyleSheet.create({
     color: colors.text,
     backgroundColor: colors.surface,
   },
+  inputText: { fontSize: 15, color: colors.text },
+  inputPlaceholder: { fontSize: 15, color: colors.faint },
   pills: { flexDirection: "row", flexWrap: "wrap", gap: 8 },
   chip: {
     borderWidth: 1,


### PR DESCRIPTION
First of the mobile/web parity fixes from the audit. Addresses the "raw text inputs for time/date/timezone feel broken" gap (P0).

## What
The mobile scheduling screens used bare `TextInput`s for times (`HH:MM`), dates (`YYYY-MM-DD`), and a free-text timezone — despite the app already shipping `@react-native-community/datetimepicker` (used in polls + Otter). This swaps them for native pickers using the **same one-picker-at-screen-level pattern as `polls/new`**.

- **Availability** — each time range opens a native **time** picker; values still persist as 24h `HH:MM` for the API but render in the device's clock format. Added a **"Use device timezone"** shortcut (`Intl.DateTimeFormat().resolvedOptions().timeZone`) beside the timezone field.
- **Out of office** — From/To are native **date** pickers; the To picker is bounded to on-or-after From, and the old manual regex validation is gone.
- **Troubleshooter** — the Day field is a native **date** picker.

## Correctness note
Dates are formatted from **local** parts (`toISODate`), not `toISOString().slice(0,10)`, so the selected day never shifts by the UTC offset (the previous `todayISO()` had that latent bug).

## Verification
`pnpm --filter @dayotter/mobile typecheck` + biome both clean. **Visual/interaction pass still pending** a simulator run — the app talks to the web API, which is down with Docker, so I verified by typecheck + following the existing in-repo picker pattern exactly. Worth eyeballing on device when we next boot the simulator.

Part of the parity set; team-rules pickers will ride along with the team-parity PR.