### PR TITLE
fix: handle withdrawal minimums by currency

### DIFF
--- a/apps/web/app/api/payments/withdraw/route.ts
+++ b/apps/web/app/api/payments/withdraw/route.ts
@@ -1,4 +1,4 @@
-import { WITHDRAW_MINIMUM, connectedBalances, createConnectedPayout } from "@/lib/payments/stripe";
+import { WITHDRAW_MINIMUM, connectedBalances, createConnectedPayout, getWithdrawMinimum } from "@/lib/payments/stripe";
 import { jsonError, withUser } from "@/lib/server/http";
 import { logger } from "@dayotter/core";
 import { eq, getDb, schema } from "@dayotter/db";
@@ -27,7 +27,7 @@ export const POST = withUser(async (u) => {
 
   try {
     const balances = await connectedBalances(user.stripeAccountId);
-    const withdrawable = balances.filter((b) => b.available >= WITHDRAW_MINIMUM);
+    const withdrawable = balances.filter((b) => b.available >= getWithdrawMinimum(b.currency));
     if (withdrawable.length === 0) {
       return jsonError("You need at least the minimum available to withdraw.", 400);
     }

--- a/apps/web/app/api/payments/withdraw/route.ts
+++ b/apps/web/app/api/payments/withdraw/route.ts
@@ -1,4 +1,4 @@
-import { WITHDRAW_MINIMUM, connectedBalances, createConnectedPayout, getWithdrawMinimum } from "@/lib/payments/stripe";
+import {  connectedBalances, createConnectedPayout, getWithdrawMinimum } from "@/lib/payments/stripe";
 import { jsonError, withUser } from "@/lib/server/http";
 import { logger } from "@dayotter/core";
 import { eq, getDb, schema } from "@dayotter/db";

--- a/apps/web/lib/payments/stripe.ts
+++ b/apps/web/lib/payments/stripe.ts
@@ -195,7 +195,8 @@ export const platformFeePercent = Math.max(
 );
 
 /** Minimum balance (minor units) a host can withdraw - $100. */
-export const WITHDRAW_MINIMUM = 10_000;const WITHDRAW_MINIMUM_MAJOR = 100;
+export const WITHDRAW_MINIMUM = 10_000;
+const WITHDRAW_MINIMUM_MAJOR = 100;
 
 const ZERO_DECIMAL_CURRENCIES = new Set([
   "bif",

--- a/apps/web/lib/payments/stripe.ts
+++ b/apps/web/lib/payments/stripe.ts
@@ -195,7 +195,33 @@ export const platformFeePercent = Math.max(
 );
 
 /** Minimum balance (minor units) a host can withdraw - $100. */
-export const WITHDRAW_MINIMUM = 10_000;
+export const WITHDRAW_MINIMUM = 10_000;const WITHDRAW_MINIMUM_MAJOR = 100;
+
+const ZERO_DECIMAL_CURRENCIES = new Set([
+  "bif",
+  "clp",
+  "djf",
+  "gnf",
+  "jpy",
+  "kmf",
+  "krw",
+  "mga",
+  "pyg",
+  "rwf",
+  "ugx",
+  "vnd",
+  "vuv",
+  "xaf",
+  "xof",
+  "xpf",
+]);
+
+/** Return the minimum withdrawal amount in Stripe minor units. */
+export function getWithdrawMinimum(currency: string): number {
+  return ZERO_DECIMAL_CURRENCIES.has(currency.toLowerCase())
+    ? WITHDRAW_MINIMUM_MAJOR
+    : WITHDRAW_MINIMUM_MAJOR * 100;
+}
 
 /** The platform fee (minor units) for a charge of `amount`. */
 export function platformFee(amount: number): number {
@@ -295,3 +321,4 @@ export async function createConnectedPayout(
   );
   return { id: payout.id };
 }
+


### PR DESCRIPTION
<!-- Thanks for contributing to DayOtter! Keep PRs focused - one logical change. -->

## What & why

Updates the Stripe withdrawal minimum to be currency-aware.

Previously, `WITHDRAW_MINIMUM` used `10_000` minor units for every currency, which works for 2-decimal currencies but is incorrect for zero-decimal currencies such as JPY.

This change adds a per-currency withdrawal minimum helper so the minimum is calculated correctly based on the currency's decimal precision.

Closes #68 

## How I verified it

* [ ] `pnpm turbo typecheck` passes
* [ ] `pnpm biome check` passes (formatted + linted)
* [ ] Verified the change by driving the actual withdrawal flow / endpoint
* [ ] Added/updated a DB migration (`pnpm --filter @dayotter/db generate`) if the schema changed
* [ ] Updated docs / module README if behaviour or an extension point changed

## Notes for the reviewer

* No database changes were required.
* The change is isolated to Stripe withdrawal minimum handling.
* Zero-decimal currencies such as JPY now use the correct minor-unit representation.
* Existing 2-decimal currencies retain the previous `$100`-equivalent minimum behavior.

---

By submitting this PR I confirm I wrote this code (or have the right to
contribute it) and agree to license it under **AGPLv3** (or the EE license for
changes under `ee/`).
