### PR TITLE
fix(teams): add edit + delete UI for team event types

### DIFF
--- a/apps/web/app/(app)/teams/[id]/events/[eventId]/edit/page.tsx
+++ b/apps/web/app/(app)/teams/[id]/events/[eventId]/edit/page.tsx
@@ -1,0 +1,77 @@
+import { EventTypeForm } from "@/components/event-type-form";
+import { PageHeader } from "@/components/page-header";
+import { getSession } from "@/lib/auth/session";
+import { paymentsEnabled } from "@/lib/payments/stripe";
+import { and, eq, getDb, schema } from "@dayotter/db";
+import { notFound } from "next/navigation";
+
+export const dynamic = "force-dynamic";
+
+export default async function EditTeamEventTypePage({
+  params,
+}: {
+  params: Promise<{ id: string; eventId: string }>;
+}) {
+  const { id: teamId, eventId } = await params;
+  const session = await getSession();
+
+  const team = await getDb().query.teams.findFirst({
+    where: eq(schema.teams.id, teamId),
+    with: { members: true },
+  });
+  if (!team) notFound();
+
+  const me = team.members.find((m) => m.userId === session!.user.id);
+  if (!me || (me.role !== "owner" && me.role !== "admin")) notFound();
+
+  const eventType = await getDb().query.eventTypes.findFirst({
+    where: and(eq(schema.eventTypes.id, eventId), eq(schema.eventTypes.teamId, teamId)),
+  });
+  if (!eventType) notFound();
+
+  return (
+    <>
+      <PageHeader title="Edit team event" description="Update how this team meeting is booked." />
+      <EventTypeForm
+        mode="edit"
+        paymentsEnabled={paymentsEnabled}
+        redirectTo={`/teams/${teamId}`}
+        initial={{
+          id: eventType.id,
+          title: eventType.title,
+          slug: eventType.slug,
+          durationMinutes: eventType.durationMinutes,
+          description: eventType.description,
+          location: eventType.location,
+          locationDetail: eventType.locationDetail,
+          locations: eventType.locations,
+          bufferBeforeMinutes: eventType.bufferBeforeMinutes,
+          bufferAfterMinutes: eventType.bufferAfterMinutes,
+          minimumNoticeMinutes: eventType.minimumNoticeMinutes,
+          slotIntervalMinutes: eventType.slotIntervalMinutes,
+          offsetStartMinutes: eventType.offsetStartMinutes,
+          minimumGapMinutes: eventType.minimumGapMinutes,
+          durationOptions: eventType.durationOptions,
+          bookingWindowDays: eventType.bookingWindowDays ?? undefined,
+          dailyBookingLimit: eventType.dailyBookingLimit,
+          weeklyBookingLimit: eventType.weeklyBookingLimit,
+          monthlyBookingLimit: eventType.monthlyBookingLimit,
+          yearlyBookingLimit: eventType.yearlyBookingLimit,
+          maxAttendees: eventType.maxAttendees,
+          recurringCount: eventType.recurringCount,
+          recurringFrequency: eventType.recurringFrequency as "weekly" | "biweekly" | "monthly",
+          hasAccessCode: eventType.accessCodeHash != null,
+          isPrivate: eventType.isPrivate,
+          requiresConfirmation: eventType.requiresConfirmation,
+          redirectUrl: eventType.redirectUrl,
+          color: eventType.color,
+          price: eventType.price,
+          currency: eventType.currency,
+          depositAmount: eventType.depositAmount,
+          questions: eventType.questions,
+          scheduleId: eventType.scheduleId,
+        }}
+      />
+    </>
+  );
+}

--- a/apps/web/app/(app)/teams/[id]/page.tsx
+++ b/apps/web/app/(app)/teams/[id]/page.tsx
@@ -222,7 +222,7 @@ export default async function TeamDetailPage({ params }: { params: Promise<{ id:
                           >
                             Edit
                           </Link>
-                          <DeleteTeamEvent teamId={team.id} eventId={e.id} title={e.title} />
+                          <DeleteTeamEvent eventId={e.id} title={e.title} />
                         </div>
                       ) : null}
                     </div>

--- a/apps/web/app/(app)/teams/[id]/page.tsx
+++ b/apps/web/app/(app)/teams/[id]/page.tsx
@@ -6,10 +6,10 @@ import { TeamCalendarSharing } from "@/components/team-calendar-sharing";
 import {
   AddMemberForm,
   CreateTeamEventForm,
+  DeleteTeamEvent,
   MemberBookable,
   RemoveMember,
 } from "@/components/team-forms";
-import { DeleteTeamEvent } from "@/components/team-forms";
 import { TeamRules } from "@/components/team-rules";
 import { TeamScheduleView } from "@/components/team-schedule-view";
 import { TransferTeamOwnership } from "@/components/transfer-team-ownership";
@@ -192,31 +192,40 @@ export default async function TeamDetailPage({ params }: { params: Promise<{ id:
                 {events.map((e) => (
                   <li
                     key={e.id}
-                    className="flex items-center justify-between rounded-md border border-[var(--color-border)] px-4 py-3"
+                    className="flex items-center justify-between gap-3 rounded-md border border-[var(--color-border)] px-4 py-3"
                   >
                     <div>
-                      <p className="text-sm font-medium">{e.title}</p>
+                      <p className="flex items-center gap-2 text-sm font-medium">
+                        {e.title}
+                        {!e.isActive ? (
+                          <span className="rounded bg-[var(--color-surface-2)] px-1.5 py-0.5 text-[11px] font-normal text-[var(--color-muted)]">
+                            hidden
+                          </span>
+                        ) : null}
+                      </p>
                       <p className="text-xs text-[var(--color-muted)]">
                         {e.durationMinutes}m · {TYPE_LABEL[e.schedulingType] ?? e.schedulingType}
                       </p>
                     </div>
-                    <Link
-                      href={`/team/${team.slug}/${e.slug}`}
-                      className="inline-flex items-center gap-1.5 text-sm text-[var(--color-accent)] hover:underline"
-                    >
-                      /team/{team.slug}/{e.slug} <ExternalLink size={13} />
-                    </Link>
-                    {canManage ? (
-                      <div className="flex items-center gap-3">
-                        <Link
-                          href={`/teams/${team.id}/events/${e.id}/edit`}
-                          className="text-xs text-[var(--color-muted)] transition-colors hover:text-[var(--color-text)]"
-                        >
-                          Edit
-                        </Link>
-                        <DeleteTeamEvent teamId={team.id} eventId={e.id} title={e.title} />
-                      </div>
-                    ) : null}
+                    <div className="flex shrink-0 items-center gap-3">
+                      <Link
+                        href={`/team/${team.slug}/${e.slug}`}
+                        className="inline-flex items-center gap-1.5 text-sm text-[var(--color-accent)] hover:underline"
+                      >
+                        /team/{team.slug}/{e.slug} <ExternalLink size={13} />
+                      </Link>
+                      {canManage ? (
+                        <div className="flex items-center gap-3">
+                          <Link
+                            href={`/teams/${team.id}/events/${e.id}/edit`}
+                            className="text-xs text-[var(--color-muted)] transition-colors hover:text-[var(--color-text)]"
+                          >
+                            Edit
+                          </Link>
+                          <DeleteTeamEvent teamId={team.id} eventId={e.id} title={e.title} />
+                        </div>
+                      ) : null}
+                    </div>
                   </li>
                 ))}
               </ul>

--- a/apps/web/app/(app)/teams/[id]/page.tsx
+++ b/apps/web/app/(app)/teams/[id]/page.tsx
@@ -9,6 +9,7 @@ import {
   MemberBookable,
   RemoveMember,
 } from "@/components/team-forms";
+import { DeleteTeamEvent } from "@/components/team-forms";
 import { TeamRules } from "@/components/team-rules";
 import { TeamScheduleView } from "@/components/team-schedule-view";
 import { TransferTeamOwnership } from "@/components/transfer-team-ownership";
@@ -205,6 +206,17 @@ export default async function TeamDetailPage({ params }: { params: Promise<{ id:
                     >
                       /team/{team.slug}/{e.slug} <ExternalLink size={13} />
                     </Link>
+                    {canManage ? (
+                      <div className="flex items-center gap-3">
+                        <Link
+                          href={`/teams/${team.id}/events/${e.id}/edit`}
+                          className="text-xs text-[var(--color-muted)] transition-colors hover:text-[var(--color-text)]"
+                        >
+                          Edit
+                        </Link>
+                        <DeleteTeamEvent teamId={team.id} eventId={e.id} title={e.title} />
+                      </div>
+                    ) : null}
                   </li>
                 ))}
               </ul>

--- a/apps/web/components/event-type-form.tsx
+++ b/apps/web/components/event-type-form.tsx
@@ -91,10 +91,13 @@ export function EventTypeForm({
   mode,
   initial,
   paymentsEnabled = false,
+  redirectTo = "/event-types",
 }: {
   mode: "create" | "edit";
   initial?: EventTypeInitial;
   paymentsEnabled?: boolean;
+  /** Where to send the user after save/delete; team events return to the team page. */
+  redirectTo?: string;
 }) {
   const router = useRouter();
   const [title, setTitle] = useState(initial?.title ?? "");
@@ -310,7 +313,7 @@ export function EventTypeForm({
       locationCount: cleanLocations.length,
       questionCount: questions.length,
     });
-    router.push("/event-types");
+    router.push(redirectTo);
     router.refresh();
   }
 
@@ -325,7 +328,7 @@ export function EventTypeForm({
       return;
     }
     track("Event Type Deleted");
-    router.push("/event-types");
+    router.push(redirectTo);
     router.refresh();
   }
 

--- a/apps/web/components/team-forms.tsx
+++ b/apps/web/components/team-forms.tsx
@@ -255,11 +255,9 @@ const DURATIONS = [15, 30, 45, 60];
 
 /** Delete a team event type (after a two-click confirm). Only shown to admins. */
 export function DeleteTeamEvent({
-  teamId,
   eventId,
   title,
 }: {
-  teamId: string;
   eventId: string;
   title: string;
 }) {

--- a/apps/web/components/team-forms.tsx
+++ b/apps/web/components/team-forms.tsx
@@ -252,6 +252,67 @@ export function MemberBookable({
 
 const DURATIONS = [15, 30, 45, 60];
 
+/** Delete a team event type (after a two-click confirm). Only shown to admins. */
+export function DeleteTeamEvent({
+  teamId,
+  eventId,
+  title,
+}: {
+  teamId: string;
+  eventId: string;
+  title: string;
+}) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [confirming, setConfirming] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  async function remove() {
+    setLoading(true);
+    const res = await fetch(`/api/event-types/${eventId}`, { method: "DELETE" });
+    if (res.ok) {
+      toast({ title: `"${title}" deleted`, variant: "success" });
+      router.refresh();
+      return;
+    }
+    setLoading(false);
+    setConfirming(false);
+    toast({ title: "Couldn't delete event", variant: "error" });
+  }
+
+  if (!confirming) {
+    return (
+      <button
+        type="button"
+        onClick={() => setConfirming(true)}
+        className="text-xs text-[var(--color-muted)] transition-colors hover:text-[var(--color-danger)]"
+      >
+        Delete
+      </button>
+    );
+  }
+  return (
+    <span className="flex items-center gap-2 text-xs">
+      <button
+        type="button"
+        onClick={remove}
+        disabled={loading}
+        className="font-medium text-[var(--color-danger)] hover:underline disabled:opacity-50"
+      >
+        {loading ? "Deleting…" : "Confirm delete"}
+      </button>
+      <button
+        type="button"
+        onClick={() => setConfirming(false)}
+        disabled={loading}
+        className="text-[var(--color-muted)] transition-colors hover:text-[var(--color-text)]"
+      >
+        Cancel
+      </button>
+    </span>
+  );
+}
+
 export function CreateTeamEventForm({ teamId }: { teamId: string }) {
   const router = useRouter();
   const { toast } = useToast();

--- a/apps/web/components/team-forms.tsx
+++ b/apps/web/components/team-forms.tsx
@@ -4,6 +4,7 @@ import { FormError } from "@/components/ui/form";
 import { Button } from "@/components/ui/button";
 import { Input, Label } from "@/components/ui/input";
 import { useToast } from "@/components/ui/toast";
+import { track } from "@/lib/analytics";
 import { Plus, UserPlus } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -271,7 +272,11 @@ export function DeleteTeamEvent({
     setLoading(true);
     const res = await fetch(`/api/event-types/${eventId}`, { method: "DELETE" });
     if (res.ok) {
-      toast({ title: `"${title}" deleted`, variant: "success" });
+      const data = (await res.json().catch(() => ({}))) as { archived?: boolean };
+      // Bookings exist → the route hides the event instead of deleting it.
+      const verb = data.archived ? "hidden (bookings kept)" : "deleted";
+      toast({ title: `"${title}" ${verb}`, variant: "success" });
+      track("Event Type Deleted", { archived: Boolean(data.archived) });
       router.refresh();
       return;
     }


### PR DESCRIPTION
## Summary
Team event types were listed on the team page with only a link to the public booking page, so owners/admins had no way to edit or delete them from the UI.

The `PUT`/`DELETE /api/event-types/[id]` routes already support team owners/admins via `manageableEventType`, but nothing wired them up for team events.

## Changes
- Add `/teams/[id]/events/[eventId]/edit` page reusing `EventTypeForm` (verifies team owner/admin).
- Add `DeleteTeamEvent` (two-click confirm) in `team-forms.tsx`, wired to the existing `DELETE /api/event-types/[id]` route.
- Surface **Edit** / **Delete** actions on each team event row (admins/owners only).
- `EventTypeForm` gains a `redirectTo` prop so team edits return to the team page instead of `/event-types`.

Both delete paths hit the existing API, which already archives-without-deleting when bookings exist.

## Test plan
- As a team owner/admin: open a team, confirm each team event shows Edit + Delete.
- Edit: change title/duration/buffers, save, verify it returns to the team page and the public link reflects the change.
- Delete: confirm prompt, delete; event disappears and the public link 404s.
- `pnpm --filter @dayotter/web typecheck` passes.

🤖 Generated with [opencode](https://opencode.ai)